### PR TITLE
Fix tenant drop ghost rows and id allocation race

### DIFF
--- a/nodedb/src/control/security/catalog/metadata.rs
+++ b/nodedb/src/control/security/catalog/metadata.rs
@@ -2,6 +2,9 @@
 
 //! Metadata counter and tenant operations for the system catalog.
 
+use redb::ReadableTable;
+
+use super::tenant_id_hwm::{HWM_KEY, TENANT_ID_HWM};
 use super::types::{METADATA, StoredTenant, SystemCatalog, TENANTS, catalog_err};
 
 impl SystemCatalog {
@@ -69,6 +72,24 @@ impl SystemCatalog {
             table
                 .insert(key.as_str(), bytes.as_slice())
                 .map_err(|e| catalog_err("insert tenant", e))?;
+        }
+        // Advance the durable tenant-id high-water-mark in the same
+        // transaction so the id is never reissued by a later
+        // auto-allocation — covers explicitly-chosen ids and ids
+        // replicated from a leader on follower-side applies alike.
+        {
+            let mut hwm = write_txn
+                .open_table(TENANT_ID_HWM)
+                .map_err(|e| catalog_err("open tenant_id_hwm", e))?;
+            let cur = hwm
+                .get(HWM_KEY)
+                .map_err(|e| catalog_err("get tenant_id_hwm", e))?
+                .map(|v| v.value())
+                .unwrap_or(0);
+            if tenant.tenant_id > cur {
+                hwm.insert(HWM_KEY, tenant.tenant_id)
+                    .map_err(|e| catalog_err("insert tenant_id_hwm", e))?;
+            }
         }
         write_txn.commit().map_err(|e| catalog_err("commit", e))
     }

--- a/nodedb/src/control/security/catalog/mod.rs
+++ b/nodedb/src/control/security/catalog/mod.rs
@@ -50,6 +50,7 @@ pub mod surrogate_pk;
 pub mod synonym_groups;
 pub mod system_catalog;
 pub mod tables;
+pub mod tenant_id_hwm;
 pub mod tenant_quotas;
 pub mod topics;
 pub mod trigger_types;

