### PR TITLE
fix(tenant): accept tenant name in DROP/ALTER/PURGE TENANT

### DIFF
--- a/nodedb/src/control/server/pgwire/ddl/tenant/alter.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/alter.rs
@@ -39,12 +39,18 @@ pub fn alter_tenant(
     }
 
     // Accept either a numeric id or a tenant name (mirrors CREATE/SHOW/DROP).
-    let tenant_id = super::resolve_tenant_ref(state, parts[2])?.ok_or_else(|| {
-        sqlstate_error(
+    let tenant_id = super::resolve_tenant_ref(state, parts[2])?
+        .ok_or_else(|| sqlstate_error("42704", &format!("tenant '{}' does not exist", parts[2])))?;
+
+    // Existence gate, uniform across numeric ids and resolved names: altering an
+    // unknown tenant must error rather than silently seed a default quota for a
+    // phantom id.
+    if !super::tenant_exists(state, tenant_id)? {
+        return Err(sqlstate_error(
             "42704",
             &format!("tenant '{}' does not exist", parts[2]),
-        )
-    })?;
+        ));
+    }
 
     if !parts[3].eq_ignore_ascii_case("SET") || !parts[4].eq_ignore_ascii_case("QUOTA") {
         return Err(sqlstate_error(

--- a/nodedb/src/control/server/pgwire/ddl/tenant/alter.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/alter.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `ALTER TENANT <id> SET QUOTA <field> = <value>` handler.
+//! `ALTER TENANT <id|name> SET QUOTA <field> = <value>` handler.
 //!
 //! Tenant quotas live in the in-memory `TenantStore` and are not part
 //! of `StoredTenant`. Quota replication is handled separately from
 //! the tenant identity record.
+//!
+//! The tenant reference accepts either a numeric id or a tenant name
+//! (single-quoted optional), parallel to `CREATE TENANT <name>` and
+//! `SHOW TENANT <name|id>`.
 
 use pgwire::api::results::{Response, Tag};
 use pgwire::error::PgWireResult;
@@ -12,7 +16,6 @@ use pgwire::error::PgWireResult;
 use crate::control::security::audit::AuditEvent;
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
-use crate::types::TenantId;
 
 use super::super::super::types::sqlstate_error;
 
@@ -31,19 +34,22 @@ pub fn alter_tenant(
     if parts.len() < 7 {
         return Err(sqlstate_error(
             "42601",
-            "syntax: ALTER TENANT <id> SET QUOTA <field> = <value>",
+            "syntax: ALTER TENANT <id|name> SET QUOTA <field> = <value>",
         ));
     }
 
-    let tid: u64 = parts[2]
-        .parse()
-        .map_err(|_| sqlstate_error("42601", "TENANT ID must be a numeric value"))?;
-    let tenant_id = TenantId::new(tid);
+    // Accept either a numeric id or a tenant name (mirrors CREATE/SHOW/DROP).
+    let tenant_id = super::resolve_tenant_ref(state, parts[2])?.ok_or_else(|| {
+        sqlstate_error(
+            "42704",
+            &format!("tenant '{}' does not exist", parts[2]),
+        )
+    })?;
 
     if !parts[3].eq_ignore_ascii_case("SET") || !parts[4].eq_ignore_ascii_case("QUOTA") {
         return Err(sqlstate_error(
             "42601",
-            "expected SET QUOTA after tenant ID",
+            "expected SET QUOTA after tenant id or name",
         ));
     }
 

--- a/nodedb/src/control/server/pgwire/ddl/tenant/drop.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/drop.rs
@@ -15,28 +15,10 @@ use crate::control::metadata_proposer::propose_catalog_entry;
 use crate::control::security::audit::AuditEvent;
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
-use crate::types::TenantId;
 
 use super::super::super::types::sqlstate_error;
 use super::super::parse_utils::strip_if_exists;
-
-/// Whether a tenant id currently exists, consulting the redb catalog when
-/// one is wired up and falling back to the in-memory quota table otherwise.
-fn tenant_exists(state: &SharedState, tenant_id: TenantId) -> PgWireResult<bool> {
-    if let Some(catalog) = state.credentials.catalog() {
-        let present = catalog
-            .load_all_tenants()
-            .map_err(|e| sqlstate_error("XX000", &format!("catalog read: {e}")))?
-            .iter()
-            .any(|t| t.tenant_id == tenant_id.as_u64());
-        return Ok(present);
-    }
-    let tenants = match state.tenants.lock() {
-        Ok(t) => t,
-        Err(p) => p.into_inner(),
-    };
-    Ok(tenants.has_quota(tenant_id))
-}
+use super::tenant_exists;
 
 pub fn drop_tenant(
     state: &SharedState,
@@ -60,7 +42,9 @@ pub fn drop_tenant(
     }
 
     // Accept either a numeric id or a tenant name; mirror the existing
-    // CREATE TENANT name-resolution path.
+    // CREATE TENANT name-resolution path. A name that matches no tenant yields
+    // `None` here; an unknown numeric id resolves to a candidate that the
+    // existence gate below rejects, so both forms behave identically.
     let tenant_id = match super::resolve_tenant_ref(state, parts[2])? {
         Some(tid) => tid,
         None => {
@@ -80,11 +64,17 @@ pub fn drop_tenant(
         return Err(sqlstate_error("42501", "cannot drop system tenant (0)"));
     }
 
-    // `IF EXISTS`: dropping a tenant that does not exist is a no-op success.
-    // (Numeric-id-not-in-catalog path; the name-not-found case was handled
-    // above.)
-    if if_exists && !tenant_exists(state, tenant_id)? {
-        return Ok(vec![Response::Execution(Tag::new("DROP TENANT"))]);
+    // Existence gate, uniform across numeric ids and resolved names: an unknown
+    // tenant is a no-op under `IF EXISTS`, otherwise `42704` — never a silent
+    // delete proposal for a tenant that does not exist.
+    if !tenant_exists(state, tenant_id)? {
+        if if_exists {
+            return Ok(vec![Response::Execution(Tag::new("DROP TENANT"))]);
+        }
+        return Err(sqlstate_error(
+            "42704",
+            &format!("tenant '{}' does not exist", parts[2]),
+        ));
     }
 
     let entry = CatalogEntry::DeleteTenant { tenant_id: tid };

--- a/nodedb/src/control/server/pgwire/ddl/tenant/drop.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/drop.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `DROP TENANT [IF EXISTS] <id>` handler. Migrated to
+//! `DROP TENANT [IF EXISTS] <id|name>` handler. Migrated to
 //! `CatalogEntry::DeleteTenant` in phase 1k.6.
+//!
+//! Accepts either a numeric tenant id or a tenant name (single-quoted
+//! optional), parallel to the `CREATE TENANT <name>` and
+//! `SHOW TENANT <name|id>` paths.
 
 use pgwire::api::results::{Response, Tag};
 use pgwire::error::PgWireResult;
@@ -51,20 +55,34 @@ pub fn drop_tenant(
     if parts.len() < 3 {
         return Err(sqlstate_error(
             "42601",
-            "syntax: DROP TENANT [IF EXISTS] <id>",
+            "syntax: DROP TENANT [IF EXISTS] <id|name>",
         ));
     }
 
-    let tid: u64 = parts[2]
-        .parse()
-        .map_err(|_| sqlstate_error("42601", "TENANT ID must be a numeric value"))?;
-    let tenant_id = TenantId::new(tid);
+    // Accept either a numeric id or a tenant name; mirror the existing
+    // CREATE TENANT name-resolution path.
+    let tenant_id = match super::resolve_tenant_ref(state, parts[2])? {
+        Some(tid) => tid,
+        None => {
+            // Name token did not resolve to any tenant.
+            if if_exists {
+                return Ok(vec![Response::Execution(Tag::new("DROP TENANT"))]);
+            }
+            return Err(sqlstate_error(
+                "42704",
+                &format!("tenant '{}' does not exist", parts[2]),
+            ));
+        }
+    };
+    let tid = tenant_id.as_u64();
 
     if tid == 0 {
         return Err(sqlstate_error("42501", "cannot drop system tenant (0)"));
     }
 
     // `IF EXISTS`: dropping a tenant that does not exist is a no-op success.
+    // (Numeric-id-not-in-catalog path; the name-not-found case was handled
+    // above.)
     if if_exists && !tenant_exists(state, tenant_id)? {
         return Ok(vec![Response::Execution(Tag::new("DROP TENANT"))]);
     }

--- a/nodedb/src/control/server/pgwire/ddl/tenant/mod.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/mod.rs
@@ -31,3 +31,64 @@ pub use show::{show_tenant_quota, show_tenant_usage};
 pub use show_in_database::{
     handle_show_tenant_quota_in_database, handle_show_tenant_usage_in_database,
 };
+
+use pgwire::error::PgWireResult;
+
+use crate::control::state::SharedState;
+use crate::types::TenantId;
+
+use super::super::types::sqlstate_error;
+
+/// Resolve a tenant reference token to a [`TenantId`], accepting either a
+/// numeric id or a tenant name.
+///
+/// The numeric form is the legacy fast path and requires no catalog access;
+/// any `u64`-parseable token returns `Ok(Some(TenantId::new(id)))` whether or
+/// not that id currently exists (callers that need existence still rely on
+/// their own `tenant_exists`-style check).
+///
+/// A non-numeric token is treated as a tenant name and resolved via
+/// [`find_tenant_by_name`]. Single-quoted names are unwrapped, mirroring the
+/// AST `TenantSelector` behavior introduced for the CREATE/SHOW paths.
+/// `Ok(None)` is returned if the name does not match any tenant, so the
+/// caller can decide between `IF EXISTS` no-op success and an explicit
+/// `42704` error.
+///
+/// Errors:
+/// - `42601` — empty token (after quote stripping).
+/// - `42601` — non-numeric token but catalog is unavailable.
+/// - `XX000` — catalog read failure.
+///
+/// Used by `DROP TENANT`, `ALTER TENANT SET QUOTA`, and `PURGE TENANT` to
+/// accept names in addition to numeric ids, parallel to the existing
+/// `CREATE TENANT <name>` and `SHOW TENANT <name>` support.
+///
+/// [`find_tenant_by_name`]:
+/// crate::control::security::credential::store::CredentialStore::catalog
+pub(super) fn resolve_tenant_ref(
+    state: &SharedState,
+    token: &str,
+) -> PgWireResult<Option<TenantId>> {
+    // Numeric id fast path — legacy compatible.
+    if let Ok(id) = token.parse::<u64>() {
+        return Ok(Some(TenantId::new(id)));
+    }
+    // Name resolution via catalog.
+    let name = token.trim_matches('\'');
+    if name.is_empty() {
+        return Err(sqlstate_error(
+            "42601",
+            "TENANT reference must be a numeric id or a tenant name",
+        ));
+    }
+    let catalog = state.credentials.catalog().as_ref().ok_or_else(|| {
+        sqlstate_error(
+            "42601",
+            "cannot resolve tenant by name: catalog unavailable; use numeric id",
+        )
+    })?;
+    Ok(catalog
+        .find_tenant_by_name(name)
+        .map_err(|e| sqlstate_error("XX000", &format!("catalog read: {e}")))?
+        .map(|stored| TenantId::new(stored.tenant_id)))
+}

--- a/nodedb/src/control/server/pgwire/ddl/tenant/mod.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/mod.rs
@@ -44,8 +44,11 @@ use super::super::types::sqlstate_error;
 ///
 /// The numeric form is the legacy fast path and requires no catalog access;
 /// any `u64`-parseable token returns `Ok(Some(TenantId::new(id)))` whether or
-/// not that id currently exists (callers that need existence still rely on
-/// their own `tenant_exists`-style check).
+/// not that id currently exists. Resolving a token to an id does **not** assert
+/// the tenant exists — callers must gate the operation through [`tenant_exists`]
+/// so that an unknown numeric id and an unknown name behave identically (both
+/// `42704`, or an `IF EXISTS` no-op). Skipping that check reintroduces the
+/// id/name asymmetry where a bogus numeric id silently "succeeds".
 ///
 /// A non-numeric token is treated as a tenant name and resolved via
 /// [`find_tenant_by_name`]. Single-quoted names are unwrapped, mirroring the
@@ -91,4 +94,25 @@ pub(super) fn resolve_tenant_ref(
         .find_tenant_by_name(name)
         .map_err(|e| sqlstate_error("XX000", &format!("catalog read: {e}")))?
         .map(|stored| TenantId::new(stored.tenant_id)))
+}
+
+/// Whether `tenant_id` currently exists, consulting the redb catalog when one
+/// is wired up and falling back to the in-memory quota table otherwise.
+///
+/// Shared by `DROP`, `ALTER`, and `PURGE TENANT` so existence is enforced the
+/// same way for numeric ids and resolved names — see [`resolve_tenant_ref`].
+pub(super) fn tenant_exists(state: &SharedState, tenant_id: TenantId) -> PgWireResult<bool> {
+    if let Some(catalog) = state.credentials.catalog() {
+        let present = catalog
+            .load_all_tenants()
+            .map_err(|e| sqlstate_error("XX000", &format!("catalog read: {e}")))?
+            .iter()
+            .any(|t| t.tenant_id == tenant_id.as_u64());
+        return Ok(present);
+    }
+    let tenants = match state.tenants.lock() {
+        Ok(t) => t,
+        Err(p) => p.into_inner(),
+    };
+    Ok(tenants.has_quota(tenant_id))
 }

--- a/nodedb/src/control/server/pgwire/ddl/tenant/purge.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/purge.rs
@@ -37,16 +37,21 @@ pub async fn purge_tenant(
     }
 
     // Accept either a numeric id or a tenant name (mirrors CREATE/SHOW/DROP).
-    let tenant_id = super::resolve_tenant_ref(state, parts[2])?.ok_or_else(|| {
-        sqlstate_error(
-            "42704",
-            &format!("tenant '{}' does not exist", parts[2]),
-        )
-    })?;
+    let tenant_id = super::resolve_tenant_ref(state, parts[2])?
+        .ok_or_else(|| sqlstate_error("42704", &format!("tenant '{}' does not exist", parts[2])))?;
     let tid = tenant_id.as_u64();
 
     if tid == 0 {
         return Err(sqlstate_error("42501", "cannot purge system tenant (0)"));
+    }
+
+    // Existence gate, uniform across numeric ids and resolved names: refuse to
+    // dispatch the destructive meta op for a tenant that does not exist.
+    if !super::tenant_exists(state, tenant_id)? {
+        return Err(sqlstate_error(
+            "42704",
+            &format!("tenant '{}' does not exist", parts[2]),
+        ));
     }
 
     if !parts[3].eq_ignore_ascii_case("CONFIRM") {

--- a/nodedb/src/control/server/pgwire/ddl/tenant/purge.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/purge.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `PURGE TENANT <id> CONFIRM` — Data Plane meta op that deletes
+//! `PURGE TENANT <id|name> CONFIRM` — Data Plane meta op that deletes
 //! ALL tenant data across every engine. Superuser-only, requires
 //! the literal `CONFIRM` keyword.
+//!
+//! The tenant reference accepts either a numeric id or a tenant name
+//! (single-quoted optional), parallel to `CREATE TENANT <name>` and
+//! `SHOW TENANT <name|id>`.
 
 use pgwire::api::results::{Response, Tag};
 use pgwire::error::PgWireResult;
@@ -10,7 +14,6 @@ use pgwire::error::PgWireResult;
 use crate::control::security::audit::AuditEvent;
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
-use crate::types::TenantId;
 
 use super::super::super::types::sqlstate_error;
 
@@ -27,12 +30,20 @@ pub async fn purge_tenant(
     }
 
     if parts.len() < 4 {
-        return Err(sqlstate_error("42601", "syntax: PURGE TENANT <id> CONFIRM"));
+        return Err(sqlstate_error(
+            "42601",
+            "syntax: PURGE TENANT <id|name> CONFIRM",
+        ));
     }
 
-    let tid: u64 = parts[2]
-        .parse()
-        .map_err(|_| sqlstate_error("42601", "TENANT ID must be a numeric value"))?;
+    // Accept either a numeric id or a tenant name (mirrors CREATE/SHOW/DROP).
+    let tenant_id = super::resolve_tenant_ref(state, parts[2])?.ok_or_else(|| {
+        sqlstate_error(
+            "42704",
+            &format!("tenant '{}' does not exist", parts[2]),
+        )
+    })?;
+    let tid = tenant_id.as_u64();
 
     if tid == 0 {
         return Err(sqlstate_error("42501", "cannot purge system tenant (0)"));
@@ -44,8 +55,6 @@ pub async fn purge_tenant(
             "PURGE TENANT requires CONFIRM keyword to prevent accidental data destruction",
         ));
     }
-
-    let tenant_id = TenantId::new(tid);
 
     state.audit_record(
         AuditEvent::AdminAction,

--- a/nodedb/tests/pgwire_auth_tenants.rs
+++ b/nodedb/tests/pgwire_auth_tenants.rs
@@ -3,9 +3,10 @@
 //! Pgwire DDL coverage for the tenant surface. Split into submodules
 //! under `pgwire_auth_tenants/`:
 //!
-//! - `lifecycle`     — CREATE / DROP TENANT, `IF [NOT] EXISTS`, `WITH ADMIN`
-//! - `introspection` — `SHOW TENANT[S]` by name / id + privilege gate
-//! - `grants`        — `GRANT / REVOKE <perm> ON TENANT <name>`
+//! - `lifecycle`       — CREATE / DROP TENANT, `IF [NOT] EXISTS`, `WITH ADMIN`
+//! - `introspection`   — `SHOW TENANT[S]` by name / id + privilege gate
+//! - `grants`          — `GRANT / REVOKE <perm> ON TENANT <name>`
+//! - `name_resolution` — DROP/ALTER/PURGE TENANT by name (mirroring CREATE/SHOW)
 //!
 //! The entry file stays thin so future additions land in the topical
 //! submodule rather than bloating one ~500-line test file.
@@ -18,3 +19,5 @@ mod grants;
 mod introspection;
 #[path = "pgwire_auth_tenants/lifecycle.rs"]
 mod lifecycle;
+#[path = "pgwire_auth_tenants/name_resolution.rs"]
+mod name_resolution;

--- a/nodedb/tests/pgwire_auth_tenants/name_resolution.rs
+++ b/nodedb/tests/pgwire_auth_tenants/name_resolution.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Name-based tenant reference resolution on the DROP / ALTER / PURGE
+//! TENANT paths.
+//!
+//! Verifies that the legacy `DROP TENANT <id>` form keeps working and that
+//! a tenant name (bare or single-quoted) resolves to the same id via the
+//! shared `resolve_tenant_ref` helper, mirroring the already-shipped
+//! `CREATE TENANT <name>` / `SHOW TENANT <name>` paths.
+
+use crate::common::pgwire_auth_helpers::{ddl_err, ddl_ok, make_state_with_catalog, superuser};
+
+// ─── DROP TENANT by name ─────────────────────────────────────────────────────
+
+/// `DROP TENANT <id>` (numeric) — regression that the legacy form still
+/// works after the resolver refactor.
+#[tokio::test]
+async fn drop_tenant_by_numeric_id_still_works() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_drop_num ID 7142").await;
+    ddl_ok(&state, &su, "DROP TENANT 7142").await;
+}
+
+/// `DROP TENANT <name>` — the new path; name resolves to the catalog id.
+#[tokio::test]
+async fn drop_tenant_by_bare_name() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_drop_name ID 7143").await;
+    ddl_ok(&state, &su, "DROP TENANT acme_drop_name").await;
+}
+
+/// `DROP TENANT '<name>'` — single-quoted name, matches the AST
+/// `TenantSelector` behavior on CREATE/SHOW.
+#[tokio::test]
+async fn drop_tenant_by_quoted_name() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_drop_quoted ID 7144").await;
+    ddl_ok(&state, &su, "DROP TENANT 'acme_drop_quoted'").await;
+}
+
+/// `DROP TENANT <unknown_name>` without `IF EXISTS` errors with `42704`.
+#[tokio::test]
+async fn drop_tenant_unknown_name_without_if_exists_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "DROP TENANT no_such_tenant").await;
+    assert!(
+        err.contains("does not exist") && err.contains("42704"),
+        "expected 42704/does not exist, got: {err}"
+    );
+}
+
+/// `DROP TENANT IF EXISTS <unknown_name>` is a no-op success — parallels the
+/// `IF EXISTS <unknown_id>` semantics.
+#[tokio::test]
+async fn drop_tenant_if_exists_unknown_name_is_noop() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "DROP TENANT IF EXISTS no_such_tenant").await;
+}
+
+/// `DROP TENANT ''` (empty quoted name) → `42601` syntax error.
+#[tokio::test]
+async fn drop_tenant_empty_name_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "DROP TENANT ''").await;
+    assert!(
+        err.contains("42601") && err.contains("numeric id or a tenant name"),
+        "expected 42601 empty-name error, got: {err}"
+    );
+}
+
+// ─── ALTER TENANT by name ────────────────────────────────────────────────────
+
+/// `ALTER TENANT <id> SET QUOTA ...` — regression: numeric form still works.
+#[tokio::test]
+async fn alter_tenant_by_numeric_id_still_works() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_alter_num ID 7145").await;
+    ddl_ok(
+        &state,
+        &su,
+        "ALTER TENANT 7145 SET QUOTA max_qps = 250",
+    )
+    .await;
+}
+
+/// `ALTER TENANT <name> SET QUOTA ...` — name resolves to id.
+#[tokio::test]
+async fn alter_tenant_by_name() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_alter_name ID 7146").await;
+    ddl_ok(
+        &state,
+        &su,
+        "ALTER TENANT acme_alter_name SET QUOTA max_qps = 250",
+    )
+    .await;
+}
+
+/// `ALTER TENANT <unknown_name> SET QUOTA ...` errors with `42704`.
+#[tokio::test]
+async fn alter_tenant_unknown_name_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(
+        &state,
+        &su,
+        "ALTER TENANT no_such_tenant SET QUOTA max_qps = 250",
+    )
+    .await;
+    assert!(
+        err.contains("does not exist") && err.contains("42704"),
+        "expected 42704/does not exist, got: {err}"
+    );
+}

