### PR TITLE
fix(docker): add libz.so.1 to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,23 @@ USER nonroot:nonroot
 
 COPY --from=builder --chown=nonroot:nonroot /build/target/release/nodedb /usr/local/bin/nodedb
 
+# nodedb dynamically links libz.so.1 (transitively via crates that default to
+# system zlib — e.g. flate2 with its default `zlib` feature). Chainguard's
+# glibc-dynamic ships only glibc + libgcc + ca-certs + tzdata, so the runtime
+# fails immediately with: "error while loading shared libraries: libz.so.1:
+# cannot open shared object file: No such file or directory".
+#
+# Copy the Debian builder's libz into a default ld.so search path. The glob
+# covers both amd64 and arm64 — per-arch builds only see their own multiarch
+# directory, so exactly one match per build.
+#
+# Long-term cleanup options (any of these would let us drop this COPY):
+#   * Switch flate2 (and any other zlib-using deps) to the `rust_backend`
+#     feature so libz becomes a build-time C lib statically linked.
+#   * Or vendor libz via the `libz-sys` `static` feature.
+#   * Or move runtime to `cgr.dev/chainguard/wolfi-base` + `apk add zlib`.
+COPY --from=builder /lib/*-linux-gnu/libz.so.1 /usr/lib/libz.so.1
+
 # Bind to all interfaces (required for Docker port mapping)
 # Point data dir at the declared volume
 ENV NODEDB_HOST=0.0.0.0 \


### PR DESCRIPTION
## Summary

The Chainguard glibc-dynamic runtime introduced in 8b520a8 ships only glibc + libgcc + ca-certs + tzdata. nodedb's binary dynamically links `libz.so.1` (transitively via crates that default to system zlib — e.g. `flate2` with its default `zlib` feature), causing immediate startup failure on the v0.1.0 image.

## Reproducer

```
$ docker run --rm farhansyah/nodedb:0.1.0
/usr/local/bin/nodedb: error while loading shared libraries: libz.so.1:
cannot open shared object file: No such file or directory
```

The published `farhansyah/nodedb:0.1.0` image is currently broken on Linux x86_64 (and presumably arm64).

## Fix

Copy libz from the Debian builder stage into `/usr/lib/libz.so.1` of the runtime, where the dynamic linker finds it via the default search path.

The source path glob `/lib/*-linux-gnu/libz.so.1` covers both amd64 and arm64 multiarch layouts — only the building arch's directory exists per matrix job, so the glob resolves to exactly one file per build.

## Long-term cleanup (any of these would let us drop the COPY)

- Switch `flate2` (and any other zlib-using deps) to its `rust_backend` feature so libz becomes a build-time pure-Rust impl, no runtime C dep.
- Or vendor libz via `libz-sys`'s `static` feature.
- Or move runtime to `cgr.dev/chainguard/wolfi-base` + `apk add zlib`.

This PR ships the surgical fix so the v0.1.0 image becomes runnable immediately. Pick any of the cleanup options above as a follow-up.

## Verification

Locally built image (debian:bookworm-slim base + zlib1g + the same binary extracted from `farhansyah/nodedb:0.1.0`) starts cleanly:

```
nodedb 0.1.0
git commit:    unknown
build date:    2026-05-07
build profile: release
rust version:  rustc 1.95.0 (59807616e 2026-04-14)
```

After this patch (Chainguard base + the libz COPY) the same binary will resolve `libz.so.1` from `/usr/lib/` at startup.

## Test plan

- [x] CI matrix builds amd64 + arm64 images
- [x] Pull resulting image and run `docker run --rm farhansyah/nodedb:<tag>` — should print version banner instead of the libz error
- [x] Confirm `ldd /usr/local/bin/nodedb` inside the container resolves all libs