--- a/nodedb/src/control/security/catalog/tenant_id_hwm.rs
+++ b/nodedb/src/control/security/catalog/tenant_id_hwm.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Durable tenant-id allocator for the `_system.tenant_id_hwm` table.
+//!
+//! Singleton table — one row keyed `"global"` holding the highest
+//! tenant id ever allocated. The high-water-mark is monotonic: it is
+//! advanced on every tenant write and never lowered by `DROP TENANT`,
+//! so a tenant id is never reused for a different tenant across a drop
+//! or a restart. This is the same durable-counter idiom the global
+//! surrogate identity uses; see [`super::surrogate_hwm`].
+//!
+//! Auto-allocation derives the next id from the max of this counter
+//! and the ids actually present in `_system.tenants`, so a database
+//! whose tenants predate the counter self-heals on first allocation
+//! instead of colliding with an existing tenant.
+
+use redb::ReadableTable;
+
+use super::types::{SystemCatalog, TENANTS, catalog_err};
+
+/// Redb table: singleton `"global"` -> highest allocated tenant id (`u64`).
+pub(super) const TENANT_ID_HWM: redb::TableDefinition<&str, u64> =
+    redb::TableDefinition::new("_system.tenant_id_hwm");
+
+/// Singleton row key.
+pub(super) const HWM_KEY: &str = "global";
+
+/// Lowest id handed to an auto-allocated tenant. `0` is the system
+/// tenant and `1` is the bootstrap/default tenant; user tenants start
+/// at `2` so neither reserved slot is ever handed out by allocation.
+pub(crate) const FIRST_USER_TENANT_ID: u64 = 2;
+
+impl SystemCatalog {
+    /// Atomically allocate the next tenant id.
+    ///
+    /// Durable and monotonic: the returned id is strictly greater than
+    /// every id previously allocated or currently stored, and the
+    /// counter is never reused after a `DROP TENANT`. Self-heals on
+    /// first use by taking the max of the stored hwm and the highest id
+    /// in `_system.tenants`, so tenants created before this counter
+    /// existed can never collide with a fresh allocation.
+    pub fn allocate_tenant_id(&self) -> crate::Result<u64> {
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|e| catalog_err("tenant_id_hwm write txn", e))?;
+        let next;
+        {
+            // Highest id currently materialised in the tenants table.
+            let mut max_existing = 0u64;
+            {
+                let tenants = write_txn
+                    .open_table(TENANTS)
+                    .map_err(|e| catalog_err("open tenants", e))?;
+                for entry in tenants
+                    .range::<&str>(..)
+                    .map_err(|e| catalog_err("range tenants", e))?
+                {
+                    let (key, _) = entry.map_err(|e| catalog_err("read tenant", e))?;
+                    if let Ok(id) = key.value().parse::<u64>() {
+                        max_existing = max_existing.max(id);
+                    }
+                }
+            }
+            let mut hwm = write_txn
+                .open_table(TENANT_ID_HWM)
+                .map_err(|e| catalog_err("open tenant_id_hwm", e))?;
+            let stored = hwm
+                .get(HWM_KEY)
+                .map_err(|e| catalog_err("get tenant_id_hwm", e))?
+                .map(|v| v.value())
+                .unwrap_or(0);
+            next = stored.max(max_existing).max(FIRST_USER_TENANT_ID - 1) + 1;
+            hwm.insert(HWM_KEY, next)
+                .map_err(|e| catalog_err("insert tenant_id_hwm", e))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| catalog_err("tenant_id_hwm commit", e))?;
+        Ok(next)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::security::catalog::StoredTenant;
+
+    fn open() -> (tempfile::TempDir, SystemCatalog) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("system.redb");
+        let catalog = SystemCatalog::open(&path).unwrap();
+        (dir, catalog)
+    }
+
+    #[test]
+    fn first_allocation_skips_reserved_slots() {
+        let (_dir, catalog) = open();
+        assert_eq!(catalog.allocate_tenant_id().unwrap(), FIRST_USER_TENANT_ID);
+    }
+
+    #[test]
+    fn allocations_are_strictly_increasing_and_distinct() {
+        let (_dir, catalog) = open();
+        let a = catalog.allocate_tenant_id().unwrap();
+        let b = catalog.allocate_tenant_id().unwrap();
+        let c = catalog.allocate_tenant_id().unwrap();
+        assert!(a < b && b < c, "{a} {b} {c}");
+    }
+
+    #[test]
+    fn never_reuses_id_after_delete() {
+        let (_dir, catalog) = open();
+        let id = catalog.allocate_tenant_id().unwrap();
+        catalog
+            .put_tenant(&StoredTenant {
+                tenant_id: id,
+                name: "t".into(),
+                created_at: 0,
+                is_active: true,
+            })
+            .unwrap();
+        catalog.delete_tenant(id).unwrap();
+        // The dropped id must not be handed out again.
+        assert!(catalog.allocate_tenant_id().unwrap() > id);
+    }
+
+    #[test]
+    fn self_heals_against_preexisting_tenants() {
+        let (_dir, catalog) = open();
+        // A tenant row written without ever bumping the counter (the
+        // pre-fix world): insert directly so the hwm stays at 0, then
+        // assert allocation still skips past the existing id.
+        let bytes = zerompk::to_msgpack_vec(&StoredTenant {
+            tenant_id: 500,
+            name: "legacy".into(),
+            created_at: 0,
+            is_active: true,
+        })
+        .unwrap();
+        let txn = catalog.db.begin_write().unwrap();
+        {
+            let mut t = txn.open_table(TENANTS).unwrap();
+            t.insert("500", bytes.as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+        assert!(catalog.allocate_tenant_id().unwrap() > 500);
+    }
+
+    #[test]
+    fn put_tenant_with_explicit_id_advances_hwm() {
+        let (_dir, catalog) = open();
+        // An explicitly-chosen high id must push the hwm forward so a
+        // later auto-allocation never collides with it.
+        catalog
+            .put_tenant(&StoredTenant {
+                tenant_id: 10,
+                name: "explicit".into(),
+                created_at: 0,
+                is_active: true,
+            })
+            .unwrap();
+        assert_eq!(catalog.allocate_tenant_id().unwrap(), 11);
+    }
+}

--- a/nodedb/src/control/security/tenant.rs
+++ b/nodedb/src/control/security/tenant.rs
@@ -102,6 +102,11 @@ pub struct TenantIsolation {
     usage: HashMap<TenantId, TenantUsage>,
     /// Default quota applied to tenants without explicit config.
     default_quota: TenantQuota,
+    /// Monotonic high-water-mark of every tenant id observed, used to
+    /// allocate fresh ids without a catalog (the embedded / unit path).
+    /// The catalog's durable `tenant_id_hwm` is authoritative when one
+    /// is wired up; this mirror only serves the no-catalog fallback.
+    id_hwm: u64,
 }
 
 impl TenantIsolation {
@@ -110,12 +115,27 @@ impl TenantIsolation {
             quotas: HashMap::new(),
             usage: HashMap::new(),
             default_quota,
+            id_hwm: 0,
         }
     }
 
     /// Set quota for a specific tenant.
     pub fn set_quota(&mut self, tenant_id: TenantId, quota: TenantQuota) {
+        self.id_hwm = self.id_hwm.max(tenant_id.as_u64());
         self.quotas.insert(tenant_id, quota);
+    }
+
+    /// Allocate the next tenant id from the in-memory high-water-mark,
+    /// skipping the reserved system (`0`) and bootstrap (`1`) slots.
+    /// Used only when no catalog is wired up; with a catalog,
+    /// `SystemCatalog::allocate_tenant_id` is the durable authority.
+    pub fn allocate_tenant_id(&mut self) -> u64 {
+        let next = self
+            .id_hwm
+            .max(crate::control::security::catalog::tenant_id_hwm::FIRST_USER_TENANT_ID - 1)
+            + 1;
+        self.id_hwm = next;
+        next
     }
 
     /// Whether a tenant already has an explicit quota record.

--- a/nodedb/src/control/server/pgwire/ddl/tenant/create.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/create.rs
@@ -54,6 +54,15 @@ fn parse_tenant_options<'a>(rest: &[&'a str]) -> PgWireResult<TenantOptions<'a>>
     })
 }
 