--- a/nodedb/tests/pgwire_auth_tenants/name_resolution.rs
+++ b/nodedb/tests/pgwire_auth_tenants/name_resolution.rs
@@ -8,7 +8,9 @@
 //! shared `resolve_tenant_ref` helper, mirroring the already-shipped
 //! `CREATE TENANT <name>` / `SHOW TENANT <name>` paths.
 
-use crate::common::pgwire_auth_helpers::{ddl_err, ddl_ok, make_state_with_catalog, superuser};
+use crate::common::pgwire_auth_helpers::{
+    ddl_err, ddl_ok, make_state, make_state_with_catalog, superuser,
+};
 
 // ─── DROP TENANT by name ─────────────────────────────────────────────────────
 
@@ -89,12 +91,7 @@ async fn alter_tenant_by_numeric_id_still_works() {
     let su = superuser();
 
     ddl_ok(&state, &su, "CREATE TENANT acme_alter_num ID 7145").await;
-    ddl_ok(
-        &state,
-        &su,
-        "ALTER TENANT 7145 SET QUOTA max_qps = 250",
-    )
-    .await;
+    ddl_ok(&state, &su, "ALTER TENANT 7145 SET QUOTA max_qps = 250").await;
 }
 
 /// `ALTER TENANT <name> SET QUOTA ...` — name resolves to id.
