### PR TITLE
fix(timeseries): align ILP shard routing with scan path and emit all columns

### DIFF
--- a/nodedb/src/control/server/ilp_listener.rs
+++ b/nodedb/src/control/server/ilp_listener.rs
@@ -283,8 +283,12 @@ async fn flush_ilp_batch(
         .unwrap_or("default_metrics")
         .to_string();
 
-    // Group lines by series key hash for per-series core routing.
-    // Each unique (measurement, sorted_tags) combination hashes to a vShard.
+    // Route all ILP lines for a collection to the same vShard as the
+    // collection-based scan uses. This ensures timeseries scans find
+    // the memtable data on the correct Data Plane core.
+    // Per-series sharding is deferred until the scan path supports
+    // fan-out across multiple cores.
+    let collection_vshard = VShardId::from_collection(&collection);
     let mut shard_batches: std::collections::HashMap<u16, String> =
         std::collections::HashMap::new();
 
@@ -293,12 +297,7 @@ async fn flush_ilp_batch(
             continue;
         }
 
-        // Extract the series key: everything before the first space
-        // (measurement + tags in ILP format).
-        let series_key = line.split(' ').next().unwrap_or(line);
-        let vshard = VShardId::from_key(series_key.as_bytes());
-
-        let entry = shard_batches.entry(vshard.as_u16()).or_default();
+        let entry = shard_batches.entry(collection_vshard.as_u16()).or_default();
         entry.push_str(line);
         entry.push('\n');
     }

--- a/nodedb/src/data/executor/handlers/timeseries.rs
+++ b/nodedb/src/data/executor/handlers/timeseries.rs
@@ -5,7 +5,7 @@ use crate::data::executor::core_loop::CoreLoop;
 use crate::data::executor::task::ExecutionTask;
 use crate::engine::timeseries::columnar_agg::{aggregate_by_time_bucket, timestamp_range_filter};
 use crate::engine::timeseries::columnar_memtable::{
-    ColumnType, ColumnarMemtable, ColumnarMemtableConfig,
+    ColumnData, ColumnType, ColumnarMemtable, ColumnarMemtableConfig,
 };
 use crate::engine::timeseries::columnar_segment::ColumnarSegmentReader;
 use crate::engine::timeseries::ilp;
@@ -68,16 +68,46 @@ impl CoreLoop {
                     });
                     results.push(row);
                 }
-            } else if !indices.is_empty() && schema.columns.len() > 1 {
-                // Raw row output.
-                let val_col = mt.column(1);
-                let values = val_col.as_f64();
+            } else if !indices.is_empty() {
+                // Raw row output — emit all columns from the memtable schema.
                 for &idx in indices.iter().take(limit) {
-                    let row = serde_json::json!({
-                        "timestamp": timestamps[idx as usize],
-                        "value": values[idx as usize],
-                    });
-                    results.push(row);
+                    let mut row = serde_json::Map::new();
+                    for (col_idx, (col_name, col_type)) in schema.columns.iter().enumerate() {
+                        let col_data = mt.column(col_idx);
+                        let val = match col_type {
+                            ColumnType::Timestamp => serde_json::Value::Number(
+                                serde_json::Number::from(col_data.as_timestamps()[idx as usize]),
+                            ),
+                            ColumnType::Float64 => {
+                                let v = col_data.as_f64()[idx as usize];
+                                serde_json::Number::from_f64(v)
+                                    .map(serde_json::Value::Number)
+                                    .unwrap_or(serde_json::Value::Null)
+                            }
+                            ColumnType::Symbol => {
+                                if let ColumnData::Symbol(ids) = col_data {
+                                    let sym_id = ids[idx as usize];
+                                    mt.symbol_dict(col_idx)
+                                        .and_then(|dict| dict.get(sym_id))
+                                        .map(|s| serde_json::Value::String(s.to_string()))
+                                        .unwrap_or(serde_json::Value::Null)
+                                } else {
+                                    serde_json::Value::Null
+                                }
+                            }
+                            ColumnType::Int64 => {
+                                if let ColumnData::Int64(vals) = col_data {
+                                    serde_json::Value::Number(serde_json::Number::from(
+                                        vals[idx as usize],
+                                    ))
+                                } else {
+                                    serde_json::Value::Null
+                                }
+                            }
+                        };
+                        row.insert(col_name.clone(), val);
+                    }
+                    results.push(serde_json::Value::Object(row));
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Fix ILP-to-scan shard routing mismatch**: ILP ingest used `VShardId::from_key()` (FxHash) while the timeseries scan planner used `VShardId::from_collection()` (DJB hash). The hash mismatch caused ingested data to land on a different Data Plane core than where scans looked, making ILP-ingested rows invisible to queries. Fixed by routing ILP via `VShardId::from_collection()` to match the scan path. Per-series sharding deferred until scan supports fan-out.

- **Emit all memtable columns in timeseries scan**: The scan handler only returned hardcoded `timestamp` and `value` columns. Extended to iterate all columns in the memtable schema and resolve Symbol (tag) columns through the SymbolDictionary, so queries return the full row.

## Test plan

- [x] ILP ingest 112K+ rows at ~430K rows/sec, zero errors
- [x] `SELECT * FROM <collection> LIMIT N` returns all columns (tags + fields + timestamp)
- [x] Symbol columns (e.g. host, region) correctly resolved to string values
- [x] `cargo clippy` clean, `cargo fmt --all` applied