+/// The default username auto-provisioned as a tenant's `tenant_admin`
+/// when `CREATE TENANT` is run without an explicit `WITH ADMIN <user>`
+/// clause. Defined once here so the `DROP TENANT` cleanup path can
+/// identify and remove this lifecycle-owned account without the
+/// convention drifting between the two sites.
+pub(super) fn default_admin_username(tenant_name: &str) -> String {
+    format!("{tenant_name}_admin")
+}
+
 /// `CREATE TENANT [IF NOT EXISTS] <name> [ID <id>] [WITH ADMIN <user>]`
 ///
 /// Creates a tenant with default quotas. Only superuser can create tenants.
@@ -95,21 +104,27 @@ pub fn create_tenant(
         return Ok(vec![Response::Execution(Tag::new("CREATE TENANT"))]);
     }
 
-    // Pick the tenant id under a short lock scope; do NOT mutate the
-    // store yet — the post_apply side effect on every node seeds the
-    // default quota when `PutTenant` commits.
-    let tenant_id = {
-        let tenants = match state.tenants.lock() {
-            Ok(t) => t,
-            Err(p) => p.into_inner(),
-        };
-        match opts.explicit_id {
-            Some(id) => TenantId::new(id),
+    // Pick the tenant id. An explicit `ID <n>` is honored verbatim;
+    // otherwise allocate a fresh id from the durable, monotonic
+    // high-water-mark so two `CREATE TENANT`s never collide and a
+    // dropped id is never reused. The catalog counter is authoritative
+    // when wired up; the in-memory mirror covers the no-catalog path.
+    let tenant_id = match opts.explicit_id {
+        Some(id) => TenantId::new(id),
+        None => match state.credentials.catalog().as_ref() {
+            Some(catalog) => TenantId::new(
+                catalog
+                    .allocate_tenant_id()
+                    .map_err(|e| sqlstate_error("XX000", &format!("tenant id alloc: {e}")))?,
+            ),
             None => {
-                let count = tenants.tenant_count() as u64;
-                TenantId::new(count + 1)
+                let mut tenants = match state.tenants.lock() {
+                    Ok(t) => t,
+                    Err(p) => p.into_inner(),
+                };
+                TenantId::new(tenants.allocate_tenant_id())
             }
-        }
+        },
     };
 
     let now = std::time::SystemTime::now()
@@ -148,7 +163,7 @@ pub fn create_tenant(
     let admin_name = opts
         .admin_override
         .map(str::to_string)
-        .unwrap_or_else(|| format!("{name}_admin"));
+        .unwrap_or_else(|| default_admin_username(name));
     let admin_password = {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();

--- a/nodedb/src/control/server/pgwire/ddl/tenant/drop.rs
+++ b/nodedb/src/control/server/pgwire/ddl/tenant/drop.rs
@@ -15,6 +15,7 @@ use crate::control::metadata_proposer::propose_catalog_entry;
 use crate::control::security::audit::AuditEvent;
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
+use crate::types::TenantId;
 
 use super::super::super::types::sqlstate_error;
 use super::super::parse_utils::strip_if_exists;
@@ -77,6 +78,21 @@ pub fn drop_tenant(
         ));
     }
 
+    // Reconcile the tenant's users before removing the tenant row.
+    //
+    // `SHOW TENANTS` derives its row set from the union of catalog
+    // tenants and every user's `tenant_id`, so any user left pointing
+    // at this tenant resurrects it as a ghost row (retained id, empty
+    // name) after the catalog row is gone. To keep `DROP TENANT`
+    // consistent with `DROP USER` (hard-delete, disappears from
+    // `SHOW`), the tenant's users must be reconciled here:
+    //
+    //   * the lifecycle-owned `<name>_admin` auto-provisioned by
+    //     `CREATE TENANT` is dropped as part of the tenant lifecycle;
+    //   * any other user is real and operator-owned — refuse the drop
+    //     (`42501`) and name them, so nobody is silently hard-deleted.
+    reconcile_tenant_users(state, identity, tenant_id)?;
+
     let entry = CatalogEntry::DeleteTenant { tenant_id: tid };
     let log_index = propose_catalog_entry(state, &entry)
         .map_err(|e| sqlstate_error("XX000", &format!("metadata propose: {e}")))?;
@@ -101,4 +117,84 @@ pub fn drop_tenant(
     );
 
     Ok(vec![Response::Execution(Tag::new("DROP TENANT"))])
+}
+
+/// Reconcile the users that belong to `tenant_id` before its catalog
+/// row is removed, so the tenant cannot survive as a ghost in
+/// `SHOW TENANTS` (which unions catalog tenants with every user's
+/// `tenant_id`).
+///
+/// The lifecycle-owned `<name>_admin` auto-provisioned by
+/// `CREATE TENANT` is hard-dropped through the canonical `DROP USER`
+/// path. Any other user is operator-owned: the drop is refused with
+/// `42501` and the remaining users are named, so no real account is
+/// ever silently hard-deleted by a tenant drop.
+fn reconcile_tenant_users(
+    state: &SharedState,
+    identity: &AuthenticatedIdentity,
+    tenant_id: TenantId,
+) -> PgWireResult<()> {
+    // Tenant identity — its name, hence the `<name>_admin` of the
+    // lifecycle-owned admin — lives only in the catalog. Without a
+    // catalog there is no persisted `StoredTenant` to surface as a
+    // ghost in `SHOW TENANTS`' catalog union, and no name to
+    // reconstruct the admin from, so there is nothing to reconcile.
+    let Some(tenant_name) = state
+        .credentials
+        .catalog()
+        .as_ref()
+        .and_then(|cat| cat.load_all_tenants().ok())
+        .and_then(|all| {
+            all.into_iter()
+                .find(|t| t.tenant_id == tenant_id.as_u64())
+                .map(|t| t.name)
+        })
+    else {
+        return Ok(());
+    };
+    let admin_username = super::create::default_admin_username(&tenant_name);
+
+    // The same active-user set `SHOW TENANTS` unions over — reconciling
+    // exactly this set is what clears the ghost.
+    let members: Vec<String> = state
+        .credentials
+        .list_user_details()
+        .into_iter()
+        .filter(|u| u.tenant_id == tenant_id)
+        .map(|u| u.username)
+        .collect();
+
+    let mut lifecycle_admin = None;
+    let mut others = Vec::new();
+    for username in members {
+        if username == admin_username {
+            lifecycle_admin = Some(username);
+        } else {
+            others.push(username);
+        }
+    }
+
+    if !others.is_empty() {
+        others.sort();
+        return Err(sqlstate_error(
+            "42501",
+            &format!(
+                "cannot drop tenant: {} user(s) still belong to it; drop or \
+                 reassign them first: {}",
+                others.len(),
+                others.join(", ")
+            ),
+        ));
+    }
+
+    // Only the lifecycle-owned admin remains (if any): hard-delete it
+    // through the canonical `DROP USER` handler so ownership
+    // reassignment, session invalidation, and catalog + redb removal
+    // all run — the same guarantees `DROP USER` gives directly.
+    if let Some(admin) = lifecycle_admin {
+        let parts = ["DROP", "USER", admin.as_str()];
+        super::super::user::drop_user(state, identity, &parts)?;
+    }
+
+    Ok(())
 }

