### PR TITLE
fix(security): bind OIDC providers to trusted tenants

### DIFF
--- a/docs/security/auth.md
+++ b/docs/security/auth.md
@@ -90,11 +90,11 @@ Authenticate via external identity providers (Auth0, Okta, Keycloak) using JWT b
 
 ```sql
 -- Admin registers provider
-CREATE OIDC PROVIDER auth0 WITH (
-    issuer = 'https://your-domain.auth0.com/',
-    jwks_url = 'https://your-domain.auth0.com/.well-known/jwks.json',
-    audience = 'nodedb-api'
-);
+CREATE OIDC PROVIDER auth0
+    ISSUER 'https://your-domain.auth0.com/'
+    JWKS_URI 'https://your-domain.auth0.com/.well-known/jwks.json'
+    TENANT 42
+    AUDIENCE 'nodedb-api';
 ```
 
 **Supported on:** Native protocol and HTTP. **Not on pgwire** — the Postgres wire protocol has no standard bearer-token framing; pgwire stays SCRAM-SHA-256 only.
@@ -109,8 +109,11 @@ Configure in `nodedb.toml`:
 
 ```toml
 [[auth.jwt.providers]]
+name = "auth0"
+jwks_url = "https://your-domain.auth0.com/.well-known/jwks.json"
 issuer = "https://your-domain.auth0.com/"
 audience = "your-api"
+tenant_id = 42
 ```
 
 JWT claims map to `$auth.*` session variables:
@@ -124,7 +127,7 @@ JWT claims map to `$auth.*` session variables:
 
 Supported algorithms: ES256, ES384, RS256. Built-in JWKS cache with disk fallback and circuit breaker for provider outages.
 
-**Note:** The OIDC provider mechanism (above) is the recommended approach for modern SSO; this `nodedb.toml` method is supported for backward compatibility.
+**Note:** The OIDC provider mechanism (above) is the recommended approach for modern SSO; this `nodedb.toml` method is supported for backward compatibility. Every static provider requires an explicit `tenant_id`; startup fails closed when it is omitted. Providers may share an issuer only when each has a distinct, non-empty audience.
 
 ## mTLS (Mutual TLS)
 

--- a/docs/security/oidc.md
+++ b/docs/security/oidc.md
@@ -18,7 +18,7 @@ OIDC is a delegated authentication protocol where:
 Create a provider configuration:
 
 ```sql
-CREATE OIDC PROVIDER okta ISSUER 'https://dev-12345.okta.com/' JWKS_URI 'https://dev-12345.okta.com/.well-known/jwks.json' AUDIENCE 'api://nodedb';
+CREATE OIDC PROVIDER okta ISSUER 'https://dev-12345.okta.com/' JWKS_URI 'https://dev-12345.okta.com/.well-known/jwks.json' TENANT 42 AUDIENCE 'api://nodedb';
 ```
 
 **Parameters:**
@@ -27,18 +27,21 @@ CREATE OIDC PROVIDER okta ISSUER 'https://dev-12345.okta.com/' JWKS_URI 'https:/
 | ----------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `ISSUER`    | Yes      | Provider's issuer URL (e.g. `https://accounts.google.com`, `https://your-domain.auth0.com/`)      |
 | `JWKS_URI`  | Yes      | JWKS endpoint for signature validation (e.g. `https://accounts.google.com/.well-known/jwks.json`) |