@@ -127,5 +124,207 @@ async fn alter_tenant_unknown_name_errors() {
     assert!(
         err.contains("does not exist") && err.contains("42704"),
         "expected 42704/does not exist, got: {err}"
+    );
+}
+
+/// `ALTER TENANT '<name>' SET QUOTA ...` — single-quoted name resolves to id,
+/// matching the quoted-name path already covered on DROP.
+#[tokio::test]
+async fn alter_tenant_by_quoted_name() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_alter_quoted ID 7147").await;
+    ddl_ok(
+        &state,
+        &su,
+        "ALTER TENANT 'acme_alter_quoted' SET QUOTA max_qps = 250",
+    )
+    .await;
+}
+
+/// `ALTER TENANT '' SET QUOTA ...` (empty quoted name) → `42601`, the same
+/// resolver guard exercised on DROP.
+#[tokio::test]
+async fn alter_tenant_empty_name_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "ALTER TENANT '' SET QUOTA max_qps = 250").await;
+    assert!(
+        err.contains("42601") && err.contains("numeric id or a tenant name"),
+        "expected 42601 empty-name error, got: {err}"
+    );
+}
+
+// ─── PURGE TENANT by name ────────────────────────────────────────────────────
+//
+// `purge_tenant` resolves the tenant reference, rejects the system tenant, and
+// only then dispatches the destructive meta op to the Data Plane. The
+// resolution and guard branches all return before that dispatch, so they are
+// covered here without a Data Plane; the post-dispatch happy path is exercised
+// by the executor-level purge tests.
+
+/// `PURGE TENANT <name> CONFIRM` on an unknown name → `42704`, before any
+/// destructive dispatch.
+#[tokio::test]
+async fn purge_tenant_unknown_name_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "PURGE TENANT no_such_tenant CONFIRM").await;
+    assert!(
+        err.contains("does not exist") && err.contains("42704"),
+        "expected 42704/does not exist, got: {err}"
+    );
+}
+
+/// `PURGE TENANT '' CONFIRM` (empty quoted name) → `42601` resolver guard.
+#[tokio::test]
+async fn purge_tenant_empty_name_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "PURGE TENANT '' CONFIRM").await;
+    assert!(
+        err.contains("42601") && err.contains("numeric id or a tenant name"),
+        "expected 42601 empty-name error, got: {err}"
+    );
+}
+
+/// `PURGE TENANT <name>` with a malformed confirmation token resolves the name
+/// first, then fails the `CONFIRM` gate with `42601`. The `42601`/CONFIRM error
+/// (rather than `42704`) proves the name resolved — covering the by-name purge
+/// path up to the Data Plane boundary.
+#[tokio::test]
+async fn purge_tenant_by_name_resolves_then_requires_confirm() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_purge_name ID 7148").await;
+    let err = ddl_err(&state, &su, "PURGE TENANT acme_purge_name PLEASE").await;
+    assert!(
+        err.contains("42601") && err.contains("CONFIRM"),
+        "expected name to resolve then hit the CONFIRM gate, got: {err}"
+    );
+}
+
+/// `PURGE TENANT <id>` (numeric) for an existing tenant with a malformed
+/// confirmation token — the legacy numeric path resolves and passes the
+/// existence gate, then fails the `CONFIRM` gate. Regression that the resolver
+/// refactor kept the numeric fast path intact for purge.
+#[tokio::test]
+async fn purge_tenant_by_numeric_id_resolves_then_requires_confirm() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme_purge_num ID 7149").await;
+    let err = ddl_err(&state, &su, "PURGE TENANT 7149 PLEASE").await;
+    assert!(
+        err.contains("42601") && err.contains("CONFIRM"),
+        "expected numeric id to resolve then hit the CONFIRM gate, got: {err}"
+    );
+}
+
+// ─── Unknown numeric id parity (id form must match name form) ─────────────────
+//
+// A numeric id that matches no tenant must behave exactly like an unknown
+// name: `42704`, or an `IF EXISTS` no-op for DROP. Before the existence gate
+// these silently proceeded (DROP proposed a delete, ALTER seeded a default
+// quota, PURGE dispatched a destructive op) — the id/name asymmetry.
+
+/// `DROP TENANT <unknown_id>` without `IF EXISTS` → `42704`, matching the
+/// unknown-name behavior.
+#[tokio::test]
+async fn drop_tenant_unknown_numeric_id_without_if_exists_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "DROP TENANT 999001").await;
+    assert!(
+        err.contains("42704") && err.contains("does not exist"),
+        "expected 42704 for unknown numeric id, got: {err}"
+    );
+}
+
+/// `DROP TENANT IF EXISTS <unknown_id>` is a no-op success, matching the
+/// unknown-name `IF EXISTS` behavior.
+#[tokio::test]
+async fn drop_tenant_if_exists_unknown_numeric_id_is_noop() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "DROP TENANT IF EXISTS 999002").await;
+}
+
+/// `ALTER TENANT <unknown_id> SET QUOTA ...` → `42704`, never a silent
+/// default-quota seed for a phantom id.
+#[tokio::test]
+async fn alter_tenant_unknown_numeric_id_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "ALTER TENANT 999003 SET QUOTA max_qps = 250").await;
+    assert!(
+        err.contains("42704") && err.contains("does not exist"),
+        "expected 42704 for unknown numeric id, got: {err}"
+    );
+}
+
+/// `PURGE TENANT <unknown_id> CONFIRM` → `42704`, never a destructive dispatch
+/// for a tenant that does not exist.
+#[tokio::test]
+async fn purge_tenant_unknown_numeric_id_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "PURGE TENANT 999004 CONFIRM").await;
+    assert!(
+        err.contains("42704") && err.contains("does not exist"),
+        "expected 42704 for unknown numeric id, got: {err}"
+    );
+}
+
+// ─── System tenant + catalog-unavailable guards ──────────────────────────────
+
+/// `DROP TENANT 0` — the system tenant is protected with `42501` regardless of
+/// the resolver refactor.
+#[tokio::test]
+async fn drop_system_tenant_numeric_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "DROP TENANT 0").await;
+    assert!(
+        err.contains("42501") && err.contains("system tenant"),
+        "expected 42501 system-tenant guard, got: {err}"
+    );
+}
+
+/// `PURGE TENANT 0 CONFIRM` — the system tenant cannot be purged.
+#[tokio::test]
+async fn purge_system_tenant_numeric_errors() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "PURGE TENANT 0 CONFIRM").await;
+    assert!(
+        err.contains("42501") && err.contains("system tenant"),
+        "expected 42501 system-tenant guard, got: {err}"
+    );
+}
+
+/// `DROP TENANT <name>` with no catalog wired up → `42601`, directing the
+/// caller to use a numeric id. Exercises the catalog-unavailable branch of
+/// `resolve_tenant_ref` that the catalog-backed fixtures cannot reach.
+#[tokio::test]
+async fn drop_tenant_by_name_without_catalog_errors() {
+    let state = make_state();
+    let su = superuser();
+
+    let err = ddl_err(&state, &su, "DROP TENANT some_tenant_name").await;
+    assert!(
+        err.contains("42601") && err.contains("catalog"),
+        "expected 42601 catalog-unavailable error, got: {err}"
     );
 }