--- a/nodedb/tests/pgwire_auth_tenants/lifecycle.rs
+++ b/nodedb/tests/pgwire_auth_tenants/lifecycle.rs
@@ -20,6 +20,70 @@ async fn create_tenant() {
     assert!(events.last().unwrap().detail.contains("acme"));
 }
 
+/// Two `CREATE TENANT`s without an explicit `ID` must receive distinct
+/// ids. The pre-fix allocator derived the id from a lazily-populated
+/// traffic counter, so with no traffic every auto-allocated tenant got
+/// id 1 and the second create silently overwrote the first.
+#[tokio::test]
+async fn create_tenant_without_id_allocates_distinct_ids() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT alpha").await;
+    ddl_ok(&state, &su, "CREATE TENANT beta").await;
+
+    let catalog = state.credentials.catalog();
+    let catalog = catalog.as_ref().expect("catalog must be wired");
+    let a = catalog
+        .find_tenant_by_name("alpha")
+        .unwrap()
+        .expect("tenant alpha must exist");
+    let b = catalog
+        .find_tenant_by_name("beta")
+        .unwrap()
+        .expect("tenant beta must survive (not be overwritten by alpha's slot)");
+    assert_ne!(
+        a.tenant_id, b.tenant_id,
+        "two auto-allocated tenants must not share an id"
+    );
+    // Reserved slots 0 (system) and 1 (bootstrap) are never handed out.
+    assert!(a.tenant_id >= 2 && b.tenant_id >= 2, "{a:?} {b:?}");
+}
+
+/// An auto-allocated id is never reused after the tenant is dropped:
+/// the durable high-water-mark only moves forward, so a dropped id
+/// cannot be silently reassigned to a different tenant.
+#[tokio::test]
+async fn dropped_tenant_id_is_not_reused() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT gamma").await;
+    let catalog = state.credentials.catalog();
+    let dropped_id = catalog
+        .as_ref()
+        .unwrap()
+        .find_tenant_by_name("gamma")
+        .unwrap()
+        .expect("gamma must exist")
+        .tenant_id;
+
+    ddl_ok(&state, &su, &format!("DROP TENANT {dropped_id}")).await;
+    ddl_ok(&state, &su, "CREATE TENANT delta").await;
+
+    let reused = state
+        .credentials
+        .catalog()
+        .as_ref()
+        .unwrap()
+        .find_tenant_by_name("delta")
+        .unwrap()
+        .expect("delta must exist")
+        .tenant_id;
+    assert_ne!(
+        reused, dropped_id,
+        "a fresh tenant must not reuse a dropped tenant's id"
+    );
+}
+
 #[tokio::test]
 async fn drop_system_tenant_rejected() {
     let state = make_state();

--- a/nodedb/tests/pgwire_show_dispatch.rs
+++ b/nodedb/tests/pgwire_show_dispatch.rs
@@ -125,6 +125,140 @@ async fn show_roles_lists_created_role() {
     );
 }
 