-| `AUDIENCE`  | Optional | Expected `aud` claim in the JWT (matches your app's audience with the provider)                   |
+| `TENANT`    | Yes      | Numeric NodeDB tenant ID bound to identities authenticated through this provider                  |
+| `AUDIENCE`  | Optional | Expected `aud` claim. Required when the same issuer is registered for more than one tenant         |
 
-**Permissions:** `CREATE OIDC PROVIDER` requires Superuser or ClusterAdmin role.
+**Permissions:** `CREATE OIDC PROVIDER` requires the Superuser role.
 
-**Persistence:** Provider config is stored in `_system.oidc_providers` and replicated via Raft.
+**Persistence:** Provider config is stored in `_system.oidc_providers` and replicated via Raft. The session tenant is always derived from this stored binding; a token's `tenant_id` claim is never authoritative. Existing provider records without a tenant binding are rejected until recreated with `TENANT`.
+
+A shared corporate issuer may serve multiple NodeDB tenants by registering one provider per tenant with a distinct, non-empty audience. Duplicate or ambiguous issuer/audience routes are rejected.
 
 ## Claim Mapping
 
 Map JWT claims to NodeDB identity attributes. Define rules using the `CLAIM MAPPING WHEN` clause:
 
 ```sql
-CREATE OIDC PROVIDER okta ISSUER 'https://dev-12345.okta.com/' JWKS_URI 'https://dev-12345.okta.com/.well-known/jwks.json'
+CREATE OIDC PROVIDER okta ISSUER 'https://dev-12345.okta.com/' JWKS_URI 'https://dev-12345.okta.com/.well-known/jwks.json' TENANT 42
   CLAIM MAPPING WHEN email = 'alice@company.com' SET DEFAULT_DATABASE = 1 ADD DATABASES [1, 2] ADD ROLES ['readwrite']
   CLAIM MAPPING WHEN email = 'bob@company.com' SET DEFAULT_DATABASE = 2 ADD DATABASES [2]
   CLAIM MAPPING WHEN department = 'engineering' ADD DATABASES [1, 2, 3] ADD ROLES ['cluster_admin'];
@@ -62,7 +65,7 @@ CLAIM MAPPING WHEN <claim> = '<value>' [SET DEFAULT_DATABASE = <db_id>] [ADD DAT
 **Example: wildcard for department**
 
 ```sql
-CREATE OIDC PROVIDER okta ISSUER '...' JWKS_URI '...'
+CREATE OIDC PROVIDER okta ISSUER '...' JWKS_URI '...' TENANT 42
   CLAIM MAPPING WHEN department = '*' ADD DATABASES [5];
 ```
 
@@ -88,14 +91,14 @@ SHOW OIDC PROVIDERS;
 
 **Output columns:**
 
-| Column                | Type      | Description             |
-| --------------------- | --------- | ----------------------- |
-| `provider_name`       | String    | Name (e.g. 'okta')      |
-| `issuer`              | String    | Issuer URL              |
-| `jwks_url`            | String    | JWKS endpoint           |
-| `audience`            | String    | Expected audience claim |
-| `claim_mapping_count` | i32       | Number of claim rules   |
-| `created_at`          | Timestamp | Registration date       |
+| Column                | Type   | Description             |
+| --------------------- | ------ | ----------------------- |
+| `name`                | String | Name (e.g. 'okta')      |
+| `issuer`              | String | Issuer URL              |
+| `jwks_uri`            | String | JWKS endpoint           |
+| `tenant_id`           | String | Bound NodeDB tenant ID  |
+| `audience`            | String | Expected audience claim |
+| `claim_mapping_rules` | String | Number of claim rules   |
 
 ## Removing a Provider
 
@@ -103,7 +106,7 @@ SHOW OIDC PROVIDERS;
 DROP OIDC PROVIDER okta;
 ```
 
-**Permissions:** Superuser or ClusterAdmin.
+**Permissions:** Superuser.
 
 **Effect:** Existing sessions tied to this provider are revoked at their next request boundary. New OIDC logins via this provider are rejected.
 
@@ -121,19 +124,19 @@ NodeDB caches JWKS locally to avoid repeated network roundtrips:
 ## JWT Verification Sequence
 
 1. Decode JWT header (check `alg`, `kid`)
-2. Look up provider by `iss` claim
-3. Fetch/cache JWKS from provider's `jwks_url`
+2. Look up one unambiguous provider route by the `iss` and `aud` claims
+3. Fetch/cache JWKS from provider's `jwks_uri`
 4. Validate signature using the key with matching `kid`
 5. Check `aud` claim matches provider's configured audience
 6. Check `exp` (expiry) not in the past
 7. Apply claim mapping rules
-8. Build ephemeral `AuthenticatedIdentity`
+8. Build an ephemeral `AuthenticatedIdentity` using the provider's stored tenant binding
 
-**Failure mode:** Any step failure returns `INVALID_CREDENTIALS` (no detail leak).
+**Failure mode:** Any unauthenticated failure returns the same generic authentication rejection, without issuer, audience, provider, key, or signature details.
 
 ## Required Role
 
-Claim-mapping operations require Superuser or ClusterAdmin. Regular users cannot list or modify OIDC providers.
+OIDC provider and claim-mapping operations require Superuser. Regular users cannot list or modify OIDC providers.
 
 ```sql
 -- Regular user attempt
@@ -146,7 +149,7 @@ ALTER OIDC PROVIDER okta SET claim_mapping = [...];
 **1. Provider registration (admin)**
 
 ```sql
-CREATE OIDC PROVIDER auth0 ISSUER 'https://your-domain.auth0.com/' JWKS_URI 'https://your-domain.auth0.com/.well-known/jwks.json' AUDIENCE 'nodedb-api';
+CREATE OIDC PROVIDER auth0 ISSUER 'https://your-domain.auth0.com/' JWKS_URI 'https://your-domain.auth0.com/.well-known/jwks.json' TENANT 42 AUDIENCE 'nodedb-api';
 ```
 
 **2. Get token from provider**

--- a/nodedb-sql/src/ddl_ast/parse/oidc_provider.rs
+++ b/nodedb-sql/src/ddl_ast/parse/oidc_provider.rs
@@ -8,6 +8,7 @@
 //! CREATE OIDC PROVIDER <name>
 //!     ISSUER '<iss>'
 //!     JWKS_URI '<uri>'
+//!     TENANT <u64>
 //!     [AUDIENCE '<aud>']
 //!     [CLAIM MAPPING WHEN <claim_name> = '<value>'
 //!         [SET DEFAULT_DATABASE = <id>]
@@ -31,18 +32,21 @@ use crate::ddl_ast::statement::{AuthStmt, NodedbStatement, OidcClaimMappingClaus
 use crate::error::SqlError;
 
 pub(super) fn try_parse(
-    upper: &str,
-    parts: &[&str],
+    _upper: &str,
+    _parts: &[&str],
     trimmed: &str,
 ) -> Option<Result<NodedbStatement, SqlError>> {
+    let statement = strip_trailing_terminator(trimmed);
+    let upper = statement.to_uppercase();
+    let parts: Vec<&str> = statement.split_whitespace().collect();
     if upper.starts_with("CREATE OIDC PROVIDER ") {
-        return Some(parse_create(parts, trimmed));
+        return Some(parse_create(&parts, statement));
     }
     if upper.starts_with("ALTER OIDC PROVIDER ") {
-        return Some(parse_alter(parts, trimmed));
+        return Some(parse_alter(&parts, statement));
     }
     if upper.starts_with("DROP OIDC PROVIDER ") {
-        return Some(parse_drop(parts));
+        return Some(parse_drop(&parts));
     }
     if upper == "SHOW OIDC PROVIDERS" {
         return Some(Ok(NodedbStatement::Auth(AuthStmt::ShowOidcProviders)));
@@ -53,7 +57,8 @@ pub(super) fn try_parse(
 // ── CREATE ─────────────────────────────────────────────────────────────────
 
 fn parse_create(parts: &[&str], trimmed: &str) -> Result<NodedbStatement, SqlError> {
-    // parts: CREATE OIDC PROVIDER <name> ISSUER '<iss>' JWKS_URI '<uri>' ...
+    let trimmed = strip_trailing_terminator(trimmed);
+    // parts: CREATE OIDC PROVIDER <name> ISSUER '<iss>' JWKS_URI '<uri>' TENANT <u64> ...
     let name = parts
         .get(3)
         .ok_or_else(|| SqlError::Parse {
@@ -62,22 +67,32 @@ fn parse_create(parts: &[&str], trimmed: &str) -> Result<NodedbStatement, SqlErr
         })?
         .to_string();
 
-    let issuer = extract_keyword_value(trimmed, "ISSUER").ok_or_else(|| SqlError::Parse {
-        detail: "CREATE OIDC PROVIDER: ISSUER '<url>' is required".to_string(),
-    })?;
+    // Provider clauses end at CLAIM MAPPING, so claim names cannot satisfy or
+    // overwrite the provider's top-level configuration.
+    let clause_start = after_token(trimmed, 4);
+    let mappings_start = claim_mapping_start(trimmed, clause_start);
+    let provider_clauses = &trimmed[clause_start..mappings_start];
+    let issuer =
+        extract_keyword_value(provider_clauses, "ISSUER")?.ok_or_else(|| SqlError::Parse {
+            detail: "CREATE OIDC PROVIDER: ISSUER '<url>' is required".to_string(),
+        })?;
 
-    let jwks_uri = extract_keyword_value(trimmed, "JWKS_URI").ok_or_else(|| SqlError::Parse {
-        detail: "CREATE OIDC PROVIDER: JWKS_URI '<url>' is required".to_string(),
-    })?;
+    let jwks_uri =
+        extract_keyword_value(provider_clauses, "JWKS_URI")?.ok_or_else(|| SqlError::Parse {
+            detail: "CREATE OIDC PROVIDER: JWKS_URI '<url>' is required".to_string(),
+        })?;
 
-    let audience = extract_keyword_value(trimmed, "AUDIENCE");
+    let tenant_id = parse_required_u64_keyword(provider_clauses, "TENANT", "CREATE OIDC PROVIDER")?;
 
-    let claim_mappings = parse_claim_mappings(trimmed)?;
+    let audience = extract_keyword_value(provider_clauses, "AUDIENCE")?;
+
+    let claim_mappings = parse_claim_mappings(&trimmed[mappings_start..])?;
 
     Ok(NodedbStatement::Auth(AuthStmt::CreateOidcProvider {
         name,
         issuer,
         jwks_uri,
+        tenant_id,
         audience,
         claim_mappings,
     }))
@@ -94,7 +109,8 @@ fn parse_alter(parts: &[&str], trimmed: &str) -> Result<NodedbStatement, SqlErro
         })?
         .to_string();
 
-    let claim_mappings = parse_claim_mappings(trimmed)?;
+    let mappings_start = claim_mapping_start(trimmed, after_token(trimmed, 4));
+    let claim_mappings = parse_claim_mappings(&trimmed[mappings_start..])?;
 
     Ok(NodedbStatement::Auth(
         AuthStmt::AlterOidcProviderClaimMapping {
@@ -160,30 +176,38 @@ fn parse_claim_mappings(trimmed: &str) -> Result<Vec<OidcClaimMappingClause>, Sq
 /// Parse a single `WHEN <claim_name> = '<value>' [SET DEFAULT_DATABASE = <id>]
 /// [ADD DATABASES [...]] [ADD ROLES [...]]` segment.
 fn parse_when_clause(segment: &str) -> Result<OidcClaimMappingClause, SqlError> {
-    let parts: Vec<&str> = segment.split_whitespace().collect();
-    // parts[0] = WHEN, parts[1] = <claim_name>, parts[2] = =, parts[3] = '<value>'
-    let claim_name = parts
-        .get(1)
+    let after_when = segment["WHEN".len()..].trim_start();
+    let claim_name_end = after_when
+        .find(char::is_whitespace)
         .ok_or_else(|| SqlError::Parse {
             detail: "CLAIM MAPPING: missing claim name after WHEN".to_string(),
+        })?;
+    let claim_name = after_when[..claim_name_end].to_lowercase();
+    let after_claim_name = after_when[claim_name_end..].trim_start();
+    let after_equals = after_claim_name
+        .strip_prefix('=')
+        .ok_or_else(|| SqlError::Parse {
+            detail: "CLAIM MAPPING: syntax is WHEN <claim> = '<value>'".to_string(),
         })?
-        .to_lowercase();
+        .trim_start();
+    let claim_value = parse_quoted_value(
+        after_equals,
+        "CLAIM MAPPING: syntax is WHEN <claim> = '<value>'",
+    )?;
 
-    let raw_value = parts.get(3).ok_or_else(|| SqlError::Parse {
-        detail: "CLAIM MAPPING: syntax is WHEN <claim> = '<value>'".to_string(),
-    })?;
-    let claim_value = raw_value.trim_matches('\'').trim_matches('"').to_string();
-
-    let seg_upper = segment.to_uppercase();
-
-    // SET DEFAULT_DATABASE = <id>
-    let default_database = extract_u64_after_eq(&seg_upper, segment, "DEFAULT_DATABASE");
-
-    // ADD DATABASES [<id>, ...]
-    let add_databases = extract_u64_list(&seg_upper, segment, "DATABASES")?;
-
-    // ADD ROLES ['<role>', ...]
-    let add_roles = extract_string_list(segment, "ROLES")?;
+    // Action sequences are found outside quoted claim values and only when
+    // every keyword is a complete word. This prevents claim names and values
+    // such as `roles` or `'ADD DATABASES'` from being mistaken for actions.
+    let default_database = find_action_end(segment, &["SET", "DEFAULT_DATABASE"])
+        .and_then(|end| extract_u64_after_eq(&segment[end..]));
+    let add_databases = find_action_end(segment, &["ADD", "DATABASES"])
+        .map(|end| extract_u64_list(&segment[end..], "DATABASES"))
+        .transpose()?
+        .unwrap_or_default();
+    let add_roles = find_action_end(segment, &["ADD", "ROLES"])
+        .map(|end| extract_string_list(&segment[end..], "ROLES"))
+        .transpose()?
+        .unwrap_or_default();
 
     Ok(OidcClaimMappingClause {
         claim_name,
@@ -196,44 +220,146 @@ fn parse_when_clause(segment: &str) -> Result<OidcClaimMappingClause, SqlError> 
 
 // ── Token extraction helpers ────────────────────────────────────────────────
 
-/// Extract the quoted string value that follows `KEYWORD` in the SQL text.
+/// Extract the quoted string value that follows `KEYWORD` in provider clauses.
 ///
-/// Handles both single-quote and double-quote delimiters.
-/// E.g. `ISSUER 'https://...'` → `"https://..."`.
-fn extract_keyword_value(trimmed: &str, keyword: &str) -> Option<String> {
+/// Both single- and double-quoted strings are accepted, but bare tokens and
+/// malformed strings are rejected.
+fn extract_keyword_value(trimmed: &str, keyword: &str) -> Result<Option<String>, SqlError> {
     let upper = trimmed.to_uppercase();
-    let kw_upper = keyword.to_uppercase();
-    let pos = upper.find(&kw_upper)?;
-    let after = &trimmed[pos + kw_upper.len()..].trim_start();
-    // The value is either 'quoted' or "double-quoted" or bare token.
-    let tok = after.split_whitespace().next()?;
-    let val = tok.trim_matches('\'').trim_matches('"').to_string();
-    if val.is_empty() { None } else { Some(val) }
-}
-
-/// Extract a `u64` value following `KEYWORD = <id>`.
-fn extract_u64_after_eq(seg_upper: &str, original: &str, keyword: &str) -> Option<u64> {
-    let pos = seg_upper.find(keyword)?;
-    let after_kw = &seg_upper[pos + keyword.len()..].trim_start();
-    if !after_kw.starts_with('=') {
-        return None;
-    }
-    let after_eq = &original[pos + keyword.len()..];
-    let tok = after_eq
-        .trim_start()
-        .trim_start_matches('=')
-        .split_whitespace()
-        .next()?;
-    tok.trim().parse::<u64>().ok()
-}
-
-/// Extract `[<id>, <id>, ...]` following `KEYWORD` (e.g. `DATABASES [1, 2, 3]`).
-fn extract_u64_list(seg_upper: &str, original: &str, keyword: &str) -> Result<Vec<u64>, SqlError> {
-    let pos = match seg_upper.find(keyword) {
-        Some(p) => p,
-        None => return Ok(Vec::new()),
+    let Some(pos) = find_keyword(&upper, keyword, 0) else {
+        return Ok(None);
     };
-    let after = &original[pos + keyword.len()..].trim_start();
+    let detail = format!("CREATE OIDC PROVIDER: {keyword} must be a quoted string");
+    parse_quoted_value(trimmed[pos + keyword.len()..].trim_start(), &detail).map(Some)
+}
+
+/// Parse one SQL-style single- or double-quoted string with doubled delimiters.
+///
+/// The value must end before whitespace or input end so tokens cannot be
+/// silently accepted after its closing quote.
+fn parse_quoted_value(input: &str, detail: &str) -> Result<String, SqlError> {
+    let Some(quote) = input.chars().next().filter(|ch| matches!(ch, '\'' | '"')) else {
+        return Err(SqlError::Parse {
+            detail: detail.to_string(),
+        });
+    };
+
+    let value = &input[quote.len_utf8()..];
+    let mut parsed = String::new();
+    let mut index = 0;
+    while index < value.len() {
+        let Some(ch) = value[index..].chars().next() else {
+            break;
+        };
+        if ch != quote {
+            parsed.push(ch);
+            index += ch.len_utf8();
+            continue;
+        }
+
+        let after_quote = index + quote.len_utf8();
+        if value[after_quote..].starts_with(quote) {
+            parsed.push(quote);
+            index = after_quote + quote.len_utf8();
+            continue;
+        }
+        if value[after_quote..]
+            .chars()
+            .next()
+            .is_some_and(|ch| !ch.is_whitespace())
+        {
+            return Err(SqlError::Parse {
+                detail: detail.to_string(),
+            });
+        }
+        return Ok(parsed);
+    }
+
+    Err(SqlError::Parse {
+        detail: detail.to_string(),
+    })
+}
+
+/// Remove one optional statement terminator from the end of an OIDC statement.
+fn strip_trailing_terminator(input: &str) -> &str {
+    input.strip_suffix(';').unwrap_or(input)
+}
+
+/// Extract the required unsigned integer immediately following `KEYWORD`.
+fn parse_required_u64_keyword(
+    original: &str,
+    keyword: &str,
+    statement: &str,
+) -> Result<u64, SqlError> {
+    let upper = original.to_uppercase();
+    let Some(pos) = find_keyword(&upper, keyword, 0) else {
+        return Err(SqlError::Parse {
+            detail: format!("{statement}: {keyword} <u64> is required"),
+        });
+    };
+    let raw_value = original[pos + keyword.len()..]
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| SqlError::Parse {
+            detail: format!("{statement}: {keyword} must be a u64"),
+        })?;
+    if !raw_value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(SqlError::Parse {
+            detail: format!("{statement}: {keyword} must be a u64"),
+        });
+    }
+    raw_value.parse::<u64>().map_err(|_| SqlError::Parse {
+        detail: format!("{statement}: {keyword} must be a u64"),
+    })
+}
+
+/// Return the start of the first top-level `CLAIM MAPPING` clause, or input end.
+fn claim_mapping_start(input: &str, search_from: usize) -> usize {
+    let upper = input.to_uppercase();
+    let mut search_from = search_from;
+    while let Some(pos) = find_keyword(&upper, "CLAIM", search_from) {
+        let after_claim = &upper[pos + "CLAIM".len()..];
+        let whitespace = after_claim.len() - after_claim.trim_start().len();
+        let mapping_start = pos + "CLAIM".len() + whitespace;
+        if find_keyword(&upper, "MAPPING", mapping_start) == Some(mapping_start) {
+            return pos;
+        }
+        search_from = pos + "CLAIM".len();
+    }
+    input.len()
+}
+
+/// Return the byte offset immediately after the first `token_count`
+/// whitespace-delimited tokens.
+fn after_token(input: &str, token_count: usize) -> usize {
+    let mut tokens_seen = 0;
+    let mut in_token = false;
+    for (index, ch) in input.char_indices() {
+        if ch.is_whitespace() {
+            if in_token {
+                tokens_seen += 1;
+                if tokens_seen == token_count {
+                    return index;
+                }
+                in_token = false;
+            }
+        } else {
+            in_token = true;
+        }
+    }
+    input.len()
+}
+
+/// Extract a `u64` value following an action's `=`, if present.
+fn extract_u64_after_eq(after_action: &str) -> Option<u64> {
+    let after_eq = after_action.trim_start().strip_prefix('=')?.trim_start();
+    let tok = after_eq.split_whitespace().next()?;
+    tok.parse::<u64>().ok()
+}
+
+/// Extract `[<id>, <id>, ...]` immediately following an `ADD DATABASES` action.
+fn extract_u64_list(after_action: &str, keyword: &str) -> Result<Vec<u64>, SqlError> {
+    let after = after_action.trim_start();
     if !after.starts_with('[') {
         // Possibly `ADD DATABASES` without a list — treat as empty.
         return Ok(Vec::new());
@@ -254,14 +380,9 @@ fn extract_u64_list(seg_upper: &str, original: &str, keyword: &str) -> Result<Ve
         .collect()
 }
 
-/// Extract `['<role>', ...]` following `KEYWORD` (e.g. `ROLES ['admin', 'reader']`).
-fn extract_string_list(original: &str, keyword: &str) -> Result<Vec<String>, SqlError> {
-    let upper = original.to_uppercase();
-    let pos = match upper.find(keyword) {
-        Some(p) => p,
-        None => return Ok(Vec::new()),
-    };
-    let after = &original[pos + keyword.len()..].trim_start();
+/// Extract `['<role>', ...]` immediately following an `ADD ROLES` action.
+fn extract_string_list(after_action: &str, keyword: &str) -> Result<Vec<String>, SqlError> {
+    let after = after_action.trim_start();
     if !after.starts_with('[') {
         return Ok(Vec::new());
     }
@@ -279,30 +400,73 @@ fn extract_string_list(original: &str, keyword: &str) -> Result<Vec<String>, Sql
 /// Find the byte offset of a whole-word keyword match (case-insensitive via
 /// pre-uppercased `haystack`). The keyword must be uppercase.
 fn find_keyword(haystack: &str, keyword: &str, from: usize) -> Option<usize> {
-    let haystack = &haystack[from..];
-    let klen = keyword.len();
-    let mut search = 0;
-    while let Some(pos) = haystack[search..].find(keyword) {
-        let abs = search + pos;
-        // Check word boundary: character before must not be alpha/digit.
-        let before_ok = abs == 0
-            || !haystack
-                .as_bytes()
-                .get(abs - 1)
-                .copied()
-                .map(|b| b.is_ascii_alphanumeric() || b == b'_')
-                .unwrap_or(false);
-        let after_ok = haystack
-            .as_bytes()
-            .get(abs + klen)
-            .map(|&b| !b.is_ascii_alphanumeric() && b != b'_')
-            .unwrap_or(true);
-        if before_ok && after_ok {
-            return Some(from + abs);
+    let bytes = haystack.as_bytes();
+    let keyword = keyword.as_bytes();
+    let mut index = from;
+    let mut quote = None;
+    while index + keyword.len() <= bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                    continue;
+                }
+                quote = None;
+            }
+            index += 1;
+            continue;
         }
-        search = abs + 1;
+        if matches!(bytes[index], b'\'' | b'"') {
+            quote = Some(bytes[index]);
+            index += 1;
+            continue;
+        }
+        let before_ok = index == 0 || !is_word_byte(bytes[index - 1]);
+        let after = index + keyword.len();
+        let after_ok = after == bytes.len() || !is_word_byte(bytes[after]);
+        if before_ok && after_ok && bytes[index..].starts_with(keyword) {
+            return Some(index);
+        }
+        index += 1;
     }
     None
+}
+
+/// Find the end of an exact, quote-aware, whitespace-delimited action sequence.
+fn find_action_end(input: &str, words: &[&str]) -> Option<usize> {
+    let upper = input.to_uppercase();
+    let mut search_from = 0;
+    while let Some(start) = find_keyword(&upper, words[0], search_from) {
+        let mut end = start + words[0].len();
+        let mut matched = true;
+        for word in &words[1..] {
+            let whitespace = input[end..].len() - input[end..].trim_start().len();
+            if whitespace == 0 {
+                matched = false;
+                break;
+            }
+            end += whitespace;
+            if !upper[end..].starts_with(word)
+                || upper
+                    .as_bytes()
+                    .get(end + word.len())
+                    .is_some_and(|byte| is_word_byte(*byte))
+            {
+                matched = false;
+                break;
+            }
+            end += word.len();
+        }
+        if matched {
+            return Some(end);
+        }
+        search_from = start + words[0].len();
+    }
+    None
+}
+
+fn is_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 #[cfg(test)]
@@ -324,6 +488,32 @@ mod tests {
             ok("SHOW OIDC PROVIDERS"),
             NodedbStatement::Auth(AuthStmt::ShowOidcProviders)
         );
+    }
+
+    #[test]
+    fn oidc_statements_accept_one_trailing_terminator() {
+        assert_eq!(
+            ok("SHOW OIDC PROVIDERS;"),
+            NodedbStatement::Auth(AuthStmt::ShowOidcProviders)
+        );
+        assert_eq!(
+            ok("DROP OIDC PROVIDER IF EXISTS myidp;"),
+            NodedbStatement::Auth(AuthStmt::DropOidcProvider {
+                name: "myidp".to_string(),
+                if_exists: true,
+            })
+        );
+        match ok(
+            "ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1;",
+        ) {
+            NodedbStatement::Auth(AuthStmt::AlterOidcProviderClaimMapping {
+                claim_mappings,
+                ..
+            }) => {
+                assert_eq!(claim_mappings[0].default_database, Some(1));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]
@@ -351,8 +541,26 @@ mod tests {
     }
 
     #[test]
-    fn create_oidc_provider_minimal() {
-        let sql = "CREATE OIDC PROVIDER auth0 ISSUER 'https://auth0.example.com' JWKS_URI 'https://auth0.example.com/.well-known/jwks.json'";
+    fn create_oidc_provider_requires_numeric_tenant() {
+        for sql in [
+            "CREATE OIDC PROVIDER auth0 ISSUER 'https://auth0.example.com' JWKS_URI 'https://auth0.example.com/jwks'",
+            "CREATE OIDC PROVIDER auth0 ISSUER 'https://auth0.example.com' JWKS_URI 'https://auth0.example.com/jwks' TENANT acme",
+        ] {
+            let upper = sql.to_uppercase();
+            let parts: Vec<&str> = sql.split_whitespace().collect();
+            assert!(
+                matches!(
+                    try_parse(&upper, &parts, sql),
+                    Some(Err(SqlError::Parse { .. }))
+                ),
+                "CREATE OIDC PROVIDER must require a numeric TENANT: {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn create_oidc_provider_with_tenant_terminator() {
+        let sql = "CREATE OIDC PROVIDER auth0 ISSUER 'https://auth0.example.com' JWKS_URI 'https://auth0.example.com/.well-known/jwks.json' TENANT 42;";
         let stmt = ok(sql);
         assert_eq!(
             stmt,
@@ -360,16 +568,54 @@ mod tests {
                 name: "auth0".to_string(),
                 issuer: "https://auth0.example.com".to_string(),
                 jwks_uri: "https://auth0.example.com/.well-known/jwks.json".to_string(),
+                tenant_id: 42,
                 audience: None,
                 claim_mappings: vec![],
             })
         );
+        assert!(
+            format!("{stmt:?}").contains("tenant_id: 42"),
+            "the parsed provider must retain its tenant binding: {stmt:?}"
+        );
     }
 
     #[test]
-    fn create_oidc_provider_with_audience() {
-        let sql = "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' JWKS_URI 'https://idp.example.com/jwks' AUDIENCE 'nodedb-api'";
+    fn provider_name_clause_keywords_do_not_supply_clauses() {
+        for name in ["ISSUER", "JWKS_URI", "TENANT", "AUDIENCE"] {
+            let stmt = ok(&format!(
+                "CREATE OIDC PROVIDER {name} ISSUER 'https://idp.example.com' \
+                 JWKS_URI 'https://idp.example.com/jwks' AUDIENCE 'nodedb-api' TENANT 42 \
+                 CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1"
+            ));
+            match stmt {
+                NodedbStatement::Auth(AuthStmt::CreateOidcProvider {
+                    name: parsed_name,
+                    issuer,
+                    jwks_uri,
+                    tenant_id,
+                    audience,
+                    claim_mappings,
+                }) => {
+                    assert_eq!(parsed_name, name);
+                    assert_eq!(issuer, "https://idp.example.com");
+                    assert_eq!(jwks_uri, "https://idp.example.com/jwks");
+                    assert_eq!(tenant_id, 42);
+                    assert_eq!(audience.as_deref(), Some("nodedb-api"));
+                    assert_eq!(claim_mappings.len(), 1);
+                }
+                other => panic!("unexpected: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn create_oidc_provider_with_audience_terminator() {
+        let sql = "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' JWKS_URI 'https://idp.example.com/jwks' TENANT 42 AUDIENCE 'nodedb-api';";
         let stmt = ok(sql);
+        assert!(
+            format!("{stmt:?}").contains("tenant_id: 42"),
+            "the parsed provider must retain its tenant binding: {stmt:?}"
+        );
         match stmt {
             NodedbStatement::Auth(AuthStmt::CreateOidcProvider { audience, .. }) => {
                 assert_eq!(audience, Some("nodedb-api".to_string()));
@@ -379,11 +625,65 @@ mod tests {
     }
 
     #[test]
+    fn claim_mappings_cannot_supply_provider_clauses() {
+        let missing_issuer = "CREATE OIDC PROVIDER auth0 JWKS_URI 'https://idp.example.com/jwks' TENANT 42 \
+            CLAIM MAPPING WHEN issuer = 'https://idp.example.com'";
+        let missing_jwks = "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' TENANT 42 \
+            CLAIM MAPPING WHEN jwks_uri = 'https://idp.example.com/jwks'";
+        let missing_tenant = "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' \
+            JWKS_URI 'https://idp.example.com/jwks' CLAIM MAPPING WHEN tenant = '42'";
+        for sql in [missing_issuer, missing_jwks, missing_tenant] {
+            let upper = sql.to_uppercase();
+            let parts: Vec<&str> = sql.split_whitespace().collect();
+            assert!(matches!(
+                try_parse(&upper, &parts, sql),
+                Some(Err(SqlError::Parse { .. }))
+            ));
+        }
+    }
+
+    #[test]
+    fn claim_audience_does_not_set_provider_audience() {
+        let stmt = ok(
+            "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' \
+             JWKS_URI 'https://idp.example.com/jwks' TENANT 42 \
+             CLAIM MAPPING WHEN audience = 'nodedb-api'",
+        );
+        match stmt {
+            NodedbStatement::Auth(AuthStmt::CreateOidcProvider { audience, .. }) => {
+                assert_eq!(audience, None);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_oidc_provider_requires_quoted_provider_strings() {
+        for sql in [
+            "CREATE OIDC PROVIDER auth0 ISSUER = 'https://idp.example.com' JWKS_URI 'https://idp.example.com/jwks' TENANT 42",
+            "CREATE OIDC PROVIDER auth0 ISSUER https://idp.example.com JWKS_URI 'https://idp.example.com/jwks' TENANT 42",
+            "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' JWKS_URI = 'https://idp.example.com/jwks' TENANT 42",
+            "CREATE OIDC PROVIDER auth0 ISSUER 'https://idp.example.com' JWKS_URI 'https://idp.example.com/jwks' AUDIENCE = 'nodedb-api' TENANT 42",
+        ] {
+            let upper = sql.to_uppercase();
+            let parts: Vec<&str> = sql.split_whitespace().collect();
+            assert!(matches!(
+                try_parse(&upper, &parts, sql),
+                Some(Err(SqlError::Parse { .. }))
+            ));
+        }
+    }
+
+    #[test]
     fn create_oidc_provider_with_claim_mapping() {
         let sql = "CREATE OIDC PROVIDER corp ISSUER 'https://sso.corp.com' JWKS_URI 'https://sso.corp.com/jwks' \
-             AUDIENCE 'nodedb' \
-             CLAIM MAPPING WHEN org_id = 'acme' SET DEFAULT_DATABASE = 42 ADD DATABASES [43, 44] ADD ROLES ['readwrite']";
+             AUDIENCE 'nodedb' TENANT 42 \
+             CLAIM MAPPING WHEN org_id = 'acme' SET DEFAULT_DATABASE = 42 ADD DATABASES [43, 44] ADD ROLES ['readwrite'];";
         let stmt = ok(sql);
+        assert!(
+            format!("{stmt:?}").contains("tenant_id: 42"),
+            "the parsed provider must retain its tenant binding: {stmt:?}"
+        );
         match stmt {
             NodedbStatement::Auth(AuthStmt::CreateOidcProvider {
                 name,
@@ -418,6 +718,82 @@ mod tests {
                 assert_eq!(claim_mappings[0].add_roles, vec!["admin"]);
             }
             other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claim_mapping_values_preserve_spaces_and_doubled_quotes() {
+        let single_quoted = ok(
+            "ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN department = 'platform engineering' \
+             ADD ROLES ['reader']",
+        );
+        let double_quoted = ok(
+            "ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN title = \"Director of \"\"Data\"\"\" \
+             SET DEFAULT_DATABASE = 7",
+        );
+
+        let NodedbStatement::Auth(AuthStmt::AlterOidcProviderClaimMapping {
+            claim_mappings, ..
+        }) = single_quoted
+        else {
+            panic!("expected ALTER OIDC PROVIDER claim mapping");
+        };
+        assert_eq!(claim_mappings[0].claim_value, "platform engineering");
+        assert_eq!(claim_mappings[0].add_roles, vec!["reader"]);
+
+        let NodedbStatement::Auth(AuthStmt::AlterOidcProviderClaimMapping {
+            claim_mappings, ..
+        }) = double_quoted
+        else {
+            panic!("expected ALTER OIDC PROVIDER claim mapping");
+        };
+        assert_eq!(claim_mappings[0].claim_value, "Director of \"Data\"");
+        assert_eq!(claim_mappings[0].default_database, Some(7));
+    }
+
+    #[test]
+    fn claim_mapping_rejects_unquoted_and_malformed_values() {
+        for sql in [
+            "ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN department = engineering",
+            "ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN department = 'platform engineering",
+            "ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN department = 'engineering'junk",
+        ] {
+            let upper = sql.to_uppercase();
+            let parts: Vec<&str> = sql.split_whitespace().collect();
+            assert!(matches!(
+                try_parse(&upper, &parts, sql),
+                Some(Err(SqlError::Parse { .. }))
+            ));
+        }
+    }
+
+    #[test]
+    fn claim_mapping_actions_ignore_keyword_like_claim_names_and_values() {
+        let absent = ok("ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN roles = \
+             'SET DEFAULT_DATABASE ADD DATABASES ADD ROLES'");
+        let actual = ok("ALTER OIDC PROVIDER auth0 SET CLAIM MAPPING WHEN add = \
+             'DEFAULT_DATABASE DATABASES ROLES SET ADD it''s ADD ROLES' \
+             SET DEFAULT_DATABASE = 7 ADD DATABASES [8, 9] ADD ROLES ['reader']");
+
+        for statement in [absent, actual] {
+            let NodedbStatement::Auth(AuthStmt::AlterOidcProviderClaimMapping {
+                claim_mappings,
+                ..
+            }) = statement
+            else {
+                panic!("expected ALTER OIDC PROVIDER claim mapping");
+            };
+            let mapping = &claim_mappings[0];
+            if mapping.claim_name == "roles" {
+                assert_eq!(mapping.default_database, None);
+                assert!(mapping.add_databases.is_empty());
+                assert!(mapping.add_roles.is_empty());
+            } else {
+                assert_eq!(mapping.claim_name, "add");
+                assert_eq!(mapping.default_database, Some(7));
+                assert_eq!(mapping.add_databases, vec![8, 9]);
+                assert_eq!(mapping.add_roles, vec!["reader"]);
+            }
         }
     }
 }

--- a/nodedb-sql/src/ddl_ast/statement/types/auth.rs
+++ b/nodedb-sql/src/ddl_ast/statement/types/auth.rs
@@ -87,13 +87,14 @@ pub enum AuthStmt {
     },
 
     // ── OIDC providers ───────────────────────────────────────────
-    /// `CREATE OIDC PROVIDER <name> ISSUER '<iss>' JWKS_URI '<uri>'
+    /// `CREATE OIDC PROVIDER <name> ISSUER '<iss>' JWKS_URI '<uri>' TENANT <u64>
     ///  [AUDIENCE '<aud>'] [CLAIM MAPPING WHEN <claim_name> = '<value>'
     ///  SET DEFAULT_DATABASE = <id>, ADD DATABASES [<ids>], ADD ROLES ['<role>', ...]]`
     CreateOidcProvider {
         name: String,
         issuer: String,
         jwks_uri: String,
+        tenant_id: u64,
         audience: Option<String>,
         /// `(claim_name, claim_value, default_database, add_databases, add_roles)` tuples.
         claim_mappings: Vec<OidcClaimMappingClause>,

--- a/nodedb/src/bootstrap/state_wiring.rs
+++ b/nodedb/src/bootstrap/state_wiring.rs
@@ -76,7 +76,7 @@ pub fn wire_state(
     {
         let registry = tokio::runtime::Handle::current().block_on(
             crate::control::security::jwks::registry::JwksRegistry::init(jwt_config.clone()),
-        );
+        )?;
         state.jwks_registry = Some(Arc::new(registry));
         info!(
             "JWKS registry initialised with {} providers",

--- a/nodedb/src/config/auth/config.rs
+++ b/nodedb/src/config/auth/config.rs
@@ -12,6 +12,8 @@
 //! through every site that constructs an `argon2::Argon2` instance —
 //! a wide ripple, not a field on the descriptor.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use super::session::SessionHandleConfig;
@@ -99,6 +101,7 @@ pub enum AuthMode {
 /// jwks_url = "https://auth.example.com/.well-known/jwks.json"
 /// issuer = "https://auth.example.com"
 /// audience = "nodedb"
+/// tenant_id = 42
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JwtAuthConfig {
@@ -192,6 +195,12 @@ pub struct JwtProviderConfig {
     /// Expected `aud` claim. Empty = don't validate audience for this provider.
     #[serde(default)]
     pub audience: String,
+
+    /// Tenant assigned to identities authenticated through this provider.
+    ///
+    /// This is deliberately required: it is a server-side binding, never a
+    /// tenant selection supplied by untrusted JWT claims.
+    pub tenant_id: u64,
 }
 
 impl JwtProviderConfig {
@@ -240,14 +249,50 @@ impl JwtAuthConfig {
         )
     }
 
-    /// Validate all providers. Called from the server-config loader so
-    /// misconfiguration fails startup rather than silently bypassing auth.
+    /// Validate all providers. Called by the server-config loader and JWKS
+    /// registry construction so misconfiguration fails before authentication.
     pub fn validate(&self) -> crate::Result<()> {
         let policy = self.jwks_policy().map_err(|e| crate::Error::Config {
             detail: format!("auth.jwt allow-list is invalid: {e}"),
         })?;
-        for p in &self.providers {
-            p.validate(&policy)?;
+        let mut provider_names = HashSet::with_capacity(self.providers.len());
+        for provider in &self.providers {
+            provider.validate(&policy)?;
+            if !provider_names.insert(provider.name.as_str()) {
+                return Err(crate::Error::Config {
+                    detail: format!(
+                        "auth.jwt providers contain duplicate static provider name {:?}",
+                        provider.name
+                    ),
+                });
+            }
+        }
+
+        for (index, provider) in self.providers.iter().enumerate() {
+            for other in self.providers.iter().skip(index + 1) {
+                if provider.issuer != other.issuer {
+                    continue;
+                }
+
+                if provider.audience.is_empty() || other.audience.is_empty() {
+                    return Err(crate::Error::Config {
+                        detail: format!(
+                            "auth.jwt providers '{}' and '{}' share issuer '{}' but \
+                             every shared-issuer route must use a distinct non-empty audience",
+                            provider.name, other.name, provider.issuer
+                        ),
+                    });
+                }
+                if provider.audience == other.audience {
+                    return Err(crate::Error::Config {
+                        detail: format!(
+                            "auth.jwt providers '{}' and '{}' duplicate the issuer/audience \
+                             route ({:?}, {:?})",
+                            provider.name, other.name, provider.issuer, provider.audience
+                        ),
+                    });
+                }
+            }
         }
         Ok(())
     }

--- a/nodedb/src/control/catalog_entry/tests/kind_labels.rs
+++ b/nodedb/src/control/catalog_entry/tests/kind_labels.rs
@@ -38,6 +38,7 @@ fn kind_label_is_stable() {
         issuer: "https://example.com".into(),
         jwks_uri: "https://example.com/.well-known/jwks.json".into(),
         audience: None,
+        tenant_id: None,
         claim_mapping: vec![],
         created_at_lsn: 0,
     };

--- a/nodedb/src/control/security/auth_context.rs
+++ b/nodedb/src/control/security/auth_context.rs
@@ -198,6 +198,28 @@ impl AuthContext {
         }
     }
 
+    /// Build `AuthContext` from an already-verified JWT and its bound identity.
+    ///
+    /// JWT claims retain non-authoritative session detail such as organization,
+    /// group, permission, and metadata fields. Identity fields that control
+    /// authorization are taken from the verified identity, whose tenant and
+    /// roles may be provider-bound rather than token-claim-derived.
+    pub fn from_verified_jwt(
+        claims: &JwtClaims,
+        identity: &AuthenticatedIdentity,
+        session_id: String,
+    ) -> Self {
+        let mut context = Self::from_jwt(claims, session_id);
+        if identity.user_id != 0 {
+            context.id = identity.user_id.to_string();
+        }
+        context.username = identity.username.clone();
+        context.tenant_id = identity.tenant_id;
+        context.roles = identity.roles.iter().map(ToString::to_string).collect();
+        context.auth_method = identity.auth_method.clone();
+        context
+    }
+
     /// Build `AuthContext` from a DB-authenticated identity (SCRAM, password, API key).
     ///
     /// This is the fallback path when no JWT is presented. The context is
@@ -489,6 +511,77 @@ mod tests {
         let rest = id.strip_prefix("s_").unwrap();
         assert_eq!(rest.len(), 32, "expected 128-bit (32 hex char) payload");
         assert!(rest.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn from_verified_jwt_uses_identity_for_authorization_fields() {
+        let claims = JwtClaims {
+            sub: "claim-user".into(),
+            tenant_id: 999,
+            roles: vec!["readonly".into()],
+            exp: 9_999_999_999,
+            nbf: 0,
+            iat: 1_700_000_000,
+            iss: "provider".into(),
+            aud: "nodedb".into(),
+            user_id: 7,
+            is_superuser: false,
+            extra: HashMap::from([
+                ("groups".into(), serde_json::json!(["engineering"])),
+                ("metadata".into(), serde_json::json!({"region": "us-west"})),
+            ]),
+        };
+        let mut identity = test_identity();
+        identity.user_id = 42;
+        identity.username = "provider-user".into();
+        identity.tenant_id = TenantId::new(1);
+        identity.auth_method = AuthMethod::OidcBearer;
+        identity.roles = vec![Role::TenantAdmin];
+
+        let ctx = AuthContext::from_verified_jwt(&claims, &identity, "s_jwt_bound".into());
+
+        assert_eq!(ctx.id, "42");
+        assert_eq!(ctx.username, "provider-user");
+        assert_eq!(ctx.tenant_id, TenantId::new(1));
+        assert_eq!(ctx.roles, vec!["tenant_admin"]);
+        assert_eq!(ctx.auth_method, AuthMethod::OidcBearer);
+        assert_eq!(ctx.groups, vec!["engineering"]);
+        assert_eq!(ctx.metadata.get("region"), Some(&"us-west".into()));
+    }
+
+    #[test]
+    fn from_verified_jwt_uses_distinct_subject_ids_when_identity_id_is_zero() {
+        let first_claims = JwtClaims {
+            sub: "oidc-subject-alice".into(),
+            tenant_id: 999,
+            roles: vec!["readonly".into()],
+            exp: 9_999_999_999,
+            nbf: 0,
+            iat: 1_700_000_000,
+            iss: "https://issuer.example".into(),
+            aud: "nodedb".into(),
+            user_id: 0,
+            is_superuser: false,
+            extra: HashMap::new(),
+        };
+        let mut second_claims = first_claims.clone();
+        second_claims.sub = "oidc-subject-bob".into();
+
+        let mut identity = test_identity();
+        identity.user_id = 0;
+        identity.auth_method = AuthMethod::OidcBearer;
+
+        let first = AuthContext::from_verified_jwt(&first_claims, &identity, "s_oidc_1".into());
+        let second = AuthContext::from_verified_jwt(&second_claims, &identity, "s_oidc_2".into());
+
+        assert_eq!(first.id, first_claims.sub);
+        assert_eq!(second.id, second_claims.sub);
+        assert_ne!(first.id, second.id);
+        assert_ne!(first.id, "0");
+        assert_eq!(first.tenant_id, identity.tenant_id);
+        assert_eq!(first.username, identity.username);
+        assert_eq!(first.roles, vec!["readwrite"]);
+        assert_eq!(first.auth_method, AuthMethod::OidcBearer);
     }
 
     #[test]

--- a/nodedb/src/control/security/catalog/oidc_providers.rs
+++ b/nodedb/src/control/security/catalog/oidc_providers.rs
@@ -56,6 +56,11 @@ pub struct StoredOidcProvider {
     /// Expected `aud` claim value. `None` = skip audience validation.
     #[msgpack(default)]
     pub audience: Option<String>,
+    /// Tenant bound to this provider. `None` preserves compatibility with
+    /// records written before tenant binding was introduced.
+    #[msgpack(default)]
+    #[serde(default)]
+    pub tenant_id: Option<u64>,
     /// Ordered claim-mapping rules evaluated at login to derive databases and roles.
     #[msgpack(default)]
     pub claim_mapping: Vec<StoredClaimMappingRule>,

--- a/nodedb/src/control/security/jwks/fetch.rs
+++ b/nodedb/src/control/security/jwks/fetch.rs
@@ -23,9 +23,13 @@ const MAX_REDIRECTS: usize = 3;
 
 /// Fetch JWKS from a provider's endpoint and update the cache.
 ///
+/// `cache_identity` is an internal generated cache key; `provider_name` is
+/// retained for operator-facing log fields.
+///
 /// Returns the number of keys successfully parsed.
 /// On HTTP or parse failure, logs a warning and returns 0 (cache unchanged).
 pub async fn fetch_and_cache(
+    cache_identity: &str,
     provider_name: &str,
     jwks_url: &str,
     cache: &JwksCache,
@@ -41,7 +45,7 @@ pub async fn fetch_and_cache(
                     keys = count,
                     "JWKS fetched successfully"
                 );
-                cache.update_provider(provider_name, keys);
+                cache.update_provider(cache_identity, keys);
             } else {
                 warn!(
                     provider = %provider_name,
@@ -215,7 +219,7 @@ impl JwksFetchError {
 /// Spawns a Tokio task that refreshes JWKS keys for all providers
 /// at the configured interval. Runs on the Control Plane.
 pub fn spawn_refresh_task(
-    providers: Vec<(String, String)>, // (name, jwks_url) pairs
+    providers: Vec<(String, String, String)>, // (cache identity, name, jwks_url) triples
     cache: std::sync::Arc<JwksCache>,
     refresh_interval_secs: u64,
     policy: std::sync::Arc<JwksPolicy>,
@@ -228,8 +232,8 @@ pub fn spawn_refresh_task(
 
         loop {
             interval.tick().await;
-            for (name, url) in &providers {
-                fetch_and_cache(name, url, &cache, &policy).await;
+            for (cache_identity, name, url) in &providers {
+                fetch_and_cache(cache_identity, name, url, &cache, &policy).await;
             }
         }
     })

--- a/nodedb/src/control/security/jwks/registry.rs
+++ b/nodedb/src/control/security/jwks/registry.rs
@@ -9,8 +9,11 @@
 //! only in how the verification key is resolved. The shared pipeline lives
 //! in [`Self::decode_unverified`] and [`Self::verify_signature_and_time`].
 
+mod cache_identity;
+
 use std::sync::Arc;
 
+use cache_identity::{catalog_cache_identity, static_cache_identity};
 use tracing::{debug, warn};
 
 use crate::config::auth::{JwtAuthConfig, JwtProviderConfig};
@@ -52,28 +55,45 @@ impl JwksRegistry {
     ///
     /// Fetches JWKS from all providers on startup, loads disk cache as fallback,
     /// and spawns the periodic refresh task.
-    pub async fn init(config: JwtAuthConfig) -> Self {
+    pub async fn init(config: JwtAuthConfig) -> crate::Result<Self> {
+        // Registry construction is also a public entry point, so it must not
+        // rely on the server-config loader to reject unsafe static providers.
+        // Validate before creating cache state, fetching remote keys, or
+        // spawning a refresh task.
+        config.validate()?;
+        let policy = Arc::new(config.jwks_policy().map_err(|e| crate::Error::Config {
+            detail: format!("auth.jwt allow-list is invalid: {e}"),
+        })?);
         let cache = Arc::new(JwksCache::new(config.jwks_cache_path.clone()));
-        // Policy construction is infallible here because ServerConfig
-        // validation already ran at startup; fall back to strict on the
-        // unlikely internal error path so runtime never opens up.
-        let policy = Arc::new(config.jwks_policy().unwrap_or_default());
 
         // Load disk cache first (offline fallback).
         cache.load_from_disk();
 
         // Fetch from all providers (best-effort — failures use disk cache).
         for provider in &config.providers {
-            super::fetch::fetch_and_cache(&provider.name, &provider.jwks_url, &cache, &policy)
-                .await;
+            let cache_identity = static_cache_identity(&provider.name);
+            super::fetch::fetch_and_cache(
+                &cache_identity,
+                &provider.name,
+                &provider.jwks_url,
+                &cache,
+                &policy,
+            )
+            .await;
         }
 
         // Spawn periodic refresh.
         let refresh_handle = if !config.providers.is_empty() {
-            let pairs: Vec<(String, String)> = config
+            let pairs: Vec<(String, String, String)> = config
                 .providers
                 .iter()
-                .map(|p| (p.name.clone(), p.jwks_url.clone()))
+                .map(|p| {
+                    (
+                        static_cache_identity(&p.name),
+                        p.name.clone(),
+                        p.jwks_url.clone(),
+                    )
+                })
                 .collect();
             Some(super::fetch::spawn_refresh_task(
                 pairs,
@@ -85,46 +105,38 @@ impl JwksRegistry {
             None
         };
 
-        Self {
+        Ok(Self {
             providers: config.providers.clone(),
             cache,
             config,
             policy,
             _refresh_handle: refresh_handle,
-        }
+        })
     }
 
-    /// Validate a JWT token using JWKS, routing by the `iss` claim.
+    /// Validate a JWT token using JWKS, routing by the `iss` and `aud` claims.
     ///
     /// Flow:
     /// 1. Decode header + payload (no signature) via [`Self::decode_unverified`].
-    /// 2. Match `iss` to a configured provider via [`Self::find_provider`].
+    /// 2. Match `iss` and `aud` to a configured provider via [`Self::find_provider`].
     /// 3. Resolve the verification key (cache lookup + on-demand re-fetch).
     /// 4. Verify signature, `exp`, `nbf` via [`Self::verify_signature_and_time`].
     /// 5. Validate `iss`, `aud` against the matched provider.
-    /// 6. Build and return an `AuthenticatedIdentity`.
+    /// 6. Build and return an `AuthenticatedIdentity` bound to that provider's tenant.
     pub async fn validate(&self, token: &str) -> Result<AuthenticatedIdentity, JwtError> {
         let decoded = self.decode_unverified(token)?;
-        let provider = self.find_provider(&decoded.claims.iss)?;
+        let provider = self.find_provider(&decoded.claims.iss, &decoded.claims.aud)?;
         let key = self.resolve_key(provider, &decoded).await?;
         self.verify_signature_and_time(&decoded, &key, &provider.name)?;
-
-        // Validate issuer.
-        if !provider.issuer.is_empty() && decoded.claims.iss != provider.issuer {
-            return Err(JwtError::InvalidIssuer);
-        }
-        // Validate audience.
-        if !provider.audience.is_empty() && decoded.claims.aud != provider.audience {
-            return Err(JwtError::InvalidAudience);
-        }
+        validate_provider_claims(provider, &decoded.claims)?;
 
         let claims = decoded.claims;
         let kid = decoded.header.kid.as_deref().unwrap_or("");
-        let identity = build_identity(&claims);
+        let identity = build_identity(&claims, provider.tenant_id);
 
         debug!(
             username = %identity.username,
-            tenant_id = claims.tenant_id,
+            tenant_id = provider.tenant_id,
             provider = %provider.name,
             kid = %kid,
             "JWKS JWT validated"
@@ -151,6 +163,7 @@ impl JwksRegistry {
             .ok_or(JwtError::InvalidIssuer)?;
         let key = self.resolve_key(provider, &decoded).await?;
         self.verify_signature_and_time(&decoded, &key, provider_name)?;
+        validate_provider_claims(provider, &decoded.claims)?;
 
         debug!(
             provider = %provider_name,
@@ -164,8 +177,9 @@ impl JwksRegistry {
     /// Validate a JWT using a named catalog provider whose JWKS endpoint is
     /// provided dynamically (catalog OIDC providers not in the static config).
     ///
-    /// The provider name is used as the cache key. The `jwks_uri` is used for
-    /// on-demand fetching when the key is not already cached.
+    /// Catalog keysets use a separate cache identity bound to their endpoint,
+    /// so they cannot reuse a static provider's keys or a prior endpoint's
+    /// keys after a catalog provider is recreated.
     pub async fn validate_with_catalog_provider(
         &self,
         provider_name: &str,
@@ -174,10 +188,11 @@ impl JwksRegistry {
     ) -> Result<JwtClaims, JwtError> {
         let decoded = self.decode_unverified(token)?;
         let kid = decoded.header.kid.as_deref().unwrap_or("");
-        let key = match self.cache.get(provider_name, kid) {
+        let cache_identity = catalog_cache_identity(provider_name, jwks_uri);
+        let key = match self.cache.get(&cache_identity, kid) {
             Some(k) => k,
             None => {
-                self.refetch_catalog_key(provider_name, jwks_uri, kid)
+                self.refetch_catalog_key(provider_name, jwks_uri, &cache_identity, kid)
                     .await?
             }
         };
@@ -295,38 +310,61 @@ impl JwksRegistry {
         decoded: &DecodedToken<'_>,
     ) -> Result<VerificationKey, JwtError> {
         let kid = decoded.header.kid.as_deref().unwrap_or("");
-        match self.cache.get(&provider.name, kid) {
+        let cache_identity = static_cache_identity(&provider.name);
+        match self.cache.get(&cache_identity, kid) {
             Some(k) => Ok(k),
-            None => self.refetch_for_unknown_kid(provider, kid).await,
+            None => {
+                self.refetch_for_unknown_kid(provider, &cache_identity, kid)
+                    .await
+            }
         }
     }
 
-    /// Find the provider matching a token's issuer.
+    /// Find the provider matching a token's issuer and audience.
     ///
-    /// Strict match only — a non-empty configured `issuer` must equal the
-    /// token's `iss`. There is **no** single-provider fallback: a token
-    /// whose issuer is empty or does not match any configured provider is
-    /// rejected, even when only one provider is configured. Accepting a
-    /// lone provider by count is how the cross-tenant-JWKS bypass worked.
-    fn find_provider(&self, issuer: &str) -> Result<&JwtProviderConfig, JwtError> {
+    /// Static configuration validation ensures a route is unique. A provider
+    /// with an empty audience is a wildcard only when it is the sole provider
+    /// for its issuer; validation forbids it from sharing that issuer. There
+    /// is no single-provider fallback for a token whose issuer is empty or
+    /// does not match a configured provider. For a known issuer with a
+    /// mismatched audience, return `InvalidAudience` rather than accepting
+    /// the first provider.
+    fn find_provider(&self, issuer: &str, audience: &str) -> Result<&JwtProviderConfig, JwtError> {
         if issuer.is_empty() {
             return Err(JwtError::InvalidIssuer);
         }
-        self.providers
-            .iter()
-            .find(|p| !p.issuer.is_empty() && p.issuer == issuer)
-            .ok_or(JwtError::InvalidIssuer)
+
+        let mut issuer_matched = false;
+        let mut wildcard_provider = None;
+        for provider in &self.providers {
+            if provider.issuer == issuer {
+                issuer_matched = true;
+                if provider.audience == audience {
+                    return Ok(provider);
+                }
+                if provider.audience.is_empty() {
+                    wildcard_provider = Some(provider);
+                }
+            }
+        }
+
+        match (issuer_matched, wildcard_provider) {
+            (_, Some(provider)) => Ok(provider),
+            (true, None) => Err(JwtError::InvalidAudience),
+            (false, None) => Err(JwtError::InvalidIssuer),
+        }
     }
 
     /// On-demand re-fetch for unknown `kid` against a static-config provider.
     async fn refetch_for_unknown_kid(
         &self,
         provider: &JwtProviderConfig,
+        cache_identity: &str,
         kid: &str,
     ) -> Result<VerificationKey, JwtError> {
         if !self
             .cache
-            .can_refetch(&provider.name, self.config.jwks_min_refetch_secs)
+            .can_refetch(cache_identity, self.config.jwks_min_refetch_secs)
         {
             warn!(
                 provider = %provider.name,
@@ -336,8 +374,9 @@ impl JwksRegistry {
             return Err(JwtError::InvalidSignature);
         }
 
-        self.cache.mark_refetch_attempted(&provider.name);
+        self.cache.mark_refetch_attempted(cache_identity);
         super::fetch::fetch_and_cache(
+            cache_identity,
             &provider.name,
             &provider.jwks_url,
             &self.cache,
@@ -346,7 +385,7 @@ impl JwksRegistry {
         .await;
 
         self.cache
-            .get(&provider.name, kid)
+            .get(cache_identity, kid)
             .ok_or(JwtError::InvalidSignature)
     }
 
@@ -356,11 +395,12 @@ impl JwksRegistry {
         &self,
         provider_name: &str,
         jwks_uri: &str,
+        cache_identity: &str,
         kid: &str,
     ) -> Result<VerificationKey, JwtError> {
         if !self
             .cache
-            .can_refetch(provider_name, self.config.jwks_min_refetch_secs)
+            .can_refetch(cache_identity, self.config.jwks_min_refetch_secs)
         {
             warn!(
                 provider = %provider_name,
@@ -369,21 +409,42 @@ impl JwksRegistry {
             );
             return Err(JwtError::InvalidSignature);
         }
-        self.cache.mark_refetch_attempted(provider_name);
-        super::fetch::fetch_and_cache(provider_name, jwks_uri, &self.cache, &self.policy).await;
+        self.cache.mark_refetch_attempted(cache_identity);
+        super::fetch::fetch_and_cache(
+            cache_identity,
+            provider_name,
+            jwks_uri,
+            &self.cache,
+            &self.policy,
+        )
+        .await;
         self.cache
-            .get(provider_name, kid)
+            .get(cache_identity, kid)
             .ok_or(JwtError::InvalidSignature)
     }
 }
 
+/// Validate the issuer and audience constraints of a selected static provider.
+fn validate_provider_claims(
+    provider: &JwtProviderConfig,
+    claims: &JwtClaims,
+) -> Result<(), JwtError> {
+    if claims.iss != provider.issuer {
+        return Err(JwtError::InvalidIssuer);
+    }
+    if !provider.audience.is_empty() && claims.aud != provider.audience {
+        return Err(JwtError::InvalidAudience);
+    }
+    Ok(())
+}
+
 /// Build an `AuthenticatedIdentity` from a verified static-provider JWT.
 ///
-/// Static-provider tokens carry a `tenant_id` numeric claim and a `roles`
-/// list parsed by [`Role::from_str`]. The catalog-provider path uses
+/// Static-provider roles are parsed by [`Role::from_str`]. Tenant ownership comes
+/// from the provider's server-side binding, never the JWT. The catalog path uses
 /// [`crate::control::security::oidc`] instead, which applies stored
 /// claim-mapping rules.
-fn build_identity(claims: &JwtClaims) -> AuthenticatedIdentity {
+fn build_identity(claims: &JwtClaims, tenant_id: u64) -> AuthenticatedIdentity {
     let roles: Vec<Role> = claims
         .roles
         .iter()
@@ -397,7 +458,7 @@ fn build_identity(claims: &JwtClaims) -> AuthenticatedIdentity {
     AuthenticatedIdentity {
         user_id: claims.user_id,
         username,
-        tenant_id: TenantId::new(claims.tenant_id),
+        tenant_id: TenantId::new(tenant_id),
         auth_method: AuthMethod::OidcBearer,
         roles,
         is_superuser: claims.is_superuser,

--- a/nodedb/src/control/security/jwks/registry/cache_identity.rs
+++ b/nodedb/src/control/security/jwks/registry/cache_identity.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Collision-free cache identities for static and catalog JWKS providers.
+
+/// Build a static cache identity disjoint from the catalog domain.
+pub(super) fn static_cache_identity(provider_name: &str) -> String {
+    format!("static:{}:{provider_name}", provider_name.len())
+}
+
+/// Build a catalog identity bound to its endpoint and disjoint from static identities.
+pub(super) fn catalog_cache_identity(provider_name: &str, jwks_uri: &str) -> String {
+    format!(
+        "catalog:{}:{provider_name}:{}:{jwks_uri}",
+        provider_name.len(),
+        jwks_uri.len()
+    )
+}

--- a/nodedb/src/control/security/oidc/verify.rs
+++ b/nodedb/src/control/security/oidc/verify.rs
@@ -3,8 +3,8 @@
 //! OIDC bearer-token verification entry point.
 //!
 //! Decodes the token header + payload (without verifying the signature) to
-//! read the `iss` claim, resolves the matching OIDC provider from the catalog,
-//! delegates signature verification to `JwksRegistry`, applies claim mapping,
+//! read the `iss` and `aud` claims, resolves the matching OIDC provider from
+//! the catalog, delegates signature verification to `JwksRegistry`, applies claim mapping,
 //! and constructs an ephemeral `AuthenticatedIdentity`.
 //!
 //! pgwire does NOT support OIDC bearer tokens (SCRAM-SHA-256 only).
@@ -13,6 +13,7 @@
 use nodedb_types::id::DatabaseId;
 use tracing::debug;
 
+use crate::control::security::catalog::StoredOidcProvider;
 use crate::control::security::identity::database_set::DatabaseSet;
 use crate::control::security::identity::{AuthMethod, AuthenticatedIdentity, Role};
 use crate::control::security::jwt::JwtError;
@@ -25,17 +26,17 @@ use super::claim_mapping::apply_claim_mapping;
 /// Verify an OIDC bearer token and return an ephemeral `AuthenticatedIdentity`.
 ///
 /// Steps:
-/// 1. Decode header + payload (no signature) to extract `iss`.
-/// 2. Look up provider by `iss` in the catalog (`_system.oidc_providers`).
-/// 3. Verify signature via `JwksRegistry::validate_with_provider`.
-/// 4. Validate `aud` (if the provider has an expected audience), `exp`, `nbf`.
+/// 1. Decode header + payload (no signature) to extract `iss` and `aud`.
+/// 2. Route by `(iss, aud)` to one catalog provider, rejecting ambiguous routes.
+/// 3. Verify signature, expiration, and not-before via `JwksRegistry`.
+/// 4. Re-check the verified issuer and audience against the selected provider.
 /// 5. Apply claim-mapping rules to derive `default_database`, `accessible_databases`, `roles`.
 /// 6. Construct `AuthenticatedIdentity` with `auth_method = OidcBearer`.
 pub async fn verify_bearer_token(
     state: &SharedState,
     token: &str,
 ) -> crate::Result<AuthenticatedIdentity> {
-    // 1. Decode payload (no sig) to read `iss`.
+    // 1. Decode payload (no sig) to read `iss` and `aud`.
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         return Err(jwt_error_to_crate_error(JwtError::MalformedToken));
@@ -45,16 +46,18 @@ pub async fn verify_bearer_token(
     let claims: crate::control::security::jwt::JwtClaims = sonic_rs::from_slice(&payload_bytes)
         .map_err(|_| jwt_error_to_crate_error(JwtError::InvalidClaims))?;
 
-    let iss = &claims.iss;
-
-    // 2. Look up provider by `iss`.
+    // 2. Route by both unverified issuer and audience. These values only select
+    // the verification key; the same constraints are checked again after
+    // signature and time validation.
     let catalog = state.credentials.catalog();
-    let provider = catalog
-        .list_oidc_providers()
-        .map_err(|_| jwt_error_to_crate_error(JwtError::InvalidIssuer))?
-        .into_iter()
-        .find(|p| p.issuer == *iss)
-        .ok_or_else(|| crate::Error::OidcUnknownProvider { iss: iss.clone() })?;
+    let provider = select_catalog_provider(
+        catalog
+            .list_oidc_providers()
+            .map_err(|_| jwt_error_to_crate_error(JwtError::InvalidIssuer))?,
+        &claims.iss,
+        &claims.aud,
+    )
+    .map_err(jwt_error_to_crate_error)?;
 
     // 3. Verify signature via JwksRegistry using the catalog-provided JWKS URI.
     let jwks = state
@@ -66,11 +69,25 @@ pub async fn verify_bearer_token(
         .await
         .map_err(jwt_error_to_crate_error)?;
 
-    // 4. Validate audience if configured.
-    if let Some(ref expected_aud) = provider.audience
-        && verified_claims.aud != *expected_aud
-    {
-        return Err(jwt_error_to_crate_error(JwtError::InvalidAudience));
+    // 4. Re-check the verified claims against the provider selected above.
+    validate_selected_provider_claims(&provider, &verified_claims)
+        .map_err(jwt_error_to_crate_error)?;
+
+    // Legacy records without a tenant binding must not reveal catalog metadata
+    // until the token has passed signature, time, issuer, and audience checks.
+    let tenant_id = provider
+        .tenant_id
+        .ok_or(crate::Error::OidcProviderTenantUnbound)?;
+
+    // A provider can outlive its tenant after a tenant drop. Confirm the bound
+    // tenant still exists before issuing an identity from an authenticated token.
+    let tenant_exists = catalog
+        .load_all_tenants()
+        .map_err(|_| crate::Error::OidcProviderTenantUnavailable { tenant_id })?
+        .into_iter()
+        .any(|tenant| tenant.tenant_id == tenant_id);
+    if !tenant_exists {
+        return Err(crate::Error::OidcProviderTenantUnavailable { tenant_id });
     }
 
     // 5. Apply claim mapping.
@@ -128,7 +145,7 @@ pub async fn verify_bearer_token(
         // is identified by the `sub` claim's username.
         user_id: verified_claims.user_id,
         username,
-        tenant_id: TenantId::new(verified_claims.tenant_id),
+        tenant_id: TenantId::new(tenant_id),
         auth_method: AuthMethod::OidcBearer,
         roles,
         is_superuser: false,
@@ -137,23 +154,87 @@ pub async fn verify_bearer_token(
     })
 }
 
-/// Map a `JwtError` to a `crate::Error` with the correct semantics for the
-/// OIDC bearer-token path:
-/// - `Expired` surfaces as `SessionTokenExpired` so callers can distinguish
-///   token-expired from auth-rejected.
-/// - All other errors become `BadRequest` (client sent an invalid token).
-fn jwt_error_to_crate_error(e: JwtError) -> crate::Error {
-    match e {
-        JwtError::Expired => crate::Error::SessionTokenExpired,
-        JwtError::MalformedToken
-        | JwtError::InvalidClaims
-        | JwtError::DecodingError
-        | JwtError::InvalidSignature
-        | JwtError::NotYetValid
-        | JwtError::InvalidIssuer
-        | JwtError::InvalidAudience
-        | JwtError::UnsupportedAlgorithm => crate::Error::BadRequest {
-            detail: e.to_string(),
-        },
+/// Select one catalog provider for the token's unverified issuer and audience.
+///
+/// A `None` or empty audience is an issuer-only wildcard, valid only when it
+/// is the sole provider for that issuer. Catalog corruption or legacy data
+/// cannot silently change routing because every duplicate or wildcard-sharing
+/// issuer route is rejected here.
+fn select_catalog_provider(
+    providers: Vec<StoredOidcProvider>,
+    iss: &str,
+    aud: &str,
+) -> Result<StoredOidcProvider, JwtError> {
+    if iss.is_empty() {
+        return Err(JwtError::InvalidIssuer);
+    }
+
+    let issuer_providers: Vec<StoredOidcProvider> = providers
+        .into_iter()
+        .filter(|provider| provider.issuer == iss)
+        .collect();
+
+    if issuer_providers.is_empty() {
+        return Err(JwtError::InvalidIssuer);
+    }
+
+    let wildcard_count = issuer_providers
+        .iter()
+        .filter(|provider| provider.audience.as_deref().is_none_or(str::is_empty))
+        .count();
+    if wildcard_count > 0 && issuer_providers.len() > 1 {
+        return Err(JwtError::InvalidIssuer);
+    }
+
+    let mut exact_matches: Vec<StoredOidcProvider> = issuer_providers
+        .iter()
+        .filter(|provider| {
+            provider
+                .audience
+                .as_deref()
+                .is_some_and(|expected| !expected.is_empty() && expected == aud)
+        })
+        .cloned()
+        .collect();
+    if exact_matches.len() > 1 {
+        return Err(JwtError::InvalidIssuer);
+    }
+    if let Some(provider) = exact_matches.pop() {
+        return Ok(provider);
+    }
+
+    if wildcard_count == 1 {
+        return issuer_providers
+            .into_iter()
+            .next()
+            .ok_or(JwtError::InvalidIssuer);
+    }
+
+    Err(JwtError::InvalidAudience)
+}
+
+/// Re-check selected provider constraints after signature and time validation.
+fn validate_selected_provider_claims(
+    provider: &StoredOidcProvider,
+    claims: &crate::control::security::jwt::JwtClaims,
+) -> Result<(), JwtError> {
+    if claims.iss != provider.issuer {
+        return Err(JwtError::InvalidIssuer);
+    }
+    if provider
+        .audience
+        .as_deref()
+        .is_some_and(|expected| !expected.is_empty() && claims.aud != expected)
+    {
+        return Err(JwtError::InvalidAudience);
+    }
+    Ok(())
+}
+
+/// Collapse every pre-authentication JWT failure into one client-visible error.
+/// Route, signature, algorithm, and token-state details remain non-observable.
+fn jwt_error_to_crate_error(_error: JwtError) -> crate::Error {
+    crate::Error::BadRequest {
+        detail: "OIDC authentication failed".into(),
     }
 }

--- a/nodedb/src/control/server/http/auth.rs
+++ b/nodedb/src/control/server/http/auth.rs
@@ -87,8 +87,9 @@ pub fn resolve_identity(
 
 /// Resolve both authenticated identity and auth context from HTTP headers.
 ///
-/// Uses `AuthContext::from_jwt()` when JWT claims are available (richer context),
-/// falls back to `build_auth_context()` for API key / password auth.
+/// Uses `AuthContext::from_verified_jwt()` for JWTs so rich claims are retained
+/// while authorization fields remain bound to the verified identity. Falls back
+/// to `build_auth_context()` for API key / password auth.
 pub fn resolve_auth(
     headers: &HeaderMap,
     state: &AppState,
@@ -112,7 +113,7 @@ pub fn resolve_auth(
             let auth_ctx = if let Some(ref registry) = state.shared.jwks_registry
                 && let Ok(claims) = registry.decode_claims(token)
             {
-                AuthContext::from_jwt(&claims, generate_session_id())
+                AuthContext::from_verified_jwt(&claims, &identity, generate_session_id())
             } else {
                 tracing::trace!("JWT claims decode unavailable, using basic auth context");
                 session_auth::build_auth_context(&identity)

--- a/nodedb/src/control/server/shared/ddl/neutral/oidc.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/oidc.rs
@@ -60,16 +60,40 @@ fn require_superuser(
     }
 }
 
+/// Whether two providers would make the issuer route ambiguous.
+fn has_ambiguous_issuer_route(existing_audience: Option<&str>, audience: Option<&str>) -> bool {
+    let existing_audience = existing_audience.filter(|value| !value.is_empty());
+    let audience = audience.filter(|value| !value.is_empty());
+    match (existing_audience, audience) {
+        (Some(existing), Some(candidate)) => existing == candidate,
+        _ => true,
+    }
+}
+
+/// Borrowed fields for a `CREATE OIDC PROVIDER` operation.
+pub struct CreateOidcProviderParams<'a> {
+    pub name: &'a str,
+    pub issuer: &'a str,
+    pub jwks_uri: &'a str,
+    pub tenant_id: u64,
+    pub audience: Option<&'a str>,
+    pub claim_mappings: &'a [OidcClaimMappingClause],
+}
+
 /// Handle `CREATE OIDC PROVIDER <name> ISSUER '<iss>' JWKS_URI '<uri>' ...`.
 pub fn create_oidc_provider(
     state: &SharedState,
     identity: &AuthenticatedIdentity,
-    name: &str,
-    issuer: &str,
-    jwks_uri: &str,
-    audience: Option<&str>,
-    claim_mappings: &[OidcClaimMappingClause],
+    params: CreateOidcProviderParams<'_>,
 ) -> Result<Vec<DdlResult>, DdlError> {
+    let CreateOidcProviderParams {
+        name,
+        issuer,
+        jwks_uri,
+        tenant_id,
+        audience,
+        claim_mappings,
+    } = params;
     require_superuser(state, identity, "create OIDC providers")?;
 
     if issuer.is_empty() {
@@ -86,6 +110,21 @@ pub fn create_oidc_provider(
     }
 
     let catalog = state.credentials.catalog();
+
+    let tenant_exists = catalog
+        .load_all_tenants()
+        .map_err(|e| DdlError {
+            sqlstate: "XX000".to_string(),
+            message: format!("tenant lookup: {e}"),
+        })?
+        .iter()
+        .any(|tenant| tenant.tenant_id == tenant_id);
+    if !tenant_exists {
+        return Err(DdlError {
+            sqlstate: "42704".to_string(),
+            message: format!("tenant '{tenant_id}' does not exist"),
+        });
+    }
 
     // Check for duplicate by provider name.
     match catalog.get_oidc_provider(name) {
@@ -104,13 +143,18 @@ pub fn create_oidc_provider(
         }
     }
 
-    // Check for duplicate issuer (one issuer → one provider).
+    // A route is `(issuer, audience)`. An absent or empty audience makes an
+    // issuer route ambiguous, while distinct non-empty audiences may share it.
     match catalog.list_oidc_providers() {
         Ok(providers) => {
-            if providers.iter().any(|p| p.issuer == issuer) {
+            if providers.iter().any(|p| {
+                p.issuer == issuer && has_ambiguous_issuer_route(p.audience.as_deref(), audience)
+            }) {
                 return Err(DdlError {
                     sqlstate: "42710".to_string(),
-                    message: format!("OIDC provider with issuer '{issuer}' already exists"),
+                    message: format!(
+                        "OIDC provider issuer/audience route for issuer '{issuer}' is ambiguous or already exists"
+                    ),
                 });
             }
         }
@@ -138,6 +182,7 @@ pub fn create_oidc_provider(
         issuer: issuer.to_string(),
         jwks_uri: jwks_uri.to_string(),
         audience: audience.map(str::to_string),
+        tenant_id: Some(tenant_id),
         claim_mapping: stored_mappings,
         created_at_lsn: 0,
     };
@@ -296,6 +341,7 @@ pub fn show_oidc_providers(
         "name".to_string(),
         "issuer".to_string(),
         "jwks_uri".to_string(),
+        "tenant_id".to_string(),
         "audience".to_string(),
         "claim_mapping_rules".to_string(),
     ];
@@ -311,6 +357,10 @@ pub fn show_oidc_providers(
         row.insert(
             "jwks_uri".to_string(),
             JsonValue::String(p.jwks_uri.clone()),
+        );
+        row.insert(
+            "tenant_id".to_string(),
+            JsonValue::String(p.tenant_id.map(|id| id.to_string()).unwrap_or_default()),
         );
         let aud = p.audience.as_deref().unwrap_or("");
         row.insert("audience".to_string(), JsonValue::String(aud.to_string()));

--- a/nodedb/src/control/server/shared/ddl/neutral/router/typed_auth.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/router/typed_auth.rs
@@ -104,16 +104,20 @@ pub(super) async fn try_typed(
             name,
             issuer,
             jwks_uri,
+            tenant_id,
             audience,
             claim_mappings,
         }) => Some(oidc::create_oidc_provider(
             state,
             identity,
-            name,
-            issuer,
-            jwks_uri,
-            audience.as_deref(),
-            claim_mappings,
+            oidc::CreateOidcProviderParams {
+                name,
+                issuer,
+                jwks_uri,
+                tenant_id: *tenant_id,
+                audience: audience.as_deref(),
+                claim_mappings,
+            },
         )),
 
         NodedbStatement::Auth(AuthStmt::AlterOidcProviderClaimMapping {

--- a/nodedb/src/error.rs
+++ b/nodedb/src/error.rs
@@ -367,11 +367,14 @@ pub enum Error {
     #[error("session closed: user account was dropped")]
     SessionUserDropped,
 
-    /// OIDC bearer token presented but no matching provider is configured.
-    #[error(
-        "OIDC token rejected: unknown provider — no configured provider matches 'iss' claim '{iss}'"
-    )]
-    OidcUnknownProvider { iss: String },
+    /// OIDC bearer token rejected because the authenticated provider has no tenant binding.
+    #[error("OIDC token rejected: authenticated provider has no tenant binding")]
+    OidcProviderTenantUnbound,
+
+    /// OIDC bearer token rejected because its authenticated provider references
+    /// a tenant that was deleted or cannot be read from the catalog.
+    #[error("OIDC token rejected: authenticated provider tenant is unavailable")]
+    OidcProviderTenantUnavailable { tenant_id: u64 },
 
     /// OIDC bearer token rejected: claim mapping produced no default database.
     #[error("OIDC token rejected: claim mapping produced no default database for subject '{sub}'")]

--- a/nodedb/src/error_from.rs
+++ b/nodedb/src/error_from.rs
@@ -292,9 +292,12 @@ impl From<Error> for NodeDbError {
             Error::SessionUserDropped => {
                 NodeDbError::bad_request("session terminated: user account dropped".to_owned())
             }
-            Error::OidcUnknownProvider { iss } => {
-                NodeDbError::bad_request(format!("OIDC: no provider registered for issuer '{iss}'"))
-            }
+            Error::OidcProviderTenantUnbound => NodeDbError::bad_request(
+                "OIDC: authenticated provider has no tenant binding".to_owned(),
+            ),
+            Error::OidcProviderTenantUnavailable { .. } => NodeDbError::bad_request(
+                "OIDC: authenticated provider tenant is unavailable".to_owned(),
+            ),
             Error::OidcNoDefaultDatabase { sub } => NodeDbError::bad_request(format!(
                 "OIDC: no default database resolved for sub '{sub}'"
             )),

--- a/nodedb/tests/auth_jwks_security.rs
+++ b/nodedb/tests/auth_jwks_security.rs
@@ -73,22 +73,25 @@ async fn spawn_redirect_loop() -> (String, Arc<AtomicUsize>) {
     (format!("https://{addr}/jwks.json"), counter)
 }
 
-/// Spin a minimal http server that returns a fixed body once.
-async fn spawn_static_body(body: &'static str) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+/// Spin a minimal HTTP server that returns a fixed body for every request.
+async fn spawn_static_body(body: impl Into<String>) -> String {
+    let body = body.into();
+    let listener = tokio::net::TcpListener::bind("[::]:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
-        if let Ok((mut s, _)) = listener.accept().await {
-            use tokio::io::AsyncWriteExt;
-            let resp = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            let _ = s.write_all(resp.as_bytes()).await;
+        loop {
+            if let Ok((mut s, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = s.write_all(resp.as_bytes()).await;
+            }
         }
     });
-    format!("http://{addr}/jwks.json")
+    format!("http://localhost:{}/jwks.json", addr.port())
 }
 
 fn b64(bytes: &[u8]) -> String {
@@ -113,14 +116,58 @@ fn forged_token(iss: &str) -> String {
 
 fn single_provider_cfg(jwks_url: &str, issuer: &str) -> JwtAuthConfig {
     JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
         providers: vec![JwtProviderConfig {
             name: "prod".into(),
             jwks_url: jwks_url.into(),
             issuer: issuer.into(),
             audience: String::new(),
+            tenant_id: 1,
         }],
         ..JwtAuthConfig::default()
     }
+}
+
+fn signed_jwt_fixture(issuer: &str, audience: &str, claimed_tenant_id: u64) -> (String, String) {
+    use rsa::pkcs1v15::SigningKey;
+    use rsa::signature::{SignatureEncoding, Signer};
+    use rsa::traits::PublicKeyParts;
+
+    let mut rng = rsa::rand_core::OsRng;
+    let private_key = rsa::RsaPrivateKey::new(&mut rng, 1024).unwrap();
+    let public_key = rsa::RsaPublicKey::from(&private_key);
+    let jwks = format!(
+        r#"{{"keys":[{{"kty":"RSA","kid":"tenant-binding","alg":"RS256","use":"sig","n":"{}","e":"{}"}}]}}"#,
+        b64(&public_key.n().to_bytes_be()),
+        b64(&public_key.e().to_bytes_be()),
+    );
+    let header = b64(br#"{"alg":"RS256","kid":"tenant-binding"}"#);
+    let payload = b64(
+        format!(
+            r#"{{"iss":"{issuer}","aud":"{audience}","sub":"alice","tenant_id":{claimed_tenant_id},"roles":["readwrite"],"exp":9999999999,"user_id":42}}"#
+        )
+        .as_bytes(),
+    );
+    let signing_input = format!("{header}.{payload}");
+    let signing_key = SigningKey::<sha2::Sha256>::new(private_key);
+    let signature: rsa::pkcs1v15::Signature = signing_key.sign(signing_input.as_bytes());
+    let token = format!("{signing_input}.{}", b64(&signature.to_bytes()));
+
+    (jwks, token)
+}
+
+fn local_jwks_config(provider_tables: &str) -> JwtAuthConfig {
+    toml::from_str(&format!(
+        r#"
+allow_http_jwks = true
+allow_jwks_hosts = ["localhost"]
+allow_jwks_cidrs = ["127.0.0.0/8", "::1/128"]
+{provider_tables}
+"#
+    ))
+    .expect("JWT provider fixture must deserialize")
 }
 
 // ── 1. Issuer bypass ───────────────────────────────────────────────────
@@ -133,7 +180,9 @@ async fn single_provider_does_not_accept_mismatched_issuer() {
     // fall through to sig/kid lookup on the sole provider.
     let jwks_url = spawn_static_body(r#"{"keys":[]}"#).await;
     let cfg = single_provider_cfg(&jwks_url, "https://auth.example.com/");
-    let registry = JwksRegistry::init(cfg).await;
+    let registry = JwksRegistry::init(cfg)
+        .await
+        .expect("valid static provider configuration must initialise");
 
     let token = forged_token("https://attacker-tenant.auth0.com/");
     let err = registry.validate(&token).await.expect_err("must reject");
@@ -144,22 +193,14 @@ async fn single_provider_does_not_accept_mismatched_issuer() {
 }
 
 #[tokio::test]
-async fn single_provider_with_empty_configured_issuer_still_rejects_any_token() {
-    // If a deployment runs through init with `issuer = ""`, either init
-    // must refuse or validate must reject all tokens. Either way, no
-    // token is ever accepted under this config shape.
+async fn single_provider_with_empty_configured_issuer_is_rejected_at_init() {
+    // Direct registry construction must fail closed too; callers are not
+    // required to have loaded the configuration through ServerConfig first.
     let jwks_url = spawn_static_body(r#"{"keys":[]}"#).await;
     let cfg = single_provider_cfg(&jwks_url, "");
-    let registry = JwksRegistry::init(cfg).await;
-
-    let token = forged_token("https://any.example.com/");
-    let err = registry
-        .validate(&token)
-        .await
-        .expect_err("empty-issuer provider must never accept a token");
     assert!(
-        matches!(err, JwtError::InvalidIssuer),
-        "empty configured issuer must behave as no-match, got {err:?}"
+        JwksRegistry::init(cfg).await.is_err(),
+        "empty-issuer provider must be rejected during registry initialisation"
     );
 }
 
@@ -168,7 +209,12 @@ async fn single_provider_with_empty_configured_issuer_still_rejects_any_token() 
 /// Build a valid ServerConfig TOML with a single JWT provider whose jwks_url
 /// and issuer are parameterised. Produces a structurally-valid config so the
 /// only reason from_file can fail is the JWT validation we're testing.
-fn config_toml_with_provider(jwks_url: &str, issuer: &str) -> String {
+fn config_toml_with_provider(
+    jwks_url: &str,
+    issuer: &str,
+    audience: &str,
+    tenant_id: u64,
+) -> String {
     format!(
         r#"
 [server]
@@ -201,6 +247,8 @@ audit_retention_days     = 0
 name     = "prod"
 jwks_url = "{jwks_url}"
 issuer   = "{issuer}"
+audience = "{audience}"
+tenant_id = {tenant_id}
 "#
     )
 }
@@ -213,6 +261,8 @@ fn config_template_is_structurally_valid() {
     let toml = config_toml_with_provider(
         "https://auth.example.com/.well-known/jwks.json",
         "https://auth.example.com/",
+        "",
+        1,
     );
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(toml.as_bytes()).unwrap();
@@ -227,6 +277,8 @@ fn server_config_rejects_jwt_provider_with_empty_issuer() {
     let toml = config_toml_with_provider(
         "https://auth.example.com/.well-known/jwks.json",
         "", // empty issuer
+        "",
+        1,
     );
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(toml.as_bytes()).unwrap();
@@ -241,6 +293,8 @@ fn server_config_rejects_http_jwks_url() {
     let toml = config_toml_with_provider(
         "http://auth.example.com/.well-known/jwks.json",
         "https://auth.example.com/",
+        "",
+        1,
     );
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(toml.as_bytes()).unwrap();
@@ -263,6 +317,8 @@ fn server_config_rejects_ip_literal_jwks_host() {
         let toml = config_toml_with_provider(
             &format!("https://{host}/.well-known/jwks.json"),
             "https://auth.example.com/",
+            "",
+            1,
         );
         let mut f = tempfile::NamedTempFile::new().unwrap();
         f.write_all(toml.as_bytes()).unwrap();
@@ -271,6 +327,165 @@ fn server_config_rejects_ip_literal_jwks_host() {
             "IP-literal host in JWKS URL must be rejected: {host}"
         );
     }
+}
+
+#[test]
+fn server_config_rejects_jwt_provider_without_tenant_binding() {
+    let mut toml = config_toml_with_provider(
+        "https://auth.example.com/.well-known/jwks.json",
+        "https://auth.example.com/",
+        "",
+        1,
+    );
+    let tenant_binding = "tenant_id = 1\n";
+    let binding_offset = toml
+        .find(tenant_binding)
+        .expect("test configuration must include its tenant binding");
+    toml.replace_range(binding_offset..binding_offset + tenant_binding.len(), "");
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(toml.as_bytes()).unwrap();
+    assert!(
+        ServerConfig::from_file(f.path()).is_err(),
+        "a static JWT provider without an explicit tenant binding must be rejected at load"
+    );
+}
+
+#[test]
+fn server_config_rejects_duplicate_static_provider_issuer_audience_routes() {
+    let mut toml = config_toml_with_provider(
+        "https://auth.example.com/.well-known/jwks.json",
+        "https://auth.example.com/",
+        "nodedb-api",
+        1,
+    );
+    toml.push_str(
+        r#"
+[[auth.jwt.providers]]
+name      = "duplicate-route"
+jwks_url  = "https://auth.example.com/other-jwks.json"
+issuer    = "https://auth.example.com/"
+audience  = "nodedb-api"
+tenant_id = 2
+"#,
+    );
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(toml.as_bytes()).unwrap();
+    assert!(
+        ServerConfig::from_file(f.path()).is_err(),
+        "two static providers must not claim the same issuer and audience route"
+    );
+}
+
+#[test]
+fn server_config_rejects_duplicate_static_provider_names_with_distinct_routes() {
+    let mut toml = config_toml_with_provider(
+        "https://auth.example.com/.well-known/jwks.json",
+        "https://auth.example.com/",
+        "tenant-a-api",
+        1,
+    );
+    toml.push_str(
+        r#"
+[[auth.jwt.providers]]
+name      = "prod"
+jwks_url  = "https://other-auth.example.com/.well-known/jwks.json"
+issuer    = "https://other-auth.example.com/"
+audience  = "tenant-b-api"
+tenant_id = 2
+"#,
+    );
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(toml.as_bytes()).unwrap();
+    assert!(
+        ServerConfig::from_file(f.path()).is_err(),
+        "static provider names must be unique even when issuer/audience routes differ"
+    );
+}
+
+#[tokio::test]
+async fn registry_init_rejects_duplicate_static_provider_issuer_audience_routes() {
+    let config = JwtAuthConfig {
+        providers: vec![
+            JwtProviderConfig {
+                name: "tenant-a".into(),
+                jwks_url: "https://auth.example.com/a-jwks.json".into(),
+                issuer: "https://auth.example.com/".into(),
+                audience: "nodedb-api".into(),
+                tenant_id: 1,
+            },
+            JwtProviderConfig {
+                name: "tenant-b".into(),
+                jwks_url: "https://auth.example.com/b-jwks.json".into(),
+                issuer: "https://auth.example.com/".into(),
+                audience: "nodedb-api".into(),
+                tenant_id: 2,
+            },
+        ],
+        ..JwtAuthConfig::default()
+    };
+
+    assert!(
+        JwksRegistry::init(config).await.is_err(),
+        "direct registry initialisation must reject duplicate issuer/audience routes"
+    );
+}
+
+#[tokio::test]
+async fn same_issuer_distinct_audiences_and_tenant_bindings_are_routed_independently() {
+    let issuer = "https://issuer.example.com/";
+    let (jwks, token) = signed_jwt_fixture(issuer, "tenant-b-api", 999);
+    let jwks_url = spawn_static_body(jwks).await;
+    let registry = JwksRegistry::init(local_jwks_config(&format!(
+        r#"
+[[providers]]
+name = "tenant-a"
+jwks_url = "{jwks_url}"
+issuer = "{issuer}"
+audience = "tenant-a-api"
+tenant_id = 101
+
+[[providers]]
+name = "tenant-b"
+jwks_url = "{jwks_url}"
+issuer = "{issuer}"
+audience = "tenant-b-api"
+tenant_id = 202
+"#
+    )))
+    .await
+    .expect("valid static provider configuration must initialise");
+
+    let identity = registry
+        .validate(&token)
+        .await
+        .expect("the issuer/audience route for tenant-b must be accepted");
+    assert_eq!(identity.tenant_id.as_u64(), 202);
+}
+
+#[tokio::test]
+async fn static_provider_tenant_binding_overrides_signed_tenant_claim() {
+    let issuer = "https://issuer.example.com/";
+    let (jwks, token) = signed_jwt_fixture(issuer, "nodedb-api", 999);
+    let jwks_url = spawn_static_body(jwks).await;
+    let registry = JwksRegistry::init(local_jwks_config(&format!(
+        r#"
+[[providers]]
+name = "bound-provider"
+jwks_url = "{jwks_url}"
+issuer = "{issuer}"
+audience = "nodedb-api"
+tenant_id = 42
+"#
+    )))
+    .await
+    .expect("valid static provider configuration must initialise");
+
+    let identity = registry.validate(&token).await.expect("JWT must validate");
+    assert_eq!(
+        identity.tenant_id.as_u64(),
+        42,
+        "the provider binding, not the signed tenant_id claim, determines the identity tenant"
+    );
 }
 
 // ── 2b. Allow-list relaxations ───────────────────────────────────────
@@ -313,6 +528,7 @@ allow_jwks_cidrs = ["10.42.0.0/16"]
 name     = "prod"
 jwks_url = "http://keycloak.internal/jwks.json"
 issuer   = "https://auth.example.com/"
+tenant_id = 1
 "#;
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(toml.as_bytes()).unwrap();
@@ -356,6 +572,7 @@ allow_jwks_hosts = ["keycloak.internal"]
 name     = "prod"
 jwks_url = "http://evil.example.com/jwks.json"
 issuer   = "https://auth.example.com/"
+tenant_id = 1
 "#;
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(toml.as_bytes()).unwrap();
@@ -400,6 +617,7 @@ allow_jwks_cidrs = ["0.0.0.0/0"]
 name     = "prod"
 jwks_url = "https://10.0.0.5/jwks.json"
 issuer   = "https://auth.example.com/"
+tenant_id = 1
 "#;
     let mut f = tempfile::NamedTempFile::new().unwrap();
     f.write_all(toml.as_bytes()).unwrap();
@@ -418,7 +636,7 @@ async fn fetch_does_not_connect_to_http_url() {
     // counting listener and assert zero inbound connections were made.
     let (url, counter) = spawn_counting_listener();
     let cache = JwksCache::new(None);
-    let keys = fetch_and_cache("prod", &url, &cache, &JwksPolicy::strict()).await;
+    let keys = fetch_and_cache("prod", "prod", &url, &cache, &JwksPolicy::strict()).await;
     // Give any leaked connect a moment to land.
     tokio::time::sleep(Duration::from_millis(200)).await;
     assert_eq!(keys, 0, "must not parse keys from a refused URL");
@@ -455,7 +673,7 @@ async fn fetch_does_not_connect_to_ip_literal_imds() {
         SocketAddr::from((Ipv4Addr::LOCALHOST, port))
     );
     let cache = JwksCache::new(None);
-    let keys = fetch_and_cache("prod", &url, &cache, &JwksPolicy::strict()).await;
+    let keys = fetch_and_cache("prod", "prod", &url, &cache, &JwksPolicy::strict()).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
     assert_eq!(keys, 0);
     assert_eq!(
@@ -479,7 +697,7 @@ async fn fetch_caps_redirect_hops() {
     // not revalidated. We pin "no more than 4 total connections".
     let (url, counter) = spawn_redirect_loop().await;
     let cache = JwksCache::new(None);
-    let keys = fetch_and_cache("prod", &url, &cache, &JwksPolicy::strict()).await;
+    let keys = fetch_and_cache("prod", "prod", &url, &cache, &JwksPolicy::strict()).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
     assert_eq!(keys, 0);
     let n = counter.load(Ordering::SeqCst);
@@ -519,7 +737,7 @@ async fn parse_error_log_does_not_leak_response_body() {
     {
         let _guard = set_default(subscriber);
         let cache = JwksCache::new(None);
-        let _ = fetch_and_cache("prod", &url, &cache, &JwksPolicy::strict()).await;
+        let _ = fetch_and_cache("prod", "prod", &url, &cache, &JwksPolicy::strict()).await;
     }
 
     let captured = String::from_utf8(buf.lock().unwrap().clone()).unwrap();

--- a/nodedb/tests/oidc.rs
+++ b/nodedb/tests/oidc.rs
@@ -4,10 +4,18 @@
 
 mod common;
 
+use std::sync::Arc;
+
+use base64::Engine;
 use common::pgwire_auth_helpers::{
     ddl_err, ddl_ok, make_state_with_catalog, readonly_user, superuser,
 };
-use nodedb::control::security::oidc::claim_mapping::apply_claim_mapping;
+use nodedb::config::auth::{JwtAuthConfig, JwtProviderConfig};
+use nodedb::control::security::jwks::registry::JwksRegistry;
+use nodedb::control::security::oidc::{claim_mapping::apply_claim_mapping, verify_bearer_token};
+use nodedb::control::server::shared::ddl;
+use nodedb::control::server::shared::ddl::result::DdlResult;
+use nodedb::control::server::shared::session::DetachedTxnScope;
 
 // ── CREATE OIDC PROVIDER ────────────────────────────────────────────────────
 
@@ -15,13 +23,15 @@ use nodedb::control::security::oidc::claim_mapping::apply_claim_mapping;
 async fn create_oidc_provider_persists_in_catalog() {
     let state = make_state_with_catalog();
     let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT acme ID 42").await;
     ddl_ok(
         &state,
         &su,
         "CREATE OIDC PROVIDER okta \
          ISSUER 'https://acme.okta.com' \
          JWKS_URI 'https://acme.okta.com/.well-known/jwks.json' \
-         AUDIENCE 'nodedb'",
+         AUDIENCE 'nodedb' \
+         TENANT 42",
     )
     .await;
 
@@ -32,23 +42,109 @@ async fn create_oidc_provider_persists_in_catalog() {
         .expect("provider must exist after CREATE");
     assert_eq!(stored.issuer, "https://acme.okta.com");
     assert_eq!(stored.audience.as_deref(), Some("nodedb"));
+    let encoded = sonic_rs::to_string(&stored).expect("provider must serialize");
+    assert!(
+        encoded.contains("\"tenant_id\":42"),
+        "persisted provider must retain its tenant binding: {encoded}"
+    );
 }
 
 #[tokio::test]
 async fn create_oidc_provider_requires_superuser() {
     let state = make_state_with_catalog();
+    let su = superuser();
     let viewer = readonly_user();
+    ddl_ok(&state, &su, "CREATE TENANT acme ID 42").await;
     let err = ddl_err(
         &state,
         &viewer,
         "CREATE OIDC PROVIDER bad \
          ISSUER 'https://x.example/' \
-         JWKS_URI 'https://x.example/jwks'",
+         JWKS_URI 'https://x.example/jwks' \
+         TENANT 42",
     )
     .await;
     assert!(
         err.contains("42501") || err.contains("permission denied"),
         "expected permission denied, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn create_oidc_provider_rejects_unknown_tenant() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+    let err = ddl_err(
+        &state,
+        &su,
+        "CREATE OIDC PROVIDER unknown_tenant \
+         ISSUER 'https://unknown-tenant.example/' \
+         JWKS_URI 'https://unknown-tenant.example/jwks' \
+         TENANT 999",
+    )
+    .await;
+    assert!(
+        err.contains("does not exist") || err.contains("unknown tenant"),
+        "expected unknown-tenant error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn same_issuer_allows_distinct_nonempty_audiences_per_tenant() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT alpha ID 42").await;
+    ddl_ok(&state, &su, "CREATE TENANT beta ID 43").await;
+    ddl_ok(&state, &su, "CREATE TENANT gamma ID 44").await;
+
+    ddl_ok(
+        &state,
+        &su,
+        "CREATE OIDC PROVIDER alpha_idp \
+         ISSUER 'https://shared.example/' \
+         JWKS_URI 'https://shared.example/jwks' \
+         AUDIENCE 'alpha-api' \
+         TENANT 42",
+    )
+    .await;
+    ddl_ok(
+        &state,
+        &su,
+        "CREATE OIDC PROVIDER beta_idp \
+         ISSUER 'https://shared.example/' \
+         JWKS_URI 'https://shared.example/jwks' \
+         AUDIENCE 'beta-api' \
+         TENANT 43",
+    )
+    .await;
+
+    let missing_audience = ddl_err(
+        &state,
+        &su,
+        "CREATE OIDC PROVIDER no_aud_route \
+         ISSUER 'https://shared.example/' \
+         JWKS_URI 'https://shared.example/jwks' \
+         TENANT 44",
+    )
+    .await;
+    assert!(
+        missing_audience.to_lowercase().contains("audience"),
+        "expected same-issuer registration without an audience to be rejected, got: {missing_audience}"
+    );
+
+    let err = ddl_err(
+        &state,
+        &su,
+        "CREATE OIDC PROVIDER duplicate_route \
+         ISSUER 'https://shared.example/' \
+         JWKS_URI 'https://shared.example/jwks' \
+         AUDIENCE 'alpha-api' \
+         TENANT 43",
+    )
+    .await;
+    assert!(
+        err.contains("42710") || err.contains("already exists"),
+        "expected duplicate issuer+audience error, got: {err}"
     );
 }
 
@@ -58,12 +154,14 @@ async fn create_oidc_provider_requires_superuser() {
 async fn drop_oidc_provider_removes_record() {
     let state = make_state_with_catalog();
     let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT auth0_tenant ID 42").await;
     ddl_ok(
         &state,
         &su,
         "CREATE OIDC PROVIDER auth0 \
          ISSUER 'https://x.auth0.com' \
-         JWKS_URI 'https://x.auth0.com/.well-known/jwks.json'",
+         JWKS_URI 'https://x.auth0.com/.well-known/jwks.json' \
+         TENANT 42",
     )
     .await;
     ddl_ok(&state, &su, "DROP OIDC PROVIDER auth0").await;
@@ -99,12 +197,15 @@ async fn drop_oidc_provider_if_exists_unknown_succeeds() {
 async fn show_oidc_providers_lists_registered() {
     let state = make_state_with_catalog();
     let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT p1_tenant ID 42").await;
+    ddl_ok(&state, &su, "CREATE TENANT p2_tenant ID 43").await;
     ddl_ok(
         &state,
         &su,
         "CREATE OIDC PROVIDER p1 \
          ISSUER 'https://p1.example/' \
-         JWKS_URI 'https://p1.example/jwks'",
+         JWKS_URI 'https://p1.example/jwks' \
+         TENANT 42",
     )
     .await;
     ddl_ok(
@@ -112,10 +213,530 @@ async fn show_oidc_providers_lists_registered() {
         &su,
         "CREATE OIDC PROVIDER p2 \
          ISSUER 'https://p2.example/' \
-         JWKS_URI 'https://p2.example/jwks'",
+         JWKS_URI 'https://p2.example/jwks' \
+         TENANT 43",
     )
     .await;
     ddl_ok(&state, &su, "SHOW OIDC PROVIDERS").await;
+}
+
+#[tokio::test]
+async fn show_oidc_providers_exposes_tenant_binding() {
+    let state = make_state_with_catalog();
+    let su = superuser();
+    ddl_ok(&state, &su, "CREATE TENANT acme ID 42").await;
+    ddl_ok(
+        &state,
+        &su,
+        "CREATE OIDC PROVIDER acme_idp \
+         ISSUER 'https://acme.example/' \
+         JWKS_URI 'https://acme.example/jwks' \
+         TENANT 42",
+    )
+    .await;
+
+    let scope = DetachedTxnScope::new();
+    let result = ddl::dispatch(
+        &state,
+        &su,
+        "SHOW OIDC PROVIDERS",
+        nodedb_types::id::DatabaseId::DEFAULT,
+        &scope.ctx(),
+    )
+    .await
+    .expect("SHOW OIDC PROVIDERS must be recognized")
+    .expect("SHOW OIDC PROVIDERS must succeed");
+
+    match &result[0] {
+        DdlResult::Rows(rows) => {
+            assert!(rows.columns.iter().any(|column| column == "tenant_id"));
+            assert_eq!(
+                rows.rows[0]
+                    .get("tenant_id")
+                    .and_then(serde_json::Value::as_str),
+                Some("42")
+            );
+        }
+        other => panic!("expected Rows response, got: {other:?}"),
+    }
+}
+
+// ── Catalog-backed bearer verification ─────────────────────────────────────
+
+async fn spawn_static_jwks(body: String) -> String {
+    let listener = tokio::net::TcpListener::bind("[::]:0")
+        .await
+        .expect("JWKS fixture must bind");
+    let addr = listener
+        .local_addr()
+        .expect("JWKS fixture must expose its address");
+    tokio::spawn(async move {
+        loop {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        }
+    });
+    format!("http://localhost:{}/jwks.json", addr.port())
+}
+
+#[derive(zerompk::ToMessagePack)]
+#[msgpack(map)]
+struct LegacyOidcProvider {
+    provider_name: String,
+    issuer: String,
+    jwks_uri: String,
+    audience: Option<String>,
+    claim_mapping: Vec<nodedb::control::security::catalog::oidc_providers::StoredClaimMappingRule>,
+    created_at_lsn: u64,
+}
+
+fn forged_signature(token: &str) -> String {
+    let (signing_input, signature) = token
+        .rsplit_once('.')
+        .expect("signed JWT fixture must have a signature");
+    format!("{signing_input}.{}", "A".repeat(signature.len()))
+}
+
+fn assert_generic_oidc_authentication_failure(error: impl std::fmt::Display) -> String {
+    let error = error.to_string();
+    assert!(
+        error.contains("OIDC authentication failed"),
+        "expected the generic OIDC authentication failure, got: {error}"
+    );
+    let lowercased = error.to_lowercase();
+    for detail in [
+        "issuer",
+        "audience",
+        "provider",
+        "signature",
+        "tenant",
+        "binding",
+        "unavailable",
+    ] {
+        assert!(
+            !lowercased.contains(detail),
+            "unauthenticated token error must not disclose {detail}: {error}"
+        );
+    }
+    error
+}
+
+fn signed_jwt_fixture(issuer: &str, audience: &str, tenant_id: u64) -> (String, String) {
+    signed_jwt_fixture_with_expiry(issuer, audience, tenant_id, 9_999_999_999)
+}
+
+fn signed_jwt_fixture_with_expiry(
+    issuer: &str,
+    audience: &str,
+    tenant_id: u64,
+    exp: u64,
+) -> (String, String) {
+    use rsa::pkcs1v15::SigningKey;
+    use rsa::signature::{SignatureEncoding, Signer};
+    use rsa::traits::PublicKeyParts;
+
+    let mut rng = rsa::rand_core::OsRng;
+    let private_key =
+        rsa::RsaPrivateKey::new(&mut rng, 1024).expect("RSA fixture key generation must succeed");
+    let public_key = rsa::RsaPublicKey::from(&private_key);
+    let encode = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+    let jwks = format!(
+        r#"{{"keys":[{{"kty":"RSA","kid":"catalog-tenant-binding","alg":"RS256","use":"sig","n":"{}","e":"{}"}}]}}"#,
+        encode(&public_key.n().to_bytes_be()),
+        encode(&public_key.e().to_bytes_be()),
+    );
+    let header = encode(br#"{"alg":"RS256","kid":"catalog-tenant-binding"}"#);
+    let payload = encode(
+        format!(
+            r#"{{"iss":"{issuer}","aud":"{audience}","sub":"alice","tenant_id":{tenant_id},"exp":{exp},"user_id":42}}"#
+        )
+        .as_bytes(),
+    );
+    let signing_input = format!("{header}.{payload}");
+    let signing_key = SigningKey::<sha2::Sha256>::new(private_key);
+    let signature: rsa::pkcs1v15::Signature = signing_key.sign(signing_input.as_bytes());
+
+    (
+        jwks,
+        format!("{signing_input}.{}", encode(&signature.to_bytes())),
+    )
+}
+
+#[tokio::test]
+async fn catalog_provider_tenant_binding_overrides_signed_tenant_claim() {
+    let issuer = "https://catalog-idp.example/";
+    let (jwks, token) = signed_jwt_fixture(issuer, "nodedb-api", 999);
+    let jwks_uri = spawn_static_jwks(jwks).await;
+    let mut state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT acme ID 42").await;
+    ddl_ok(
+        &state,
+        &su,
+        &format!(
+            "CREATE OIDC PROVIDER catalog_idp \
+             ISSUER '{issuer}' \
+             JWKS_URI '{jwks_uri}' \
+             AUDIENCE 'nodedb-api' \
+             TENANT 42 \
+             CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1"
+        ),
+    )
+    .await;
+
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+    Arc::get_mut(&mut state)
+        .expect("test state must remain uniquely owned")
+        .jwks_registry = Some(Arc::new(registry));
+
+    let identity = verify_bearer_token(&state, &token)
+        .await
+        .expect("catalog-backed OIDC token must validate");
+    assert_eq!(
+        identity.tenant_id.as_u64(),
+        42,
+        "the catalog provider TENANT binding, not the signed tenant_id claim, determines the identity tenant"
+    );
+}
+
+#[tokio::test]
+async fn catalog_provider_does_not_reuse_static_provider_cache_entry() {
+    let catalog_issuer = "https://catalog-collision-idp.example/";
+    let (static_jwks, token) = signed_jwt_fixture(catalog_issuer, "catalog-api", 999);
+    let (catalog_jwks, _) = signed_jwt_fixture(catalog_issuer, "catalog-api", 999);
+    let static_jwks_uri = spawn_static_jwks(static_jwks).await;
+    let catalog_jwks_uri = spawn_static_jwks(catalog_jwks).await;
+    let mut state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT catalog_tenant ID 42").await;
+    ddl_ok(
+        &state,
+        &su,
+        &format!(
+            "CREATE OIDC PROVIDER colliding_idp \
+             ISSUER '{catalog_issuer}' \
+             JWKS_URI '{catalog_jwks_uri}' \
+             AUDIENCE 'catalog-api' \
+             TENANT 42 \
+             CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1"
+        ),
+    )
+    .await;
+
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        providers: vec![JwtProviderConfig {
+            // This is exactly the catalog cache identity generated before
+            // static identities moved into their own generated domain.
+            name: format!("catalog:colliding_idp:{catalog_jwks_uri}"),
+            jwks_url: static_jwks_uri,
+            issuer: "https://static-collision-idp.example/".into(),
+            audience: "static-api".into(),
+            tenant_id: 1,
+        }],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+    Arc::get_mut(&mut state)
+        .expect("test state must remain uniquely owned")
+        .jwks_registry = Some(Arc::new(registry));
+
+    let err = verify_bearer_token(&state, &token)
+        .await
+        .expect_err("catalog verification must not reuse the static provider key");
+    assert_generic_oidc_authentication_failure(err);
+}
+
+#[tokio::test]
+async fn catalog_authentication_failures_are_client_indistinguishable() {
+    let issuer = "https://generic-auth-failure-idp.example/";
+    let (jwks, valid_token) = signed_jwt_fixture(issuer, "expected-audience", 999);
+    let jwks_uri = spawn_static_jwks(jwks).await;
+    let (_, unknown_issuer_token) = signed_jwt_fixture(
+        "https://unknown-auth-failure-idp.example/",
+        "expected-audience",
+        999,
+    );
+    let (_, wrong_audience_token) = signed_jwt_fixture(issuer, "wrong-audience", 999);
+    let (expired_jwks, expired_token) =
+        signed_jwt_fixture_with_expiry(issuer, "expired-audience", 999, 1);
+    let expired_jwks_uri = spawn_static_jwks(expired_jwks).await;
+    let mut state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT auth_failure ID 42").await;
+    ddl_ok(
+        &state,
+        &su,
+        &format!(
+            "CREATE OIDC PROVIDER auth_failure_idp \
+             ISSUER '{issuer}' \
+             JWKS_URI '{jwks_uri}' \
+             AUDIENCE 'expected-audience' \
+             TENANT 42 \
+             CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1"
+        ),
+    )
+    .await;
+    ddl_ok(
+        &state,
+        &su,
+        &format!(
+            "CREATE OIDC PROVIDER expired_auth_failure_idp \
+             ISSUER '{issuer}' \
+             JWKS_URI '{expired_jwks_uri}' \
+             AUDIENCE 'expired-audience' \
+             TENANT 42 \
+             CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1"
+        ),
+    )
+    .await;
+
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+    Arc::get_mut(&mut state)
+        .expect("test state must remain uniquely owned")
+        .jwks_registry = Some(Arc::new(registry));
+
+    let errors = [
+        verify_bearer_token(&state, &unknown_issuer_token)
+            .await
+            .expect_err("an unknown issuer must be rejected"),
+        verify_bearer_token(&state, &wrong_audience_token)
+            .await
+            .expect_err("a wrong audience must be rejected"),
+        verify_bearer_token(&state, &forged_signature(&valid_token))
+            .await
+            .expect_err("an invalid signature must be rejected"),
+        verify_bearer_token(&state, &expired_token)
+            .await
+            .expect_err("an expired token must be rejected"),
+    ]
+    .map(assert_generic_oidc_authentication_failure);
+    assert_eq!(
+        errors[0], errors[1],
+        "unknown issuer and wrong audience must expose the same client error"
+    );
+    assert_eq!(
+        errors[1], errors[2],
+        "wrong audience and invalid signature must expose the same client error"
+    );
+    assert_eq!(
+        errors[2], errors[3],
+        "invalid signature and expiry must expose the same client error"
+    );
+}
+
+#[tokio::test]
+async fn catalog_provider_cache_identity_frames_name_and_uri() {
+    let issuer = "https://catalog-framing-idp.example/";
+    let (first_jwks, first_token) = signed_jwt_fixture(issuer, "catalog-api", 999);
+    let (second_jwks, second_token) = signed_jwt_fixture(issuer, "catalog-api", 999);
+    let first_jwks_uri = spawn_static_jwks(first_jwks).await;
+    let second_jwks_uri = spawn_static_jwks(second_jwks).await;
+    let first_provider_name = "alpha";
+    let first_provider_uri = format!("{first_jwks_uri}?redirect=:{second_jwks_uri}");
+    let second_provider_name = format!("{first_provider_name}:{first_jwks_uri}?redirect=");
+
+    assert_eq!(
+        format!("catalog:{first_provider_name}:{first_provider_uri}"),
+        format!("catalog:{second_provider_name}:{second_jwks_uri}"),
+        "fixture tuples must collide under the legacy concatenated cache identity"
+    );
+
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+
+    registry
+        .validate_with_catalog_provider(first_provider_name, &first_provider_uri, &first_token)
+        .await
+        .expect("first catalog provider must validate with its own JWKS key");
+    registry
+        .validate_with_catalog_provider(&second_provider_name, &second_jwks_uri, &second_token)
+        .await
+        .expect("second catalog provider must not reuse the first provider cache entry");
+}
+
+#[tokio::test]
+async fn authenticated_token_is_rejected_when_provider_tenant_was_dropped() {
+    let issuer = "https://dropped-tenant-idp.example/";
+    let (jwks, token) = signed_jwt_fixture(issuer, "nodedb-api", 999);
+    let jwks_uri = spawn_static_jwks(jwks).await;
+    let mut state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT removed_tenant ID 42").await;
+    ddl_ok(
+        &state,
+        &su,
+        &format!(
+            "CREATE OIDC PROVIDER removed_tenant_idp \
+             ISSUER '{issuer}' \
+             JWKS_URI '{jwks_uri}' \
+             AUDIENCE 'nodedb-api' \
+             TENANT 42 \
+             CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 1"
+        ),
+    )
+    .await;
+    ddl_ok(&state, &su, "DROP TENANT removed_tenant").await;
+
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+    Arc::get_mut(&mut state)
+        .expect("test state must remain uniquely owned")
+        .jwks_registry = Some(Arc::new(registry));
+
+    let err = verify_bearer_token(&state, &forged_signature(&token))
+        .await
+        .expect_err("an unauthenticated token must fail before tenant-state validation");
+    assert_generic_oidc_authentication_failure(err);
+
+    let err = verify_bearer_token(&state, &token)
+        .await
+        .expect_err("a token bound to a dropped tenant must fail closed");
+    assert!(matches!(
+        err,
+        nodedb::Error::OidcProviderTenantUnavailable { tenant_id: 42 }
+    ));
+}
+
+#[tokio::test]
+async fn catalog_providers_with_shared_issuer_route_by_audience() {
+    let issuer = "https://shared-catalog-idp.example/";
+    let (jwks, token) = signed_jwt_fixture(issuer, "tenant-b-api", 999);
+    let jwks_uri = spawn_static_jwks(jwks).await;
+    let mut state = make_state_with_catalog();
+    let su = superuser();
+
+    ddl_ok(&state, &su, "CREATE TENANT alpha ID 42").await;
+    ddl_ok(&state, &su, "CREATE TENANT beta ID 43").await;
+    for (name, audience, tenant_id) in [
+        ("alpha_idp", "tenant-a-api", 42),
+        ("beta_idp", "tenant-b-api", 43),
+    ] {
+        ddl_ok(
+            &state,
+            &su,
+            &format!(
+                "CREATE OIDC PROVIDER {name} \
+                 ISSUER '{issuer}' \
+                 JWKS_URI '{jwks_uri}' \
+                 AUDIENCE '{audience}' \
+                 TENANT {tenant_id} \
+                 CLAIM MAPPING WHEN sub = '*' SET DEFAULT_DATABASE = 0"
+            ),
+        )
+        .await;
+    }
+
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+    Arc::get_mut(&mut state)
+        .expect("test state must remain uniquely owned")
+        .jwks_registry = Some(Arc::new(registry));
+
+    let identity = verify_bearer_token(&state, &token)
+        .await
+        .expect("issuer and audience must select the tenant-b provider");
+    assert_eq!(identity.tenant_id.as_u64(), 43);
+}
+
+#[tokio::test]
+async fn catalog_provider_without_tenant_binding_is_rejected() {
+    let issuer = "https://legacy-idp.example/";
+    let (jwks, token) = signed_jwt_fixture(issuer, "nodedb-api", 999);
+    let jwks_uri = spawn_static_jwks(jwks).await;
+    let legacy = LegacyOidcProvider {
+        provider_name: "legacy_idp".into(),
+        issuer: issuer.into(),
+        jwks_uri,
+        audience: Some("nodedb-api".into()),
+        claim_mapping: vec![
+            nodedb::control::security::catalog::oidc_providers::StoredClaimMappingRule {
+                claim_name: "sub".into(),
+                claim_value: "*".into(),
+                default_database: Some(0),
+                add_databases: vec![],
+                add_roles: vec![],
+            },
+        ],
+        created_at_lsn: 0,
+    };
+    let encoded = zerompk::to_msgpack_vec(&legacy).expect("legacy provider must serialize");
+    let provider = zerompk::from_msgpack(&encoded).expect("legacy provider must deserialize");
+
+    let mut state = make_state_with_catalog();
+    state
+        .credentials
+        .catalog()
+        .put_oidc_provider(&provider)
+        .expect("legacy provider fixture must persist");
+    let registry = JwksRegistry::init(JwtAuthConfig {
+        allow_http_jwks: true,
+        allow_jwks_hosts: vec!["localhost".into()],
+        allow_jwks_cidrs: vec!["127.0.0.0/8".into(), "::1/128".into()],
+        ..JwtAuthConfig::default()
+    })
+    .await
+    .expect("test JWKS registry must initialize");
+    Arc::get_mut(&mut state)
+        .expect("test state must remain uniquely owned")
+        .jwks_registry = Some(Arc::new(registry));
+
+    let err = verify_bearer_token(&state, &forged_signature(&token))
+        .await
+        .expect_err("an unauthenticated token must fail before tenant-binding validation");
+    assert_generic_oidc_authentication_failure(err);
+
+    let err = verify_bearer_token(&state, &token)
+        .await
+        .expect_err("an unbound persisted provider must fail closed");
+    assert!(matches!(err, nodedb::Error::OidcProviderTenantUnbound));
 }
 
 // ── Claim-mapping public surface smoke check ────────────────────────────────


### PR DESCRIPTION
## Summary

Bind every catalog-backed OIDC provider and static JWT provider to an explicit, trusted NodeDB tenant. Authentication now derives the session tenant from provider configuration rather than the token's `tenant_id` claim.

## Security behavior

- Routes providers by issuer and audience instead of issuer alone.
- Allows a shared issuer across tenants only through distinct, non-empty audiences.
- Rejects duplicate or ambiguous provider routes and duplicate static provider names.
- Rejects legacy catalog providers without a tenant binding and static configurations that omit one.
- Revalidates catalog tenant existence before issuing an authenticated identity.
- Keeps HTTP authorization context aligned with the verified provider-bound identity.
- Returns indistinguishable client-visible errors for pre-authentication token failures.
- Isolates static and catalog JWKS cache domains with collision-free, endpoint-bound identities.

## DDL and configuration

`CREATE OIDC PROVIDER` now requires `TENANT <id>`, persists the binding, validates the referenced tenant, and exposes it through `SHOW OIDC PROVIDERS`.

Static providers now require `tenant_id` in `auth.jwt.providers`. Missing bindings fail startup validation rather than falling back to token claims.

## Compatibility

Persisted catalog records remain deserializable through an optional compatibility field, but unbound records fail authentication until recreated with an explicit tenant. This intentionally fails closed.

## Validation

- Expanded parser, catalog OIDC, static JWKS, and verified AuthContext regression coverage.
- Focused Nextest suites pass.
- All-target, all-feature Clippy passes with warnings denied.
- Formatting, diff hygiene, production file-size limits, and independent security review are clean.
