### PR TITLE
feat(timeseries): propagate ILP-inferred schema to catalog for SQL column resolution

### DIFF
--- a/nodedb/src/control/planner/catalog.rs
+++ b/nodedb/src/control/planner/catalog.rs
@@ -156,7 +156,13 @@ fn collection_to_arrow_schema(
         ]));
     }
 
-    let mut fields = vec![Field::new("id", DataType::Utf8, false)];
+    let is_timeseries = coll.collection_type.is_timeseries();
+
+    let mut fields = if is_timeseries {
+        Vec::new()
+    } else {
+        vec![Field::new("id", DataType::Utf8, false)]
+    };
 
     for (name, type_str) in &coll.fields {
         let dt = match type_str.to_uppercase().as_str() {
@@ -166,6 +172,7 @@ fn collection_to_arrow_schema(
             "BOOL" | "BOOLEAN" => DataType::Boolean,
             "BYTES" | "BYTEA" | "BLOB" => DataType::Binary,
             "JSON" | "JSONB" => DataType::Utf8,
+            "TIMESTAMP" | "TIMESTAMPTZ" if is_timeseries => DataType::Int64,
             "TIMESTAMP" | "TIMESTAMPTZ" => DataType::Utf8,
             t if t.starts_with("VECTOR") => DataType::Utf8,
             _ => DataType::Utf8,

--- a/nodedb/src/control/server/ilp_listener.rs
+++ b/nodedb/src/control/server/ilp_listener.rs
@@ -327,10 +327,35 @@ async fn flush_ilp_batch(
         .await?;
 
         if !response.payload.is_empty() {
-            total_accepted += serde_json::from_slice::<serde_json::Value>(&response.payload)
-                .ok()
-                .and_then(|v| v.get("accepted").and_then(|a| a.as_u64()))
-                .unwrap_or(0);
+            if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&response.payload) {
+                total_accepted += v.get("accepted").and_then(|a| a.as_u64()).unwrap_or(0);
+
+                if let Some(schema_cols) = v.get("schema_columns").and_then(|s| s.as_array()) {
+                    let fields: Vec<(String, String)> = schema_cols
+                        .iter()
+                        .filter_map(|pair| {
+                            let arr = pair.as_array()?;
+                            Some((
+                                arr.first()?.as_str()?.to_string(),
+                                arr.get(1)?.as_str()?.to_string(),
+                            ))
+                        })
+                        .collect();
+
+                    if !fields.is_empty() {
+                        if let Some(catalog) = state.credentials.catalog() {
+                            if let Ok(Some(mut coll)) =
+                                catalog.get_collection(tenant_id.as_u32(), &collection)
+                            {
+                                if coll.fields.len() != fields.len() {
+                                    coll.fields = fields;
+                                    let _ = catalog.put_collection(&coll);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/nodedb/src/data/executor/handlers/timeseries.rs
+++ b/nodedb/src/data/executor/handlers/timeseries.rs
@@ -239,7 +239,8 @@ impl CoreLoop {
                 }
 
                 // Ensure memtable exists (auto-create on first write).
-                if !self.columnar_memtables.contains_key(collection) {
+                let is_new_memtable = !self.columnar_memtables.contains_key(collection);
+                if is_new_memtable {
                     let schema = ilp_ingest::infer_schema(&lines);
                     let config = ColumnarMemtableConfig {
                         max_memory_bytes: 64 * 1024 * 1024,
@@ -263,11 +264,35 @@ impl CoreLoop {
 
                 self.checkpoint_coordinator
                     .mark_dirty("timeseries", accepted);
-                let result = serde_json::json!({
-                    "accepted": accepted,
-                    "rejected": rejected,
-                    "collection": collection,
-                });
+                let result = if is_new_memtable {
+                    let mt = self.columnar_memtables.get(collection).unwrap();
+                    let schema_columns: Vec<serde_json::Value> = mt
+                        .schema()
+                        .columns
+                        .iter()
+                        .map(|(name, col_type)| {
+                            let type_str = match col_type {
+                                ColumnType::Timestamp => "TIMESTAMP",
+                                ColumnType::Float64 => "FLOAT",
+                                ColumnType::Int64 => "BIGINT",
+                                ColumnType::Symbol => "VARCHAR",
+                            };
+                            serde_json::json!([name, type_str])
+                        })
+                        .collect();
+                    serde_json::json!({
+                        "accepted": accepted,
+                        "rejected": rejected,
+                        "collection": collection,
+                        "schema_columns": schema_columns,
+                    })
+                } else {
+                    serde_json::json!({
+                        "accepted": accepted,
+                        "rejected": rejected,
+                        "collection": collection,
+                    })
+                };
                 let json = serde_json::to_vec(&result).unwrap_or_default();
                 Response {
                     request_id: task.request.request_id,


### PR DESCRIPTION
## Summary

- **Propagate ILP-inferred schema to the catalog**: On first ILP ingest, the Data Plane infers a columnar schema (tags → Symbol/VARCHAR, fields → Float64/Int64, timestamp). Previously this schema only existed in the in-memory memtable, invisible to the SQL planner which still saw the default `(timestamp, value)` fields from `CREATE TIMESERIES`. Now the inferred schema is returned in the ingest response and the ILP listener updates `StoredCollection.fields` in the catalog.

- **Fix Arrow schema for timeseries collections**: Omit the synthetic `id` column (timeseries rows don't have document IDs) and map `TIMESTAMP` to `DataType::Int64` (internal millis representation) instead of `Utf8`.

Unblocks queries like:
```sql
SELECT qtype, COUNT(*) FROM metrics GROUP BY qtype;
SELECT client, AVG(elapsed_ms) FROM metrics GROUP BY client;
SELECT MIN(elapsed_ms), MAX(elapsed_ms) FROM metrics;
```

## Test plan

- [x] ILP ingest 1M rows from AdGuard Home DNS query logs at ~180K rows/sec
- [x] `DESCRIBE collection` shows all ILP-inferred columns after first ingest
- [x] `GROUP BY` on tag columns (qtype, client, status) returns correct counts
- [x] `AVG/MIN/MAX` on numeric fields (elapsed_ms) returns correct values
- [x] `WHERE + GROUP BY` works for aggregate queries
- [x] Non-timeseries collections unaffected (schema still includes `id` prefix)
- [x] Schema only sent on first ingest batch (no overhead on subsequent writes)
- [x] `cargo clippy` clean, `cargo fmt --all` applied