+/// After `DROP ROLE`, `SHOW ROLES` must not list the dropped role. A
+/// `DROP` that leaves the entry visible in `SHOW` is a ghost — the
+/// catalog and the introspection view disagree on whether the role
+/// exists.
+#[tokio::test]
+async fn show_roles_omits_dropped_role() {
+    let server = TestServer::start().await;
+    server
+        .exec("CREATE ROLE ghost_role_to_drop")
+        .await
+        .expect("CREATE ROLE must succeed");
+    server
+        .exec("DROP ROLE ghost_role_to_drop")
+        .await
+        .expect("DROP ROLE must succeed");
+
+    let rows = server
+        .query_named_rows("SHOW ROLES")
+        .await
+        .expect("SHOW ROLES must not error");
+
+    assert!(
+        !rows
+            .iter()
+            .any(|r| r.values().any(|v| v == "ghost_role_to_drop")),
+        "SHOW ROLES must not list a role that was dropped: {rows:?}"
+    );
+}
+
+// ── SHOW TENANTS after DROP TENANT ───────────────────────────────────
+
+/// After `DROP TENANT`, `SHOW TENANTS` must not list the dropped tenant
+/// — neither by name nor as a ghost id-slot.
+///
+/// `CREATE TENANT` auto-provisions a `<name>_admin` user in the new
+/// tenant. `SHOW TENANTS` derives its row set from the union of
+/// catalog-registered tenants and every user's `tenant_id`, so an
+/// orphaned admin user resurrects the dropped tenant as a ghost row
+/// whose `name` is empty (the catalog row is gone) but whose
+/// `tenant_id` slot is retained. The regression guard below asserts no
+/// such empty-named ghost survives for the dropped id.
+#[tokio::test]
+async fn show_tenants_omits_dropped_tenant() {
+    let server = TestServer::start().await;
+    // Explicit high id so the new tenant does not collide with the
+    // bootstrap superuser's home tenant; the auto-provisioned
+    // `<name>_admin` is then the only user in it.
+    server
+        .exec("CREATE TENANT ghost_tenant_to_drop ID 4242")
+        .await
+        .expect("CREATE TENANT must succeed");
+
+    let before = server
+        .query_named_rows("SHOW TENANTS")
+        .await
+        .expect("SHOW TENANTS must not error");
+    let tenant_id = before
+        .iter()
+        .find(|r| {
+            r.get("name")
+                .map(|n| n == "ghost_tenant_to_drop")
+                .unwrap_or(false)
+        })
+        .and_then(|r| r.get("tenant_id"))
+        .cloned()
+        .expect("created tenant must be visible in SHOW TENANTS before drop");
+
+    server
+        .exec("DROP TENANT ghost_tenant_to_drop")
+        .await
+        .expect("DROP TENANT must succeed");
+
+    let after = server
+        .query_named_rows("SHOW TENANTS")
+        .await
+        .expect("SHOW TENANTS must not error");
+
+    assert!(
+        !after.iter().any(|r| r
+            .get("name")
+            .map(|n| n == "ghost_tenant_to_drop")
+            .unwrap_or(false)),
+        "SHOW TENANTS must not list a tenant dropped by name: {after:?}"
+    );
+    // Regression guard for the specific silent failure mode: a retained
+    // id-slot with a cleared (empty) name is the ghost signature.
+    assert!(
+        !after.iter().any(|r| r.get("tenant_id") == Some(&tenant_id)),
+        "SHOW TENANTS must not retain the id-slot of a dropped tenant \
+         (ghost row with empty name): {after:?}"
+    );
+}
+
+/// `DROP TENANT` must refuse (`42501`) when an operator-owned user
+/// still belongs to the tenant, rather than orphaning it (which leaves
+/// a `SHOW TENANTS` ghost) or silently hard-deleting it. The user and
+/// the tenant must both survive the refused drop.
+#[tokio::test]
+async fn drop_tenant_refuses_when_real_users_remain() {
+    let server = TestServer::start().await;
+    server
+        .exec("CREATE TENANT keep_tenant ID 4243")
+        .await
+        .expect("CREATE TENANT must succeed");
+    server
+        .exec("CREATE USER keep_tenant_member WITH PASSWORD 'pw' TENANT 4243")
+        .await
+        .expect("CREATE USER must succeed");
+
+    let err = server
+        .client
+        .simple_query("DROP TENANT keep_tenant")
+        .await
+        .expect_err("DROP TENANT must be refused while a real user remains");
+    let code = err.code().map(|c| c.code().to_string()).unwrap_or_default();
+    assert_eq!(
+        code, "42501",
+        "DROP TENANT with a remaining real user must fail with 42501, got: {err}"
+    );
+
+    // No silent deletion: the real user must still exist.
+    let users = server
+        .query_named_rows("SHOW USERS")
+        .await
+        .expect("SHOW USERS must not error");
+    assert!(
+        users.iter().any(|r| r
+            .get("username")
+            .map(|n| n == "keep_tenant_member")
+            .unwrap_or(false)),
+        "the operator-owned user must survive a refused DROP TENANT: {users:?}"
+    );
+}
+
 // ── SHOW STATS / SHOW SERVER STATS / SHOW METRICS / SHOW MEMORY ──────
 
 /// `SHOW STATS` must reach a real handler. The session-parameter fallback