### PR DESCRIPTION
Closes #130.

## Summary

Mirror the `CREATE TENANT <name>` (#119 / 86e8ea99) and `SHOW TENANT <name>` (#126 / 56a29f13) name-resolution paths on the remaining tenant DDL forms: `DROP TENANT`, `ALTER TENANT SET QUOTA`, and `PURGE TENANT`. Before this change those three commands accepted only a numeric id and rejected names with `ERROR: TENANT ID must be a numeric value`, which is inconsistent with CREATE/SHOW and prevents common substrate-management workflows such as `DROP TENANT IF EXISTS my_test_tenant`.

## Change shape

- New shared helper `resolve_tenant_ref(state, token) -> PgWireResult<Option<TenantId>>` in `pgwire/ddl/tenant/mod.rs`:
  - Numeric tokens go through the legacy fast path (no catalog access).
  - Non-numeric tokens have leading/trailing single quotes stripped and are resolved via `Catalog::find_tenant_by_name`.
  - Returns `Ok(None)` on name-not-found so callers can decide between `IF EXISTS` no-op and an explicit `42704`.
- Wire the helper into `drop_tenant`, `alter_tenant`, `purge_tenant`. Syntax-hint strings updated from `<id>` to `<id|name>`. Now-unused `TenantId` imports removed in `alter.rs` and `purge.rs`.

`DROP TENANT IF EXISTS` on an unknown name is a no-op success (parallels the unknown-numeric-id behavior already shipped); without `IF EXISTS`, both return `42704`.

## Test plan

New `tests/pgwire_auth_tenants/name_resolution.rs` with 9 cases:

- `drop_tenant_by_numeric_id_still_works` (regression)
- `drop_tenant_by_bare_name`
- `drop_tenant_by_quoted_name`
- `drop_tenant_unknown_name_without_if_exists_errors` — asserts `42704`
- `drop_tenant_if_exists_unknown_name_is_noop`
- `drop_tenant_empty_name_errors` — asserts `42601`
- `alter_tenant_by_numeric_id_still_works` (regression)
- `alter_tenant_by_name`
- `alter_tenant_unknown_name_errors` — asserts `42704`

Local run on `origin/main @ 25040fdf`:

\`\`\`
cargo test --test pgwire_auth_tenants
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

(`PURGE TENANT` shares the helper but is not integration-tested here — it routes through the data-plane dispatcher which needs heavier scaffolding. Happy to add an integration test for purge if you'd like, point me at the right harness.)

## Why not migrate to the AST `TenantSelector` path

The full migration of `DROP/ALTER/PURGE TENANT` to the AST + `TenantSelector` (matching `parse_user_auth.rs::parse_tenant_selector`) is the proper structural fix and would centralize name resolution further. I scoped this PR to the smaller, immediately-useful fix that mirrors the existing `create.rs` pattern; happy to follow up with the AST migration in a separate PR if that's the preferred direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)