### PR DESCRIPTION
## Summary

Fix two critical tenant lifecycle bugs: prevent ghost tenant rows appearing in SHOW TENANTS after DROP TENANT, and replace fragile count-based tenant-id allocation with a durable high-water-mark to eliminate id collisions.

## Issues

Closes #131

## Fix 1: Ghost Tenants in SHOW TENANTS

**Root cause:** CREATE TENANT auto-provisions a `<name>_admin` user inside the new tenant. DROP TENANT removed only the tenant's catalog row, orphaning that admin user. SHOW TENANTS builds its row set from the union of catalog tenants and every user's tenant_id, so the orphaned admin resurrected the tenant as a ghost row with an id but empty name. The design flaw was that SHOW and DROP disagreed on the authoritative source of tenant existence.

**Fix:** DROP TENANT now reconciles the tenant's users before removing it. The lifecycle-owned `<name>_admin` user is hard-dropped via the canonical DROP USER path, ensuring ownership reassignment, session invalidation, and catalog+redb removal all run together. If any operator-owned users remain, the drop is refused with SQLSTATE 42501 listing the remaining users, so no account is ever silently deleted.

## Fix 2: Tenant-ID Collision Race

**Root cause:** CREATE TENANT without an explicit ID allocated `tenant_count() + 1`, where `tenant_count()` returned the size of a lazily-populated traffic-counter map (empty until a tenant receives requests). With no traffic, every auto-allocated tenant got id 1, and subsequent CREATE TENANT silently upserted over the previous tenant's catalog entry, collapsing two tenants into one id-slot with cross-tenant bleed and silent data loss.

**Fix:** A durable, monotonic, self-healing tenant-id high-water-mark in the system catalog (`_system.tenant_id_hwm`), mirroring the existing surrogate-identity HWM pattern. `allocate_tenant_id()` atomically computes `max(stored_hwm, max existing tenant id, reserved_floor) + 1` and persists it. `put_tenant` advances the HWM in the same transaction (covering explicit ids and replicated writes). DROP TENANT never lowers it, so ids are never reused. Reserved slots 0 (system) and 1 (bootstrap) are protected. No new Raft metadata — it rides the existing PutTenant replication.

## Testing

- New unit tests in `tenant_id_hwm.rs`: reserved-slot floor, strictly-increasing/distinct allocation, no-reuse-after-delete, self-healing against pre-existing rows, explicit-id advances HWM.
- New integration tests in `pgwire_auth_tenants/lifecycle.rs`: auto-allocated tenants get distinct ids; dropped id not reused.
- New integration tests in `pgwire_show_dispatch.rs`: SHOW TENANTS omits dropped tenant incl. ghost-row guard; DROP TENANT refuses when real users remain; SHOW ROLES omits dropped role.
- All 115 tests pass across pgwire_show_dispatch, pgwire_auth_tenants, pgwire_auth_users, pgwire_auth_grants plus new unit tests.
- cargo clippy: clean. cargo fmt: applied.

## Files Changed

- New: `nodedb/src/tenant_id_hwm.rs` (durable HWM allocator)
- Modified: tenant create/drop paths, system catalog init, integration tests (8 files, +530/-14)