### PR TITLE
fix(security): preserve UTF-8 SQL parser offsets

### DIFF
--- a/nodedb-sql/src/ddl_ast/collection_type.rs
+++ b/nodedb-sql/src/ddl_ast/collection_type.rs
@@ -13,6 +13,7 @@ use nodedb_types::columnar::{ColumnDef, ColumnType, StrictSchema};
 use nodedb_types::kv_parsing;
 
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 /// Build a `CollectionType` from the pre-parsed DDL fields.
 ///
@@ -142,7 +143,7 @@ pub(crate) fn build_strict_schema(
             None
         };
         if let Some(kw) = gen_kw {
-            let gen_pos = upper_type.find(kw).expect(
+            let gen_pos = find_ascii_case_insensitive(type_str, kw).expect(
                 "invariant: kw was found via upper_type.contains(kw) in the enclosing if-let",
             );
             let after_gen = type_str[gen_pos + kw.len()..].trim();
@@ -303,7 +304,7 @@ pub fn parse_column_type_str_full(type_str: &str) -> (String, bool, bool, Option
 
     // Extract the DEFAULT clause from the type_str.
     // type_str may look like: "TEXT DEFAULT upper('x')" or "INT NOT NULL DEFAULT 1 + 2".
-    let default_expr = if let Some(def_pos) = upper.find("DEFAULT") {
+    let default_expr = if let Some(def_pos) = find_ascii_case_insensitive(type_str, "DEFAULT") {
         let after = type_str[def_pos + "DEFAULT".len()..].trim();
         if after.is_empty() {
             None
@@ -431,6 +432,16 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn default_after_unicode_type_text_preserves_original_offsets() {
+        let (bare_type, is_pk, is_not_null, default_expr) =
+            parse_column_type_str_full("CUSTOMﬀﬀ DEFAULT 42");
+        assert_eq!(bare_type, "CUSTOMﬀﬀ");
+        assert!(!is_pk);
+        assert!(!is_not_null);
+        assert_eq!(default_expr.as_deref(), Some("42"));
     }
 
     // ── engine name → CollectionType variant ─────────────────────────────

--- a/nodedb-sql/src/ddl_ast/parse/alert.rs
+++ b/nodedb-sql/src/ddl_ast/parse/alert.rs
@@ -5,6 +5,9 @@
 use super::helpers::extract_name_after_if_exists;
 use crate::ddl_ast::statement::{AutomationStmt, NodedbStatement};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
 
 pub(super) fn try_parse(
     upper: &str,
@@ -61,8 +64,6 @@ pub(super) fn try_parse(
 fn parse_create_alert(upper: &str, trimmed: &str) -> NodedbStatement {
     let prefix = "CREATE ALERT ";
     let after_prefix = &trimmed[prefix.len()..];
-    let upper_after = &upper[prefix.len()..];
-
     // name = first whitespace token
     let name = after_prefix
         .split_whitespace()
@@ -71,8 +72,7 @@ fn parse_create_alert(upper: &str, trimmed: &str) -> NodedbStatement {
         .to_lowercase();
 
     // collection = token after " ON "
-    let collection = upper_after
-        .find(" ON ")
+    let collection = find_ascii_case_insensitive(after_prefix, " ON ")
         .map(|pos| {
             after_prefix[pos + 4..]
                 .split_whitespace()
@@ -83,11 +83,10 @@ fn parse_create_alert(upper: &str, trimmed: &str) -> NodedbStatement {
         .unwrap_or_default();
 
     // WHERE filter = text between "WHERE " and "CONDITION "
-    let where_filter = extract_between(upper, trimmed, "WHERE ", "CONDITION ");
+    let where_filter = extract_between(trimmed, "WHERE ", "CONDITION ");
 
     // condition_raw = text after "CONDITION " up to next major clause boundary
     let condition_raw = extract_clause_text(
-        upper,
         trimmed,
         "CONDITION ",
         &[
@@ -102,10 +101,10 @@ fn parse_create_alert(upper: &str, trimmed: &str) -> NodedbStatement {
     .unwrap_or_default();
 
     // GROUP BY columns
-    let group_by = extract_group_by(upper, trimmed);
+    let group_by = extract_group_by(trimmed);
 
     // WINDOW duration string (contents of first single-quoted token after WINDOW)
-    let window_raw = extract_quoted_after(upper, trimmed, "WINDOW ").unwrap_or_default();
+    let window_raw = extract_quoted_after(trimmed, "WINDOW ").unwrap_or_default();
 
     // FOR 'N consecutive windows'
     let fire_after = extract_consecutive_count(upper, "FOR ").unwrap_or(1).max(1);
@@ -117,11 +116,10 @@ fn parse_create_alert(upper: &str, trimmed: &str) -> NodedbStatement {
 
     // SEVERITY '<level>'
     let severity =
-        extract_quoted_after(upper, trimmed, "SEVERITY ").unwrap_or_else(|| "warning".to_string());
+        extract_quoted_after(trimmed, "SEVERITY ").unwrap_or_else(|| "warning".to_string());
 
     // Raw NOTIFY section (everything after NOTIFY keyword)
-    let notify_targets_raw = upper
-        .find("NOTIFY")
+    let notify_targets_raw = find_ascii_case_insensitive(trimmed, "NOTIFY")
         .map(|pos| {
             trimmed[pos + 6..]
                 .trim()
@@ -146,11 +144,11 @@ fn parse_create_alert(upper: &str, trimmed: &str) -> NodedbStatement {
 }
 
 /// Extract text between two keyword boundaries (case-insensitive search, original-case result).
-fn extract_between(upper: &str, sql: &str, start_kw: &str, end_kw: &str) -> Option<String> {
-    let start = upper.find(start_kw)?;
+fn extract_between(sql: &str, start_kw: &str, end_kw: &str) -> Option<String> {
+    let start = find_ascii_case_insensitive(sql, start_kw)?;
     let after_start = start + start_kw.len();
-    let end = upper[after_start..].find(end_kw)?;
-    let text = sql[after_start..after_start + end].trim();
+    let end = find_ascii_case_insensitive_from(sql, end_kw, after_start)?;
+    let text = sql[after_start..end].trim();
     if text.is_empty() {
         None
     } else {
@@ -159,15 +157,15 @@ fn extract_between(upper: &str, sql: &str, start_kw: &str, end_kw: &str) -> Opti
 }
 
 /// Extract text after `start_kw` up to the nearest of the `end_kws` boundaries.
-fn extract_clause_text(upper: &str, sql: &str, start_kw: &str, end_kws: &[&str]) -> Option<String> {
-    let start = upper.find(start_kw)?;
+fn extract_clause_text(sql: &str, start_kw: &str, end_kws: &[&str]) -> Option<String> {
+    let start = find_ascii_case_insensitive(sql, start_kw)?;
     let after = start + start_kw.len();
     let end = end_kws
         .iter()
-        .filter_map(|kw| upper[after..].find(kw))
+        .filter_map(|kw| find_ascii_case_insensitive_from(sql, kw, after))
         .min()
-        .unwrap_or(upper.len() - after);
-    let text = sql[after..after + end].trim();
+        .unwrap_or(sql.len());
+    let text = sql[after..end].trim();
     if text.is_empty() {
         None
     } else {
@@ -176,21 +174,21 @@ fn extract_clause_text(upper: &str, sql: &str, start_kw: &str, end_kws: &[&str])
 }
 
 /// Extract GROUP BY column list (lowercased).
-fn extract_group_by(upper: &str, sql: &str) -> Vec<String> {
+fn extract_group_by(sql: &str) -> Vec<String> {
     let kw = "GROUP BY ";
-    let pos = match upper.find(kw) {
+    let pos = match find_ascii_case_insensitive(sql, kw) {
         Some(p) => p,
         None => return Vec::new(),
     };
-    let after = &sql[pos + kw.len()..];
     // End at next major keyword
     let end_kws = ["WINDOW ", "FOR ", "RECOVER ", "SEVERITY ", "NOTIFY"];
+    let after_start = pos + kw.len();
     let end = end_kws
         .iter()
-        .filter_map(|kw| upper[pos + 9..].find(kw))
+        .filter_map(|kw| find_ascii_case_insensitive_from(sql, kw, after_start))
         .min()
-        .unwrap_or(after.len());
-    after[..end]
+        .unwrap_or(sql.len());
+    sql[after_start..end]
         .split(',')
         .map(|s| s.trim().to_lowercase())
         .filter(|s| !s.is_empty())
@@ -198,8 +196,8 @@ fn extract_group_by(upper: &str, sql: &str) -> Vec<String> {
 }
 
 /// Extract a single-quoted value after a keyword.
-fn extract_quoted_after(upper: &str, sql: &str, keyword: &str) -> Option<String> {
-    let pos = upper.find(keyword)?;
+fn extract_quoted_after(sql: &str, keyword: &str) -> Option<String> {
+    let pos = find_ascii_case_insensitive(sql, keyword)?;
     let after = &sql[pos + keyword.len()..];
     let start = after.find('\'')?;
     let end = after[start + 1..].find('\'')?;
@@ -222,6 +220,29 @@ fn extract_consecutive_count(upper: &str, keyword: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_alert_unicode_name_preserves_original_offsets() {
+        let sql = "CREATE ALERT highﬀﬀ ON sensors CONDITION AVG(temp) > 90 WINDOW '5 minutes' SEVERITY 'critical'";
+        let upper = sql.to_uppercase();
+        if let NodedbStatement::Automation(AutomationStmt::CreateAlert {
+            name,
+            collection,
+            condition_raw,
+            window_raw,
+            severity,
+            ..
+        }) = parse_create_alert(&upper, sql)
+        {
+            assert_eq!(name, "highﬀﬀ");
+            assert_eq!(collection, "sensors");
+            assert_eq!(condition_raw, "AVG(temp) > 90");
+            assert_eq!(window_raw, "5 minutes");
+            assert_eq!(severity, "critical");
+        } else {
+            panic!("expected CreateAlert");
+        }
+    }
 
     #[test]
     fn parse_create_alert_full() {

--- a/nodedb-sql/src/ddl_ast/parse/change_stream.rs
+++ b/nodedb-sql/src/ddl_ast/parse/change_stream.rs
@@ -5,6 +5,7 @@
 use super::helpers::extract_name_after_if_exists;
 use crate::ddl_ast::statement::{NodedbStatement, StreamViewStmt};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 pub(super) fn try_parse(
     upper: &str,
@@ -88,7 +89,7 @@ pub(super) fn try_parse(
 ///
 /// Extracts name, collection, and the raw WITH clause inner text.
 /// The handler converts the raw WITH pairs to OpFilter, StreamFormat, etc.
-fn parse_create_change_stream(upper: &str, trimmed: &str) -> NodedbStatement {
+fn parse_create_change_stream(_upper: &str, trimmed: &str) -> NodedbStatement {
     let prefix = "CREATE CHANGE STREAM ";
     let rest = &trimmed[prefix.len()..];
     let tokens: Vec<&str> = rest.split_whitespace().collect();
@@ -110,8 +111,7 @@ fn parse_create_change_stream(upper: &str, trimmed: &str) -> NodedbStatement {
         .unwrap_or_default();
 
     // Extract WITH clause inner text (everything inside outer parens after WITH).
-    let with_clause_raw = upper
-        .find("WITH")
+    let with_clause_raw = find_ascii_case_insensitive(trimmed, "WITH")
         .and_then(|pos| {
             let after = &trimmed[pos + 4..].trim_start();
             after

--- a/nodedb-sql/src/ddl_ast/parse/collection/alter_ops.rs
+++ b/nodedb-sql/src/ddl_ast/parse/collection/alter_ops.rs
@@ -3,6 +3,7 @@
 //! Parse ALTER COLLECTION sub-operations.
 
 use crate::ddl_ast::statement::AlterCollectionOp;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 pub(super) fn parse_alter_operation(
     upper: &str,
@@ -23,7 +24,7 @@ pub(super) fn parse_alter_operation(
 
     // MATERIALIZED_SUM takes priority over ADD COLUMN.
     if upper.contains("MATERIALIZED_SUM") {
-        return parse_materialized_sum(upper, parts, trimmed, collection_name);
+        return parse_materialized_sum(parts, trimmed, collection_name);
     }
 
     if upper.contains("ADD COLUMN") || (upper.contains(" ADD ") && !upper.contains("MATERIALIZED"))
@@ -73,7 +74,6 @@ pub(super) fn parse_alter_operation(
 /// Returns `None` if any required keyword is absent — the router will surface a
 /// parse error to the client.
 fn parse_materialized_sum(
-    upper: &str,
     parts: &[&str],
     trimmed: &str,
     collection_name: &str,
@@ -92,12 +92,12 @@ fn parse_materialized_sum(
     let source_collection = parts.get(source_idx + 1)?.to_lowercase();
 
     // Join column: extract from ON clause `source.col = target.id`.
-    let on_pos = upper.find(" ON ")?;
+    let on_pos = find_ascii_case_insensitive(trimmed, " ON ")?;
     let after_on = &trimmed[on_pos + 4..];
     let join_column = extract_join_column(after_on, &source_collection)?;
 
     // Value expression: token(s) after VALUE keyword.
-    let value_pos = upper.find(" VALUE ")?;
+    let value_pos = find_ascii_case_insensitive(trimmed, " VALUE ")?;
     let value_expr_raw = trimmed[value_pos + 7..].trim().trim_end_matches(';');
     let value_expr = extract_value_expr(value_expr_raw, &source_collection)?;
 
@@ -250,4 +250,30 @@ fn extract_tag_value(upper: &str) -> Option<String> {
         return None;
     }
     Some(value[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialized_sum_keywords_after_unicode_name_preserve_original_offsets() {
+        let sql = "ALTER COLLECTION totalsﬀﬀ ADD COLUMN total INT MATERIALIZED_SUM SOURCE orders ON orders.customer_id = totalsﬀﬀ.id VALUE orders.amount";
+        let parts: Vec<&str> = sql.split_whitespace().collect();
+        let op =
+            parse_materialized_sum(&parts, sql, "totalsﬀﬀ").expect("materialized sum should parse");
+        assert!(matches!(
+            op,
+            AlterCollectionOp::AddMaterializedSum {
+                target_collection,
+                source_collection,
+                join_column,
+                value_expr,
+                ..
+            } if target_collection == "totalsﬀﬀ"
+                && source_collection == "orders"
+                && join_column == "customer_id"
+                && value_expr == "amount"
+        ));
+    }
 }

--- a/nodedb-sql/src/ddl_ast/parse/collection/body.rs
+++ b/nodedb-sql/src/ddl_ast/parse/collection/body.rs
@@ -6,6 +6,9 @@ use super::column_list::{extract_column_pairs, find_column_list_paren_end};
 use super::engine_suffix::extract_engine_suffix;
 use super::with_clause::{extract_balanced_raw, extract_with_options};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::{
+    find_ascii_case_insensitive, keyword_position_outside_literals,
+};
 
 /// Parsed body of a `CREATE COLLECTION` / `CREATE TABLE` statement.
 ///
@@ -28,14 +31,51 @@ pub(super) type CollectionBody = (
 );
 
 pub(super) fn parse_collection_body(trimmed: &str, name: &str) -> Result<CollectionBody, SqlError> {
-    // Skip past the name to find the body.
-    let lower = trimmed.to_lowercase();
-    let name_lower = name.to_lowercase();
-    let body = if let Some(pos) = lower.find(&name_lower) {
-        trimmed[pos + name.len()..].trim()
-    } else {
+    // Locate the source identifier structurally. `name` is normalized by the
+    // dispatcher, so searching for it in the original SQL is not reliable for
+    // Unicode identifiers whose lowercase representation differs in bytes.
+    let keyword = ["COLLECTION", "TABLE"]
+        .into_iter()
+        .filter_map(|candidate| {
+            keyword_position_outside_literals(trimmed, candidate)
+                .map(|position| (position, candidate))
+        })
+        .min_by_key(|(position, _)| *position);
+    let Some((keyword_position, keyword)) = keyword else {
         return Ok((None, Vec::new(), Vec::new(), Vec::new(), None));
     };
+    let after_keyword = &trimmed[keyword_position + keyword.len()..];
+    let mut name_source = after_keyword.trim_start();
+    if find_ascii_case_insensitive(name_source, "IF NOT EXISTS") == Some(0) {
+        name_source = name_source["IF NOT EXISTS".len()..].trim_start();
+    }
+    let name_end = if let Some(quote) = name_source
+        .chars()
+        .next()
+        .filter(|c| matches!(c, '"' | '`'))
+    {
+        name_source[quote.len_utf8()..]
+            .find(quote)
+            .map(|position| quote.len_utf8() + position + quote.len_utf8())
+    } else {
+        Some(
+            name_source
+                .char_indices()
+                .find(|(_, character)| character.is_whitespace() || *character == '(')
+                .map_or(name_source.len(), |(position, _)| position),
+        )
+    };
+    let Some(name_end) = name_end else {
+        return Ok((None, Vec::new(), Vec::new(), Vec::new(), None));
+    };
+    if name_source[..name_end]
+        .trim_matches(['"', '`'])
+        .to_lowercase()
+        != name
+    {
+        return Ok((None, Vec::new(), Vec::new(), Vec::new(), None));
+    }
+    let body = name_source[name_end..].trim();
 
     let upper_body = body.to_uppercase();
 
@@ -79,7 +119,7 @@ pub(super) fn parse_collection_body(trimmed: &str, name: &str) -> Result<Collect
         flags.push("BITEMPORAL".to_string());
     }
 
-    let balanced_raw = extract_balanced_raw(&upper_body, body);
+    let balanced_raw = extract_balanced_raw(body);
 
     Ok((engine, columns, options, flags, balanced_raw))
 }
@@ -87,6 +127,26 @@ pub(super) fn parse_collection_body(trimmed: &str, name: &str) -> Result<Collect
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn collection_body_after_unicode_comment_preserves_original_offsets() {
+        let (engine, columns, ..) = parse_collection_body(
+            "CREATE /*İ*/ COLLECTION items (id INT) WITH (engine='kv')",
+            "items",
+        )
+        .expect("collection body should parse");
+        assert_eq!(engine, Some("kv".to_string()));
+        assert_eq!(columns, vec![("id".to_string(), "INT".to_string())]);
+    }
+
+    #[test]
+    fn normalized_unicode_collection_name_preserves_body_boundary() {
+        let (engine, columns, ..) =
+            parse_collection_body("CREATE COLLECTION Åx (id INT) WITH (engine='kv')", "åx")
+                .expect("collection body should parse");
+        assert_eq!(engine, Some("kv".to_string()));
+        assert_eq!(columns, vec![("id".to_string(), "INT".to_string())]);
+    }
 
     #[test]
     fn engine_suffix_matches_with_clause_result() {

--- a/nodedb-sql/src/ddl_ast/parse/collection/column_list.rs
+++ b/nodedb-sql/src/ddl_ast/parse/collection/column_list.rs
@@ -3,6 +3,7 @@
 //! Parse the parenthesised column list in CREATE COLLECTION / CREATE TABLE.
 
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 /// Find the byte offset of the closing paren that matches the first `(` in
 /// `body` (depth-aware, so nested parens like `VECTOR(128)` are handled).
@@ -306,13 +307,24 @@ fn parse_col_token(token: &str) -> Result<Option<(String, String)>, SqlError> {
 
     // When GENERATED ALWAYS AS was found, append the remainder of the original
     // token text verbatim so that downstream builders can parse the expression.
-    if hit_generated {
-        let upper_token = token.to_uppercase();
-        if let Some(gen_pos) = upper_token.find("GENERATED") {
-            type_str.push(' ');
-            type_str.push_str(token[gen_pos..].trim());
-        }
+    if hit_generated && let Some(gen_pos) = find_ascii_case_insensitive(token, "GENERATED") {
+        type_str.push(' ');
+        type_str.push_str(token[gen_pos..].trim());
     }
 
     Ok(Some((name, type_str)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_clause_after_unicode_type_preserves_original_offsets() {
+        let parsed = parse_col_token("slug CUSTOMﬀﬀ GENERATED ALWAYS AS (lower(name))")
+            .expect("column should parse")
+            .expect("column definition should be present");
+        assert_eq!(parsed.0, "slug");
+        assert_eq!(parsed.1, "CUSTOMﬀﬀ GENERATED ALWAYS AS (lower(name))");
+    }
 }

--- a/nodedb-sql/src/ddl_ast/parse/collection/with_clause.rs
+++ b/nodedb-sql/src/ddl_ast/parse/collection/with_clause.rs
@@ -2,13 +2,16 @@
 
 //! Parse the `WITH (...)` clause and `BALANCED ON (...)` clause in CREATE COLLECTION.
 
+use crate::parser::preprocess::lex::{
+    find_ascii_case_insensitive, keyword_position_outside_literals,
+};
+
 /// Extract engine name and other key-value options from the `WITH (...)` clause.
 ///
 /// Returns `(engine, other_options)` where `engine` is the value of the
 /// `engine=` key (lowercased) and `other_options` is all other k=v pairs.
 pub(super) fn extract_with_options(body: &str) -> (Option<String>, Vec<(String, String)>) {
-    let upper = body.to_uppercase();
-    let with_pos = match upper.find(" WITH ").or_else(|| upper.find("WITH (")) {
+    let with_pos = match keyword_position_outside_literals(body, "WITH") {
         Some(p) => p,
         None => return (None, Vec::new()),
     };
@@ -119,8 +122,8 @@ fn parse_kv_token(token: &str) -> Option<(String, String)> {
 ///
 /// Returns `None` when the clause is absent. The handler calls
 /// `parse_balanced_clause_from_raw` with this string.
-pub(super) fn extract_balanced_raw(upper_body: &str, body: &str) -> Option<String> {
-    let bal_pos = upper_body.find("BALANCED ON")?;
+pub(super) fn extract_balanced_raw(body: &str) -> Option<String> {
+    let bal_pos = find_ascii_case_insensitive(body, "BALANCED ON")?;
     let after = body[bal_pos + "BALANCED ON".len()..].trim_start();
     if !after.starts_with('(') {
         return None;
@@ -142,4 +145,25 @@ pub(super) fn extract_balanced_raw(upper_body: &str, body: &str) -> Option<Strin
     }
     let end = end?;
     Some(after[1..end].trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_clause_after_unicode_text_preserves_original_offsets() {
+        let (engine, options) = extract_with_options("(name ﬀﬀ) WITH (engine = 'kv', ttl = 60)");
+        assert_eq!(engine.as_deref(), Some("kv"));
+        assert_eq!(options, vec![("ttl".to_string(), "60".to_string())]);
+    }
+
+    #[test]
+    fn balanced_clause_after_unicode_text_preserves_original_offsets() {
+        let body = "(name ﬀﬀ) BALANCED ON (group_key = tenant_id)";
+        assert_eq!(
+            extract_balanced_raw(body),
+            Some("group_key = tenant_id".to_string())
+        );
+    }
 }

--- a/nodedb-sql/src/ddl_ast/parse/copy_from.rs
+++ b/nodedb-sql/src/ddl_ast/parse/copy_from.rs
@@ -9,6 +9,7 @@
 
 use crate::ddl_ast::statement::{CopyFormat, MiscStmt, NodedbStatement};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 /// Try to parse a COPY statement.
 ///
@@ -34,7 +35,11 @@ pub(super) fn try_parse(
     // Fall through for COPY ... TO — handled by copy_to parser.
     let has_from = upper.contains(" FROM ");
     let has_to = upper.contains(" TO ");
-    if has_to && (!has_from || upper.find(" TO ") < upper.find(" FROM ")) {
+    if has_to
+        && (!has_from
+            || find_ascii_case_insensitive(trimmed, " TO ")
+                < find_ascii_case_insensitive(trimmed, " FROM "))
+    {
         return None;
     }
 
@@ -47,16 +52,17 @@ pub(super) fn try_parse(
         return None;
     }
 
-    Some(parse_copy_from(trimmed, upper))
+    Some(parse_copy_from(trimmed))
 }
 
-fn parse_copy_from(trimmed: &str, upper: &str) -> Result<NodedbStatement, SqlError> {
+fn parse_copy_from(trimmed: &str) -> Result<NodedbStatement, SqlError> {
     // Grammar: COPY <name> FROM '<path>' [WITH (...)]
 
     // Extract collection name (first word before FROM).
-    let from_pos = upper.find(" FROM ").ok_or_else(|| SqlError::Parse {
-        detail: "COPY: missing FROM keyword".to_string(),
-    })?;
+    let from_pos =
+        find_ascii_case_insensitive(trimmed, " FROM ").ok_or_else(|| SqlError::Parse {
+            detail: "COPY: missing FROM keyword".to_string(),
+        })?;
 
     // The collection name is between "COPY " and " FROM ".
     let coll_raw = trimmed["COPY ".len()..from_pos].trim();
@@ -309,6 +315,20 @@ mod tests {
         parse(sql)
             .expect("expected Some")
             .expect_err("expected Err")
+    }
+
+    #[test]
+    fn unicode_collection_before_from_preserves_original_offsets() {
+        let stmt = ok("COPY usersﬀﬀ FROM '/tmp/users.ndjson'");
+        match stmt {
+            NodedbStatement::Misc(MiscStmt::CopyFromFile {
+                collection, path, ..
+            }) => {
+                assert_eq!(collection, "usersﬀﬀ");
+                assert_eq!(path, "/tmp/users.ndjson");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]

--- a/nodedb-sql/src/ddl_ast/parse/copy_to.rs
+++ b/nodedb-sql/src/ddl_ast/parse/copy_to.rs
@@ -5,6 +5,7 @@
 
 use crate::ddl_ast::statement::{CopyFormat, CopyToSource, MiscStmt, NodedbStatement};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 use super::copy_from::{
     detect_format_from_path, extract_quoted_string, parse_with_clause, strip_quotes,
@@ -62,8 +63,7 @@ fn parse_copy_to(trimmed: &str, after_copy: &str) -> Result<NodedbStatement, Sql
 
 /// `COPY <collection> TO '<path>' [WITH (...)]`
 fn parse_table_form(trimmed: &str) -> Result<NodedbStatement, SqlError> {
-    let upper = trimmed.to_uppercase();
-    let to_pos = upper.find(" TO ").ok_or_else(|| SqlError::Parse {
+    let to_pos = find_ascii_case_insensitive(trimmed, " TO ").ok_or_else(|| SqlError::Parse {
         detail: "COPY: missing TO keyword".to_string(),
     })?;
 
@@ -185,6 +185,18 @@ mod tests {
         parse(sql)
             .expect("expected Some")
             .expect_err("expected Err")
+    }
+
+    #[test]
+    fn unicode_collection_before_to_preserves_original_offsets() {
+        let stmt = ok("COPY usersﬀﬀ TO '/tmp/out.ndjson'");
+        match stmt {
+            NodedbStatement::Misc(MiscStmt::CopyToFile { source, path, .. }) => {
+                assert_eq!(source, CopyToSource::Collection("usersﬀﬀ".to_string()));
+                assert_eq!(path, "/tmp/out.ndjson");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]

--- a/nodedb-sql/src/ddl_ast/parse/custom_type.rs
+++ b/nodedb-sql/src/ddl_ast/parse/custom_type.rs
@@ -11,6 +11,7 @@
 
 use crate::ddl_ast::statement::{NodedbStatement, PolicyStmt};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 /// Try to parse custom type DDL statements.
 pub(super) fn try_parse(
@@ -128,10 +129,8 @@ fn parse_alter(parts: &[&str], trimmed: &str) -> Result<NodedbStatement, SqlErro
     }
 
     // Extract the label: everything after ADD VALUE, trimmed, possibly quoted.
-    let orig_upper = trimmed.to_uppercase();
-    let add_value_pos = orig_upper
-        .find(" ADD VALUE ")
-        .ok_or_else(|| SqlError::Parse {
+    let add_value_pos =
+        find_ascii_case_insensitive(trimmed, " ADD VALUE ").ok_or_else(|| SqlError::Parse {
             detail: "ALTER TYPE: could not locate ADD VALUE in statement".to_string(),
         })?;
     let after_add_value = trimmed[add_value_pos + " ADD VALUE ".len()..].trim();
@@ -150,20 +149,19 @@ fn parse_alter(parts: &[&str], trimmed: &str) -> Result<NodedbStatement, SqlErro
 
 /// Extract `('label1', 'label2', ...)` after the ENUM keyword.
 fn parse_label_list(original: &str) -> Result<Vec<String>, SqlError> {
-    let orig_upper = original.to_uppercase();
     // Find the opening paren after ENUM.
-    let enum_pos = orig_upper.find(" AS ENUM").ok_or_else(|| SqlError::Parse {
-        detail: "CREATE TYPE … AS ENUM: cannot locate AS ENUM".to_string(),
-    })?;
+    let enum_pos =
+        find_ascii_case_insensitive(original, " AS ENUM").ok_or_else(|| SqlError::Parse {
+            detail: "CREATE TYPE … AS ENUM: cannot locate AS ENUM".to_string(),
+        })?;
     let s = original[enum_pos + " AS ENUM".len()..].trim_start();
     extract_quoted_list(s, "CREATE TYPE … AS ENUM")
 }
 
 /// Extract `(<field> <type>, ...)` after the AS keyword for composite types.
 fn parse_composite_fields(original: &str) -> Result<Vec<(String, String)>, SqlError> {
-    let orig_upper = original.to_uppercase();
     // Find " AS (" — skip over "AS ENUM" by checking the next non-ws char.
-    let as_pos = orig_upper.find(" AS ").ok_or_else(|| SqlError::Parse {
+    let as_pos = find_ascii_case_insensitive(original, " AS ").ok_or_else(|| SqlError::Parse {
         detail: "CREATE TYPE: missing AS keyword".to_string(),
     })?;
     let after_as = original[as_pos + 4..].trim_start();
@@ -277,6 +275,18 @@ mod tests {
     }
 
     #[test]
+    fn create_enum_with_unicode_name_preserves_original_offsets() {
+        let stmt = ok("CREATE TYPE statusﬀﬀ AS ENUM ('active', 'inactive')");
+        match stmt {
+            NodedbStatement::Policy(PolicyStmt::CreateEnumType { name, labels }) => {
+                assert_eq!(name, "statusﬀﬀ");
+                assert_eq!(labels, vec!["active", "inactive"]);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
     fn create_enum_basic() {
         let stmt = ok("CREATE TYPE status AS ENUM ('active', 'inactive', 'pending')");
         match stmt {
@@ -310,6 +320,18 @@ mod tests {
         let e = err("CREATE TYPE mood AS ENUM ('happy', 'happy', 'sad')");
         assert!(matches!(e, SqlError::Parse { .. }));
         assert!(e.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn create_composite_with_unicode_name_preserves_original_offsets() {
+        let stmt = ok("CREATE TYPE addressﬀﬀ AS (street TEXT, city TEXT)");
+        match stmt {
+            NodedbStatement::Policy(PolicyStmt::CreateCompositeType { name, fields }) => {
+                assert_eq!(name, "addressﬀﬀ");
+                assert_eq!(fields.len(), 2);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
     }
 
     #[test]
@@ -347,6 +369,18 @@ mod tests {
             NodedbStatement::Policy(PolicyStmt::DropType {
                 name: "status".to_string(),
                 if_exists: true,
+            })
+        );
+    }
+
+    #[test]
+    fn alter_unicode_type_add_value_preserves_original_offsets() {
+        let stmt = ok("ALTER TYPE statusﬀﬀ ADD VALUE 'archived'");
+        assert_eq!(
+            stmt,
+            NodedbStatement::Policy(PolicyStmt::AlterTypeAddValue {
+                type_name: "statusﬀﬀ".to_string(),
+                label: "archived".to_string(),
             })
         );
     }

--- a/nodedb-sql/src/ddl_ast/parse/database/with_options.rs
+++ b/nodedb-sql/src/ddl_ast/parse/database/with_options.rs
@@ -2,11 +2,12 @@
 
 //! Shared `WITH (key=value, ...)` extraction for database DDL.
 
+use crate::parser::preprocess::lex::find_ascii_keyword;
+
 /// Extract `WITH (key=value, ...)` pairs from a raw SQL string.
 /// Returns an empty vec if no WITH clause is present.
 pub(super) fn parse_with_options(sql: &str) -> Vec<(String, String)> {
-    let upper = sql.to_uppercase();
-    let with_start = match upper.find("WITH") {
+    let with_start = match find_ascii_keyword(sql, "WITH") {
         Some(i) => i,
         None => return Vec::new(),
     };
@@ -33,4 +34,17 @@ pub(super) fn parse_with_options(sql: &str) -> Vec<(String, String)> {
             if k.is_empty() { None } else { Some((k, v)) }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_clause_after_unicode_database_name_preserves_original_offsets() {
+        assert_eq!(
+            parse_with_options("CREATE DATABASE tenantﬀﬀ WITH (region='eu')"),
+            vec![("region".to_string(), "eu".to_string())]
+        );
+    }
 }

--- a/nodedb-sql/src/ddl_ast/parse/materialized_view.rs
+++ b/nodedb-sql/src/ddl_ast/parse/materialized_view.rs
@@ -5,6 +5,9 @@
 use super::helpers::extract_name_after_if_exists;
 use crate::ddl_ast::statement::{NodedbStatement, StreamViewStmt};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from, rfind_ascii_case_insensitive,
+};
 
 pub(super) fn try_parse(
     upper: &str,
@@ -62,7 +65,7 @@ fn parse_create_mv(upper: &str, trimmed: &str) -> NodedbStatement {
     const KW_ON: &str = " ON ";
     const KW_AS: &str = " AS ";
 
-    let mv_pos = upper.find(KW_MV).unwrap_or(0);
+    let mv_pos = find_ascii_case_insensitive(trimmed, KW_MV).unwrap_or(0);
     let after_mv_start = mv_pos + KW_MV.len();
     let after_mv = trimmed[after_mv_start..].trim_start();
 
@@ -72,10 +75,9 @@ fn parse_create_mv(upper: &str, trimmed: &str) -> NodedbStatement {
         .unwrap_or("")
         .to_lowercase();
 
-    let source = upper[after_mv_start..]
-        .find(KW_ON)
+    let source = find_ascii_case_insensitive_from(trimmed, KW_ON, after_mv_start)
         .map(|on_pos| {
-            let after_on_start = after_mv_start + on_pos + KW_ON.len();
+            let after_on_start = on_pos + KW_ON.len();
             trimmed[after_on_start..]
                 .split_whitespace()
                 .next()
@@ -84,16 +86,15 @@ fn parse_create_mv(upper: &str, trimmed: &str) -> NodedbStatement {
         })
         .unwrap_or_default();
 
-    let after_on_start = upper[after_mv_start..]
-        .find(KW_ON)
-        .map(|p| after_mv_start + p + KW_ON.len())
+    let after_on_start = find_ascii_case_insensitive_from(trimmed, KW_ON, after_mv_start)
+        .map(|position| position + KW_ON.len())
         .unwrap_or(after_mv_start);
 
-    let query_sql = upper[after_on_start..]
-        .find(KW_AS)
+    let query_sql = find_ascii_case_insensitive_from(trimmed, KW_AS, after_on_start)
         .map(|as_pos| {
-            let query_start = after_on_start + as_pos + KW_AS.len();
-            let query_end = find_trailing_with_options(upper, query_start).unwrap_or(trimmed.len());
+            let query_start = as_pos + KW_AS.len();
+            let query_end =
+                find_trailing_with_options(trimmed, query_start).unwrap_or(trimmed.len());
             trimmed[query_start..query_end].trim().to_string()
         })
         .unwrap_or_default();
@@ -109,11 +110,11 @@ fn parse_create_mv(upper: &str, trimmed: &str) -> NodedbStatement {
 }
 
 /// Find trailing `WITH (` options clause (not a CTE WITH).
-fn find_trailing_with_options(upper: &str, query_start: usize) -> Option<usize> {
-    let region = &upper[query_start..];
+fn find_trailing_with_options(sql: &str, query_start: usize) -> Option<usize> {
+    let region = &sql[query_start..];
     let mut search_end = region.len();
     loop {
-        let pos = region[..search_end].rfind("WITH")?;
+        let pos = rfind_ascii_case_insensitive(&region[..search_end], "WITH")?;
         let after = region[pos + 4..].trim_start();
         if after.starts_with('(') {
             let before = &region[..pos];
@@ -134,7 +135,7 @@ fn find_trailing_with_options(upper: &str, query_start: usize) -> Option<usize> 
 
 fn extract_refresh_mode(upper: &str, trimmed: &str) -> String {
     // Look for WITH (...) at the end; find REFRESH key.
-    if let Some(pos) = find_trailing_with_options(upper, 0) {
+    if let Some(pos) = find_trailing_with_options(trimmed, 0) {
         let after = trimmed[pos + 4..].trim_start();
         if let Some(inner) = after
             .strip_prefix('(')
@@ -160,18 +161,15 @@ fn extract_refresh_mode(upper: &str, trimmed: &str) -> String {
 /// Structural extraction for `CREATE CONTINUOUS AGGREGATE`.
 ///
 /// Extracts name, source, bucket_raw, aggregate_exprs_raw, group_by, with_clause_raw.
-fn parse_create_continuous_aggregate(upper: &str, trimmed: &str) -> NodedbStatement {
+fn parse_create_continuous_aggregate(_upper: &str, trimmed: &str) -> NodedbStatement {
     const PREFIX: &str = "CREATE CONTINUOUS AGGREGATE ";
 
     let rest = &trimmed[PREFIX.len()..];
-    let rest_upper = &upper[PREFIX.len()..];
-
     // name = token after "CONTINUOUS AGGREGATE "
     let name = rest.split_whitespace().next().unwrap_or("").to_lowercase();
 
     // source = token after " ON "
-    let source = rest_upper
-        .find(" ON ")
+    let source = find_ascii_case_insensitive(rest, " ON ")
         .map(|pos| {
             rest[pos + 4..]
                 .split_whitespace()
@@ -182,8 +180,7 @@ fn parse_create_continuous_aggregate(upper: &str, trimmed: &str) -> NodedbStatem
         .unwrap_or_default();
 
     // bucket_raw = quoted token after BUCKET keyword
-    let bucket_raw = rest_upper
-        .find("BUCKET")
+    let bucket_raw = find_ascii_case_insensitive(rest, "BUCKET")
         .and_then(|pos| {
             let after = rest[pos + 6..].trim_start();
             if let Some(inner) = after.strip_prefix('\'') {
@@ -195,28 +192,25 @@ fn parse_create_continuous_aggregate(upper: &str, trimmed: &str) -> NodedbStatem
         .unwrap_or_default();
 
     // aggregate_exprs_raw = text after AGGREGATE up to GROUP BY or WITH
-    let aggregate_exprs_raw = rest_upper
-        .find("AGGREGATE ")
+    let aggregate_exprs_raw = find_ascii_case_insensitive(rest, "AGGREGATE ")
         .map(|pos| {
-            let after = &rest[pos + 10..];
-            let after_upper = &rest_upper[pos + 10..];
+            let after_start = pos + 10;
             let end = ["GROUP BY ", "WITH "]
                 .iter()
-                .filter_map(|kw| after_upper.find(kw))
+                .filter_map(|kw| find_ascii_case_insensitive_from(rest, kw, after_start))
                 .min()
-                .unwrap_or(after.len());
-            after[..end].trim().to_string()
+                .unwrap_or(rest.len());
+            rest[after_start..end].trim().to_string()
         })
         .unwrap_or_default();
 
     // GROUP BY columns
-    let group_by = rest_upper
-        .find("GROUP BY ")
+    let group_by = find_ascii_case_insensitive(rest, "GROUP BY ")
         .map(|pos| {
-            let after = &rest[pos + 9..];
-            let after_upper = &rest_upper[pos + 9..];
-            let end = after_upper.find("WITH ").unwrap_or(after.len());
-            after[..end]
+            let after_start = pos + 9;
+            let end =
+                find_ascii_case_insensitive_from(rest, "WITH ", after_start).unwrap_or(rest.len());
+            rest[after_start..end]
                 .split(',')
                 .map(|s| s.trim().to_lowercase())
                 .filter(|s| !s.is_empty())
@@ -225,8 +219,7 @@ fn parse_create_continuous_aggregate(upper: &str, trimmed: &str) -> NodedbStatem
         .unwrap_or_default();
 
     // WITH clause raw inner text
-    let with_clause_raw = rest_upper
-        .find("WITH ")
+    let with_clause_raw = find_ascii_case_insensitive(rest, "WITH ")
         .and_then(|pos| {
             let after = rest[pos + 5..].trim_start();
             after
@@ -251,6 +244,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parse_mv_unicode_name_preserves_original_offsets() {
+        let sql = "CREATE MATERIALIZED VIEW summaryﬀﬀ ON orders AS SELECT count(*) FROM orders";
+        let upper = sql.to_uppercase();
+        if let NodedbStatement::StreamView(StreamViewStmt::CreateMaterializedView {
+            name,
+            source,
+            query_sql,
+            ..
+        }) = parse_create_mv(&upper, sql)
+        {
+            assert_eq!(name, "summaryﬀﬀ");
+            assert_eq!(source, "orders");
+            assert_eq!(query_sql, "SELECT count(*) FROM orders");
+        } else {
+            panic!("expected CreateMaterializedView");
+        }
+    }
+
+    #[test]
     fn parse_mv_basic() {
         let sql = "CREATE MATERIALIZED VIEW summary ON orders AS SELECT count(*) FROM orders";
         let upper = sql.to_uppercase();
@@ -267,6 +279,27 @@ mod tests {
             assert_eq!(refresh_mode, "FULL");
         } else {
             panic!("expected CreateMaterializedView");
+        }
+    }
+
+    #[test]
+    fn parse_continuous_aggregate_unicode_name_preserves_original_offsets() {
+        let sql = "CREATE CONTINUOUS AGGREGATE hourlyﬀﬀ ON metrics BUCKET '1h' AGGREGATE avg(cpu) AS mean_cpu";
+        let upper = sql.to_uppercase();
+        if let NodedbStatement::StreamView(StreamViewStmt::CreateContinuousAggregate {
+            name,
+            source,
+            bucket_raw,
+            aggregate_exprs_raw,
+            ..
+        }) = parse_create_continuous_aggregate(&upper, sql)
+        {
+            assert_eq!(name, "hourlyﬀﬀ");
+            assert_eq!(source, "metrics");
+            assert_eq!(bucket_raw, "1h");
+            assert!(aggregate_exprs_raw.contains("avg(cpu)"));
+        } else {
+            panic!("expected CreateContinuousAggregate");
         }
     }
 

--- a/nodedb-sql/src/ddl_ast/parse/oidc_provider.rs
+++ b/nodedb-sql/src/ddl_ast/parse/oidc_provider.rs
@@ -30,6 +30,7 @@
 
 use crate::ddl_ast::statement::{AuthStmt, NodedbStatement, OidcClaimMappingClause};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive_from;
 
 pub(super) fn try_parse(
     _upper: &str,
@@ -152,13 +153,12 @@ fn parse_drop(parts: &[&str]) -> Result<NodedbStatement, SqlError> {
 /// Each clause is delimited by the next `WHEN` (case-insensitive) or end-of-input.
 fn parse_claim_mappings(trimmed: &str) -> Result<Vec<OidcClaimMappingClause>, SqlError> {
     // Find all WHEN keyword positions (case-insensitive, whole-word).
-    let upper = trimmed.to_uppercase();
     let mut clauses = Vec::new();
 
     // Split the input into segments starting at each "WHEN".
     let mut positions: Vec<usize> = Vec::new();
     let mut search_from = 0;
-    while let Some(pos) = find_keyword(&upper, "WHEN", search_from) {
+    while let Some(pos) = find_keyword(trimmed, "WHEN", search_from) {
         positions.push(pos);
         search_from = pos + 4;
     }
@@ -225,8 +225,7 @@ fn parse_when_clause(segment: &str) -> Result<OidcClaimMappingClause, SqlError> 
 /// Both single- and double-quoted strings are accepted, but bare tokens and
 /// malformed strings are rejected.
 fn extract_keyword_value(trimmed: &str, keyword: &str) -> Result<Option<String>, SqlError> {
-    let upper = trimmed.to_uppercase();
-    let Some(pos) = find_keyword(&upper, keyword, 0) else {
+    let Some(pos) = find_keyword(trimmed, keyword, 0) else {
         return Ok(None);
     };
     let detail = format!("CREATE OIDC PROVIDER: {keyword} must be a quoted string");
@@ -291,8 +290,7 @@ fn parse_required_u64_keyword(
     keyword: &str,
     statement: &str,
 ) -> Result<u64, SqlError> {
-    let upper = original.to_uppercase();
-    let Some(pos) = find_keyword(&upper, keyword, 0) else {
+    let Some(pos) = find_keyword(original, keyword, 0) else {
         return Err(SqlError::Parse {
             detail: format!("{statement}: {keyword} <u64> is required"),
         });
@@ -315,13 +313,12 @@ fn parse_required_u64_keyword(
 
 /// Return the start of the first top-level `CLAIM MAPPING` clause, or input end.
 fn claim_mapping_start(input: &str, search_from: usize) -> usize {
-    let upper = input.to_uppercase();
     let mut search_from = search_from;
-    while let Some(pos) = find_keyword(&upper, "CLAIM", search_from) {
-        let after_claim = &upper[pos + "CLAIM".len()..];
+    while let Some(pos) = find_keyword(input, "CLAIM", search_from) {
+        let after_claim = &input[pos + "CLAIM".len()..];
         let whitespace = after_claim.len() - after_claim.trim_start().len();
         let mapping_start = pos + "CLAIM".len() + whitespace;
-        if find_keyword(&upper, "MAPPING", mapping_start) == Some(mapping_start) {
+        if find_keyword(input, "MAPPING", mapping_start) == Some(mapping_start) {
             return pos;
         }
         search_from = pos + "CLAIM".len();
@@ -397,14 +394,13 @@ fn extract_string_list(after_action: &str, keyword: &str) -> Result<Vec<String>,
         .collect())
 }
 
-/// Find the byte offset of a whole-word keyword match (case-insensitive via
-/// pre-uppercased `haystack`). The keyword must be uppercase.
+/// Find the byte offset of a quote-aware whole-word ASCII keyword match.
 fn find_keyword(haystack: &str, keyword: &str, from: usize) -> Option<usize> {
     let bytes = haystack.as_bytes();
-    let keyword = keyword.as_bytes();
+    let keyword_len = keyword.len();
     let mut index = from;
     let mut quote = None;
-    while index + keyword.len() <= bytes.len() {
+    while index + keyword_len <= bytes.len() {
         if let Some(delimiter) = quote {
             if bytes[index] == delimiter {
                 if bytes.get(index + 1) == Some(&delimiter) {
@@ -422,9 +418,12 @@ fn find_keyword(haystack: &str, keyword: &str, from: usize) -> Option<usize> {
             continue;
         }
         let before_ok = index == 0 || !is_word_byte(bytes[index - 1]);
-        let after = index + keyword.len();
+        let after = index + keyword_len;
         let after_ok = after == bytes.len() || !is_word_byte(bytes[after]);
-        if before_ok && after_ok && bytes[index..].starts_with(keyword) {
+        if before_ok
+            && after_ok
+            && find_ascii_case_insensitive_from(haystack, keyword, index) == Some(index)
+        {
             return Some(index);
         }
         index += 1;
@@ -434,9 +433,8 @@ fn find_keyword(haystack: &str, keyword: &str, from: usize) -> Option<usize> {
 
 /// Find the end of an exact, quote-aware, whitespace-delimited action sequence.
 fn find_action_end(input: &str, words: &[&str]) -> Option<usize> {
-    let upper = input.to_uppercase();
     let mut search_from = 0;
-    while let Some(start) = find_keyword(&upper, words[0], search_from) {
+    while let Some(start) = find_keyword(input, words[0], search_from) {
         let mut end = start + words[0].len();
         let mut matched = true;
         for word in &words[1..] {
@@ -446,8 +444,8 @@ fn find_action_end(input: &str, words: &[&str]) -> Option<usize> {
                 break;
             }
             end += whitespace;
-            if !upper[end..].starts_with(word)
-                || upper
+            if find_ascii_case_insensitive_from(input, word, end) != Some(end)
+                || input
                     .as_bytes()
                     .get(end + word.len())
                     .is_some_and(|byte| is_word_byte(*byte))
@@ -480,6 +478,33 @@ mod tests {
         try_parse(&upper, &parts, sql)
             .expect("expected Some")
             .expect("expected Ok")
+    }
+
+    #[test]
+    fn quoted_provider_value_after_unicode_text_preserves_original_offsets() {
+        assert_eq!(
+            extract_keyword_value("prefixﬀﬀ ISSUER 'https://idp.example'", "ISSUER").unwrap(),
+            Some("https://idp.example".to_string())
+        );
+    }
+
+    #[test]
+    fn required_numeric_value_after_unicode_text_preserves_original_offsets() {
+        assert_eq!(
+            parse_required_u64_keyword("prefixﬀﬀ TENANT 42", "TENANT", "provider").unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn claim_mapping_boundaries_after_unicode_values_preserve_original_offsets() {
+        let mappings = parse_claim_mappings(
+            "WHEN sub = 'ﬀﬀ' ADD ROLES ['readonly'] WHEN aud = 'api' ADD DATABASES [7]",
+        )
+        .unwrap();
+        assert_eq!(mappings.len(), 2);
+        assert_eq!(mappings[0].add_roles, vec!["readonly"]);
+        assert_eq!(mappings[1].add_databases, vec![7]);
     }
 
     #[test]

--- a/nodedb-sql/src/ddl_ast/parse/retention.rs
+++ b/nodedb-sql/src/ddl_ast/parse/retention.rs
@@ -5,13 +5,12 @@
 use super::helpers::extract_name_after_if_exists;
 use crate::ddl_ast::statement::{NodedbStatement, PolicyStmt};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_case_insensitive;
 
 /// Extract the value for a SET key from the SQL string.
 /// Returns a quoted string's inner content or an unquoted token.
 fn extract_set_value(sql: &str, key: &str) -> Option<String> {
-    let upper = sql.to_uppercase();
-    let key_upper = key.to_uppercase();
-    let pos = upper.find(&key_upper)?;
+    let pos = find_ascii_case_insensitive(sql, key)?;
     let after = sql[pos + key.len()..].trim_start();
     let after = after.strip_prefix('=').unwrap_or(after).trim_start();
     if let Some(inner) = after.strip_prefix('\'') {
@@ -92,16 +91,13 @@ pub(super) fn try_parse(
 /// Extracts name, collection, raw body (between outer parens), and
 /// optional EVAL_INTERVAL string. The handler converts the body to
 /// RetentionPolicyDef.
-fn parse_create_retention_policy(upper: &str, trimmed: &str) -> NodedbStatement {
+fn parse_create_retention_policy(_upper: &str, trimmed: &str) -> NodedbStatement {
     // Syntax: CREATE RETENTION POLICY <name> ON <collection> ( <body> ) [WITH (EVAL_INTERVAL = '<val>')]
     let prefix = "CREATE RETENTION POLICY ";
     let rest = &trimmed[prefix.len()..];
-    let rest_upper = &upper[prefix.len()..];
-
     let name = rest.split_whitespace().next().unwrap_or("").to_lowercase();
 
-    let collection = rest_upper
-        .find(" ON ")
+    let collection = find_ascii_case_insensitive(rest, " ON ")
         .map(|pos| {
             rest[pos + 4..]
                 .split_whitespace()
@@ -115,7 +111,7 @@ fn parse_create_retention_policy(upper: &str, trimmed: &str) -> NodedbStatement 
     let body_raw = extract_outer_parens(trimmed).unwrap_or_default();
 
     // EVAL_INTERVAL from trailing WITH clause
-    let eval_interval_raw = extract_eval_interval(upper, trimmed);
+    let eval_interval_raw = extract_eval_interval(trimmed);
 
     NodedbStatement::Policy(PolicyStmt::CreateRetentionPolicy {
         name,
@@ -150,7 +146,7 @@ fn extract_outer_parens(s: &str) -> Option<String> {
 }
 
 /// Extract EVAL_INTERVAL value from WITH clause (if present).
-fn extract_eval_interval(upper: &str, trimmed: &str) -> Option<String> {
+fn extract_eval_interval(trimmed: &str) -> Option<String> {
     // Find trailing WITH ( after the main body parens.
     // The main body is the first outer-paren group; WITH comes after.
     let body_end = {
@@ -173,8 +169,8 @@ fn extract_eval_interval(upper: &str, trimmed: &str) -> Option<String> {
         end
     };
 
-    let after_body = &upper[body_end..];
-    let with_pos = after_body.find("WITH")?;
+    let after_body = &trimmed[body_end..];
+    let with_pos = find_ascii_case_insensitive(after_body, "WITH")?;
     let after_with = &trimmed[body_end + with_pos + 4..].trim_start();
     let inner = after_with
         .strip_prefix('(')
@@ -194,6 +190,36 @@ fn extract_eval_interval(upper: &str, trimmed: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unicode_retention_name_preserves_original_offsets() {
+        let sql = "CREATE RETENTION POLICY rpﬀﬀ ON metrics (RAW RETAIN '7d')";
+        let upper = sql.to_uppercase();
+        if let NodedbStatement::Policy(PolicyStmt::CreateRetentionPolicy {
+            name,
+            collection,
+            body_raw,
+            ..
+        }) = parse_create_retention_policy(&upper, sql)
+        {
+            assert_eq!(name, "rpﬀﬀ");
+            assert_eq!(collection, "metrics");
+            assert_eq!(body_raw, "RAW RETAIN '7d'");
+        } else {
+            panic!("expected CreateRetentionPolicy");
+        }
+    }
+
+    #[test]
+    fn set_value_after_unicode_text_preserves_original_offsets() {
+        assert_eq!(
+            extract_set_value(
+                "ALTER RETENTION POLICY rpﬀﬀ SET INTERVAL = '1h'",
+                "INTERVAL"
+            ),
+            Some("1h".to_string())
+        );
+    }
 
     #[test]
     fn parse_basic_retention_policy() {

--- a/nodedb-sql/src/ddl_ast/parse/schedule.rs
+++ b/nodedb-sql/src/ddl_ast/parse/schedule.rs
@@ -5,12 +5,12 @@
 use super::helpers::extract_name_after_if_exists;
 use crate::ddl_ast::statement::{AutomationStmt, NodedbStatement};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::{find_ascii_case_insensitive, rfind_ascii_case_insensitive};
 
 /// Extract the content between the first pair of single quotes after
 /// "CRON" in the SQL string.
 fn extract_quoted_cron(sql: &str) -> Option<String> {
-    let upper = sql.to_uppercase();
-    let cron_idx = upper.find("CRON")?;
+    let cron_idx = find_ascii_case_insensitive(sql, "CRON")?;
     let rest = &sql[cron_idx + 4..];
     let start = rest.find('\'')?;
     let inner = &rest[start + 1..];
@@ -112,7 +112,7 @@ fn parse_create_schedule(upper: &str, trimmed: &str) -> NodedbStatement {
     let mut allow_overlap = true;
     let mut missed_policy = "SKIP".to_string();
 
-    if let Some(with_pos) = upper.find(" WITH ") {
+    if let Some(with_pos) = find_ascii_case_insensitive(trimmed, " WITH ") {
         let after_with = &trimmed[with_pos + 6..];
         if let Some(inner) = after_with
             .trim()
@@ -140,8 +140,7 @@ fn parse_create_schedule(upper: &str, trimmed: &str) -> NodedbStatement {
     }
 
     // Body SQL: everything after the last " AS " keyword.
-    let body_sql = upper
-        .rfind(" AS ")
+    let body_sql = rfind_ascii_case_insensitive(trimmed, " AS ")
         .map(|pos| trimmed[pos + 4..].trim().to_string())
         .unwrap_or_default();
 
@@ -157,8 +156,7 @@ fn parse_create_schedule(upper: &str, trimmed: &str) -> NodedbStatement {
 
 /// Extract cron expression from rest (after "CREATE SCHEDULE <name> ").
 fn extract_cron_expr_str(rest: &str) -> Option<String> {
-    let rest_upper = rest.to_uppercase();
-    let cron_pos = rest_upper.find("CRON")?;
+    let cron_pos = find_ascii_case_insensitive(rest, "CRON")?;
     let after_cron = rest[cron_pos + 4..].trim_start();
 
     // Quoted form: 'expr'
@@ -187,6 +185,24 @@ mod tests {
     fn create(sql: &str) -> NodedbStatement {
         let upper = sql.to_uppercase();
         parse_create_schedule(&upper, sql)
+    }
+
+    #[test]
+    fn unicode_schedule_name_preserves_original_offsets() {
+        let sql = "CREATE SCHEDULE cleanupﬀﬀ CRON '0 0 * * *' AS BEGIN DELETE FROM old; END";
+        if let NodedbStatement::Automation(AutomationStmt::CreateSchedule {
+            name,
+            cron_expr,
+            body_sql,
+            ..
+        }) = create(sql)
+        {
+            assert_eq!(name, "cleanupﬀﬀ");
+            assert_eq!(cron_expr, "0 0 * * *");
+            assert_eq!(body_sql, "BEGIN DELETE FROM old; END");
+        } else {
+            panic!("expected CreateSchedule");
+        }
     }
 
     #[test]

--- a/nodedb-sql/src/ddl_ast/parse/synonym_group.rs
+++ b/nodedb-sql/src/ddl_ast/parse/synonym_group.rs
@@ -9,6 +9,7 @@
 
 use crate::ddl_ast::statement::{NodedbStatement, PolicyStmt};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::find_ascii_keyword;
 
 /// Try to parse synonym group DDL statements.
 pub(super) fn try_parse(
@@ -97,15 +98,11 @@ fn parse_drop(parts: &[&str]) -> Result<NodedbStatement, SqlError> {
 fn parse_term_list(_fragment: &str, original: &str) -> Result<Vec<String>, SqlError> {
     // Find the AS keyword in the original to get the parenthesised region.
     // We use a simple scan: find '(' and matching ')'.
-    let orig_upper = original.to_uppercase();
-    let as_pos = orig_upper
-        .find(" AS ")
-        .or_else(|| orig_upper.find(" AS\t"))
-        .ok_or_else(|| SqlError::Parse {
-            detail: "CREATE SYNONYM GROUP: missing AS keyword".to_string(),
-        })?;
+    let as_pos = find_ascii_keyword(original, "AS").ok_or_else(|| SqlError::Parse {
+        detail: "CREATE SYNONYM GROUP: missing AS keyword".to_string(),
+    })?;
 
-    let s = original[as_pos + 4..].trim_start();
+    let s = original[as_pos + "AS".len()..].trim_start();
 
     let open = s.find('(').ok_or_else(|| SqlError::Parse {
         detail: "CREATE SYNONYM GROUP: term list must start with '('".to_string(),
@@ -174,6 +171,18 @@ mod tests {
         parse(sql)
             .expect("expected Some")
             .expect_err("expected Err")
+    }
+
+    #[test]
+    fn create_unicode_group_name_preserves_original_offsets() {
+        let stmt = ok("CREATE SYNONYM GROUP termsﬀﬀ AS ('database', 'db')");
+        match stmt {
+            NodedbStatement::Policy(PolicyStmt::CreateSynonymGroup { name, terms }) => {
+                assert_eq!(name, "termsﬀﬀ");
+                assert_eq!(terms, vec!["database", "db"]);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
     }
 
     #[test]

--- a/nodedb-sql/src/ddl_ast/parse/trigger.rs
+++ b/nodedb-sql/src/ddl_ast/parse/trigger.rs
@@ -5,6 +5,7 @@
 use super::helpers::{extract_after_keyword, extract_name_after_if_exists};
 use crate::ddl_ast::statement::{AutomationStmt, NodedbStatement};
 use crate::error::SqlError;
+use crate::parser::preprocess::lex::{find_ascii_case_insensitive_from, find_ascii_keyword};
 
 pub(super) fn try_parse(
     upper: &str,
@@ -70,7 +71,7 @@ pub(super) fn try_parse(
 fn parse_create_trigger(upper: &str, trimmed: &str) -> NodedbStatement {
     let (or_replace, execution_mode, rest_original) = strip_create_trigger_prefix(upper, trimmed);
 
-    let (header_original, header_upper, body_sql) = split_header_and_body(rest_original);
+    let (header_original, body_sql) = split_header_and_body(rest_original);
 
     let tokens_orig: Vec<&str> = header_original.split_whitespace().collect();
     let tokens_upper: Vec<String> = tokens_orig.iter().map(|t| t.to_uppercase()).collect();
@@ -95,8 +96,7 @@ fn parse_create_trigger(upper: &str, trimmed: &str) -> NodedbStatement {
     i += 1;
 
     let granularity = parse_granularity_tokens(&tokens_upper, &mut i);
-    let when_condition =
-        extract_when_condition(&header_upper, &header_original, &tokens_upper, &mut i);
+    let when_condition = extract_when_condition(&header_original, &tokens_upper, &mut i);
     let priority = parse_priority_token(&tokens_orig, &tokens_upper, &mut i);
     let security = parse_security_token(&tokens_upper, &mut i);
 
@@ -137,19 +137,16 @@ fn strip_create_trigger_prefix<'a>(upper: &str, original: &'a str) -> (bool, Str
     (false, "ASYNC".to_string(), original)
 }
 
-/// Split trigger SQL into (header_original, header_upper, body_sql).
+/// Split trigger SQL into `(header_original, body_sql)`.
 /// Handles both `$$ ... $$` and `BEGIN ... END` body forms.
-fn split_header_and_body(rest: &str) -> (String, String, String) {
-    let upper = rest.to_uppercase();
-
+fn split_header_and_body(rest: &str) -> (String, String) {
     // Try $$ ... $$ first
     if let Some(first) = rest.find("$$") {
         let inner_start = first + 2;
         if let Some(second) = rest[inner_start..].find("$$") {
             let header = rest[..first].trim().to_string();
             let body = rest[inner_start..inner_start + second].trim().to_string();
-            let header_upper = header.to_uppercase();
-            return (header, header_upper, body);
+            return (header, body);
         }
     }
 
@@ -171,7 +168,7 @@ fn split_header_and_body(rest: &str) -> (String, String, String) {
             }
             continue;
         }
-        if i + 5 <= upper.len() && &upper[i..i + 5] == "BEGIN" {
+        if find_ascii_case_insensitive_from(rest, "BEGIN", i) == Some(i) {
             let before_ok =
                 i == 0 || (!bytes[i - 1].is_ascii_alphanumeric() && bytes[i - 1] != b'_');
             let after_ok = i + 5 >= bytes.len()
@@ -179,13 +176,12 @@ fn split_header_and_body(rest: &str) -> (String, String, String) {
             if before_ok && after_ok {
                 let header = rest[..i].trim().to_string();
                 let body = rest[i..].trim().to_string();
-                let header_upper = header.to_uppercase();
-                return (header, header_upper, body);
+                return (header, body);
             }
         }
         i += 1;
     }
-    (rest.to_string(), upper, String::new())
+    (rest.to_string(), String::new())
 }
 
 fn parse_timing_token(tokens: &[String], i: &mut usize) -> String {
@@ -252,7 +248,6 @@ fn parse_granularity_tokens(tokens: &[String], i: &mut usize) -> String {
 }
 
 fn extract_when_condition(
-    header_upper: &str,
     header_original: &str,
     tokens_upper: &[String],
     i: &mut usize,
@@ -262,7 +257,7 @@ fn extract_when_condition(
     }
     *i += 1;
 
-    let when_pos = header_upper.find("WHEN")?;
+    let when_pos = find_ascii_keyword(header_original, "WHEN")?;
     let after_when = header_original[when_pos + 4..].trim_start();
     if !after_when.starts_with('(') {
         return None;
@@ -325,6 +320,31 @@ mod tests {
     fn create(sql: &str) -> NodedbStatement {
         let upper = sql.to_uppercase();
         parse_create_trigger(&upper, sql)
+    }
+
+    #[test]
+    fn unicode_trigger_name_before_when_preserves_original_offsets() {
+        let sql = "CREATE TRIGGER tﬀﬀ AFTER INSERT ON orders FOR EACH ROW WHEN (NEW.status = 'active') BEGIN RETURN; END";
+        if let NodedbStatement::Automation(AutomationStmt::CreateTrigger {
+            name,
+            when_condition,
+            ..
+        }) = create(sql)
+        {
+            assert_eq!(name, "tﬀﬀ");
+            assert_eq!(when_condition.as_deref(), Some("NEW.status = 'active'"));
+        } else {
+            panic!("expected CreateTrigger");
+        }
+    }
+
+    #[test]
+    fn unicode_text_before_begin_preserves_body_boundary() {
+        let (header, body) = split_header_and_body(
+            "t AFTER INSERT ON orders WHEN (NEW.note = 'ﬀﬀ') BEGIN RETURN; END",
+        );
+        assert_eq!(header, "t AFTER INSERT ON orders WHEN (NEW.note = 'ﬀﬀ')");
+        assert_eq!(body, "BEGIN RETURN; END");
     }
 
     #[test]

--- a/nodedb-sql/src/ddl_ast/parse/vector_primary.rs
+++ b/nodedb-sql/src/ddl_ast/parse/vector_primary.rs
@@ -13,6 +13,10 @@ use nodedb_types::vector_ann::VectorQuantization;
 use nodedb_types::vector_distance::DistanceMetric;
 use nodedb_types::vector_dtype::VectorStorageDtype;
 
+use crate::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from, find_ascii_keyword,
+};
+
 /// Known quantization codec names accepted in DDL.
 const VALID_QUANTIZATIONS: &[&str] = &[
     "none", "sq8", "pq", "rabitq", "bbq", "binary", "ternary", "opq",
@@ -296,8 +300,7 @@ pub fn parse_vector_primary_options_from_kvs(
 /// Find the substring inside the outermost `WITH (...)` clause, if any.
 /// Falls back to the whole SQL when no WITH clause is present.
 fn with_clause(sql: &str) -> &str {
-    let upper = sql.to_uppercase();
-    let Some(pos) = upper.find("WITH") else {
+    let Some(pos) = find_ascii_keyword(sql, "WITH") else {
         return sql;
     };
     // Whole-word check on WITH.
@@ -321,15 +324,11 @@ fn with_clause(sql: &str) -> &str {
 /// Extract a `key = 'value'` or `key = "value"` string from SQL WITH options.
 fn extract_with_str(sql: &str, key: &str) -> Option<String> {
     let scope = with_clause(sql);
-    let upper = scope.to_uppercase();
-    let key_upper = key.to_uppercase();
-
     // Find a whole-word, '='-followed occurrence; skip false matches like
     // "m" inside "metric" or inside "dim".
     let mut start = 0usize;
     let pos = loop {
-        let rel = upper[start..].find(&key_upper)?;
-        let abs = start + rel;
+        let abs = find_ascii_case_insensitive_from(scope, key, start)?;
         let before_ok = abs == 0 || {
             let b = scope.as_bytes()[abs - 1];
             !(b.is_ascii_alphanumeric() || b == b'_')
@@ -381,8 +380,7 @@ fn extract_with_u32(sql: &str, key: &str) -> Option<u32> {
 /// Returns an empty `Vec` if the key is absent.
 fn extract_payload_indexes(sql: &str) -> Vec<String> {
     let scope = with_clause(sql);
-    let upper = scope.to_uppercase();
-    let pos = match upper.find("PAYLOAD_INDEXES") {
+    let pos = match find_ascii_case_insensitive(scope, "PAYLOAD_INDEXES") {
         Some(p) => p,
         None => return Vec::new(),
     };
@@ -473,6 +471,30 @@ fn parse_metric(m: &str) -> Result<DistanceMetric, NodeDbError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn with_clause_after_unicode_schema_preserves_original_offsets() {
+        assert_eq!(
+            with_clause("CREATE COLLECTION v (name ﬀﬀ) WITH (primary='vector')"),
+            "primary='vector'"
+        );
+    }
+
+    #[test]
+    fn option_after_unicode_value_preserves_original_offsets() {
+        assert_eq!(
+            extract_with_str("WITH (note='ﬀﬀ', metric='cosine')", "metric"),
+            Some("cosine".to_string())
+        );
+    }
+
+    #[test]
+    fn payload_indexes_after_unicode_value_preserve_original_offsets() {
+        assert_eq!(
+            extract_payload_indexes("WITH (note='ﬀﬀ', payload_indexes=['category'])"),
+            vec!["category"]
+        );
+    }
 
     // ── Happy path ────────────────────────────────────────────────────────
 

--- a/nodedb-sql/src/parser/preprocess/lex.rs
+++ b/nodedb-sql/src/parser/preprocess/lex.rs
@@ -255,6 +255,89 @@ pub fn has_brace_outside_literals(sql: &str) -> bool {
     has_operator_outside_literals(sql, "{")
 }
 
+/// Find an ASCII `needle` in `text` without allocating a case-transformed
+/// copy. The returned byte offset always belongs to `text`.
+pub fn find_ascii_case_insensitive(text: &str, needle: &str) -> Option<usize> {
+    find_ascii_case_insensitive_from(text, needle, 0)
+}
+
+/// Find the last ASCII `needle` in `text` without allocating a transformed
+/// copy. The returned byte offset always belongs to `text`.
+pub fn rfind_ascii_case_insensitive(text: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(text.len());
+    }
+    if !needle.is_ascii() || needle.len() > text.len() {
+        return None;
+    }
+
+    let haystack = text.as_bytes();
+    let needle = needle.as_bytes();
+    (0..=haystack.len() - needle.len()).rev().find(|&position| {
+        haystack[position..position + needle.len()]
+            .iter()
+            .zip(needle)
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
+    })
+}
+
+/// Find an ASCII `needle` at or after byte offset `start` in `text`.
+///
+/// `start` need not be a UTF-8 character boundary because matching is performed
+/// on bytes. A successful position is always a boundary: an ASCII needle can
+/// only begin on an ASCII byte in the original string.
+pub fn find_ascii_case_insensitive_from(text: &str, needle: &str, start: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return (start <= text.len()).then_some(start);
+    }
+    if !needle.is_ascii() || start > text.len() || needle.len() > text.len() - start {
+        return None;
+    }
+
+    let haystack = text.as_bytes();
+    let needle = needle.as_bytes();
+    (start..=haystack.len() - needle.len()).find(|&position| {
+        haystack[position..position + needle.len()]
+            .iter()
+            .zip(needle)
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
+    })
+}
+
+fn is_identifier_char(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+fn has_word_boundaries(text: &str, position: usize, length: usize) -> bool {
+    let before_ok = position == 0
+        || !text[..position]
+            .chars()
+            .next_back()
+            .map(is_identifier_char)
+            .unwrap_or(false);
+    let after = position + length;
+    let after_ok = after >= text.len()
+        || !text[after..]
+            .chars()
+            .next()
+            .map(is_identifier_char)
+            .unwrap_or(false);
+    before_ok && after_ok
+}
+
+/// Find a whole ASCII keyword in `text`, comparing case-insensitively while
+/// returning an offset into the unchanged input.
+pub fn find_ascii_keyword(text: &str, keyword: &str) -> Option<usize> {
+    let mut start = 0;
+    while let Some(position) = find_ascii_case_insensitive_from(text, keyword, start) {
+        if has_word_boundaries(text, position, keyword.len()) {
+            return Some(position);
+        }
+        start = position + keyword.len().max(1);
+    }
+    None
+}
+
 /// Return the byte position (relative to `sql`) of the first case-insensitive
 /// occurrence of the keyword `kw` that falls inside a `Text` segment. Returns
 /// `None` if not found.
@@ -263,36 +346,12 @@ pub fn has_brace_outside_literals(sql: &str) -> bool {
 /// match (if any) must not be alphanumeric or `_`, and the character
 /// immediately after the match (if any) must not be alphanumeric or `_`.
 pub fn keyword_position_outside_literals(sql: &str, kw: &str) -> Option<usize> {
-    let kw_upper = kw.to_uppercase();
     for seg in segments(sql) {
-        if let SqlSegment::Text(t) = seg {
-            let base = t.as_ptr() as usize - sql.as_ptr() as usize;
-            let upper = t.to_uppercase();
-            let mut search_from = 0;
-            while search_from < upper.len() {
-                let Some(rel) = upper[search_from..].find(&kw_upper) else {
-                    break;
-                };
-                let abs_rel = search_from + rel;
-                // word-boundary check
-                let before_ok = abs_rel == 0
-                    || !t[..abs_rel]
-                        .chars()
-                        .next_back()
-                        .map(|c| c.is_alphanumeric() || c == '_')
-                        .unwrap_or(false);
-                let after_start = abs_rel + kw.len();
-                let after_ok = after_start >= t.len()
-                    || !t[after_start..]
-                        .chars()
-                        .next()
-                        .map(|c| c.is_alphanumeric() || c == '_')
-                        .unwrap_or(false);
-                if before_ok && after_ok {
-                    return Some(base + abs_rel);
-                }
-                search_from = abs_rel + 1;
-            }
+        if let SqlSegment::Text(text) = seg
+            && let Some(position) = find_ascii_keyword(text, kw)
+        {
+            let base = text.as_ptr() as usize - sql.as_ptr() as usize;
+            return Some(base + position);
         }
     }
     None
@@ -509,5 +568,12 @@ mod tests {
         // verify the slice at that position matches the keyword (case-insensitively)
         let found = &sql[pos..pos + "FOR SYSTEM_TIME".len()];
         assert_eq!(found.to_uppercase(), "FOR SYSTEM_TIME");
+    }
+
+    #[test]
+    fn keyword_position_after_unicode_text_indexes_original_sql() {
+        let sql = "SELECT ﬀﬀ FROM records";
+        let pos = keyword_position_outside_literals(sql, "FROM").unwrap();
+        assert_eq!(&sql[pos..pos + "FROM".len()], "FROM");
     }
 }

--- a/nodedb-sql/src/parser/preprocess/temporal.rs
+++ b/nodedb-sql/src/parser/preprocess/temporal.rs
@@ -36,7 +36,10 @@
 //! Any other expression form is rejected with a typed `TemporalParseError`
 //! naming the unsupported form.
 
-use super::lex::keyword_position_outside_literals;
+use super::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+    keyword_position_outside_literals,
+};
 use crate::temporal::{TemporalScope, ValidTime};
 use nodedb_types::SystemTimeScope;
 
@@ -152,8 +155,7 @@ fn strip_system_time_as_of(sql: &str) -> Result<Option<(String, i64)>, TemporalP
 /// stable; the planner ignores the synthetic column because the temporal
 /// scope is carried out-of-band.
 fn strip_system_as_of_function(sql: &str) -> Result<Option<(String, i64)>, TemporalParseError> {
-    let upper = sql.to_uppercase();
-    let Some(start) = upper.find("__SYSTEM_AS_OF__(") else {
+    let Some(start) = find_ascii_case_insensitive(sql, "__SYSTEM_AS_OF__(") else {
         return Ok(None);
     };
     let after_open = start + "__SYSTEM_AS_OF__(".len();
@@ -392,20 +394,18 @@ fn parse_as_of_expr(
         "OFFSET",
         ";",
     ];
-    let upper_trimmed = trimmed.to_uppercase();
     let mut end_rel = trimmed.len();
     for stop in &stop_tokens {
         // Only match at a word boundary (preceded by whitespace or start).
         let mut search_from = 0;
-        while let Some(pos) = upper_trimmed[search_from..].find(stop) {
-            let abs_pos = search_from + pos;
-            let at_boundary = abs_pos == 0
-                || upper_trimmed[..abs_pos].ends_with(|c: char| c.is_ascii_whitespace());
+        while let Some(abs_pos) = find_ascii_case_insensitive_from(trimmed, stop, search_from) {
+            let at_boundary =
+                abs_pos == 0 || trimmed[..abs_pos].ends_with(|c: char| c.is_ascii_whitespace());
             if at_boundary {
                 end_rel = end_rel.min(abs_pos);
                 break;
             }
-            search_from = abs_pos + 1;
+            search_from = abs_pos + stop.len();
         }
     }
     // Trim trailing whitespace from the extracted token.
@@ -439,6 +439,16 @@ fn parse_trailing_i64(sql: &str, offset: usize) -> Result<(i64, usize), Temporal
         .last()
         .ok_or_else(|| TemporalParseError(format!("expected integer at offset {offset}")))?;
     let num_str = &trimmed[..end_rel];
+    if trimmed[end_rel..]
+        .chars()
+        .next()
+        .is_some_and(|c| !c.is_ascii_whitespace() && !matches!(c, ';' | ',' | ')'))
+    {
+        return Err(TemporalParseError(format!(
+            "invalid character after integer temporal expression at offset {}",
+            offset + leading + end_rel
+        )));
+    }
     let v: i64 = num_str
         .parse()
         .map_err(|_| TemporalParseError(format!("not an i64: {num_str}")))?;
@@ -452,6 +462,12 @@ mod tests {
     #[test]
     fn passthrough_no_temporal() {
         assert!(extract("SELECT * FROM t WHERE x = 1").unwrap().is_none());
+    }
+
+    #[test]
+    fn unicode_in_invalid_as_of_expression_returns_error_without_panicking() {
+        let result = extract("SELECT * FROM t FOR SYSTEM_TIME AS OF 100ﬀﬀ LIMIT 1");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/nodedb/src/control/planner/procedural/executor/bindings.rs
+++ b/nodedb/src/control/planner/procedural/executor/bindings.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashMap;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive_from;
 use nodedb_types::Value;
 
 /// Row bindings available during trigger/procedure body execution.
@@ -283,13 +284,16 @@ fn replace_case_insensitive(input: &str, pattern: &str, replacement: &str) -> St
     if pattern.is_empty() {
         return input.to_string();
     }
-    let lower_input = input.to_lowercase();
-    let lower_pattern = pattern.to_lowercase();
     let mut result = String::with_capacity(input.len());
     let mut search_from = 0;
 
-    while let Some(pos) = lower_input[search_from..].find(&lower_pattern) {
-        let abs_pos = search_from + pos;
+    while let Some(abs_pos) = if pattern.is_ascii() {
+        find_ascii_case_insensitive_from(input, pattern, search_from)
+    } else {
+        input[search_from..]
+            .find(pattern)
+            .map(|position| search_from + position)
+    } {
         result.push_str(&input[search_from..abs_pos]);
         result.push_str(replacement);
         search_from = abs_pos + pattern.len();
@@ -301,6 +305,14 @@ fn replace_case_insensitive(input: &str, pattern: &str, replacement: &str) -> St
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replacement_after_expanding_unicode_preserves_original_offsets() {
+        assert_eq!(
+            replace_case_insensitive("SELECT 'ﬀﬀ', NEW.id, new.ID", "NEW.id", "42"),
+            "SELECT 'ﬀﬀ', 42, 42"
+        );
+    }
 
     #[test]
     fn substitute_new_fields() {

--- a/nodedb/src/control/server/http/routes/ws_rpc/format.rs
+++ b/nodedb/src/control/server/http/routes/ws_rpc/format.rs
@@ -2,6 +2,8 @@
 
 //! Formatting helpers for WebSocket RPC responses and notifications.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::control::change_stream::ChangeEvent;
 use crate::control::gateway::GatewayErrorMap;
 
@@ -33,9 +35,7 @@ pub fn ws_error_from_gateway(id: &serde_json::Value, err: &crate::Error) -> Stri
 
 /// Extract collection name from SQL (first word after FROM, case-insensitive).
 pub fn extract_collection_from_sql(sql: &str) -> String {
-    let upper = sql.to_uppercase();
-    upper
-        .find(" FROM ")
+    find_ascii_case_insensitive(sql, " FROM ")
         .and_then(|pos| sql.get(pos + 6..))
         .and_then(|after| after.split_whitespace().next())
         .map(|s| s.to_lowercase())

--- a/nodedb/src/control/server/native/dispatch/sql_admin.rs
+++ b/nodedb/src/control/server/native/dispatch/sql_admin.rs
@@ -4,6 +4,7 @@
 //! dispatch path. Split out of `sql.rs` to keep that file under the
 //! file-size limit; behavior is unchanged.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use nodedb_types::protocol::NativeResponse;
 use nodedb_types::value::Value;
 
@@ -26,7 +27,7 @@ pub(super) fn handle_set_sql(ctx: &DispatchCtx<'_>, seq: u64, sql: &str) -> Nati
                 .trim_matches('\'')
                 .to_string(),
         )
-    } else if let Some(to_pos) = after_set.to_uppercase().find(" TO ") {
+    } else if let Some(to_pos) = find_ascii_case_insensitive(after_set, " TO ") {
         (
             after_set[..to_pos].trim().to_lowercase(),
             after_set[to_pos + 4..]

--- a/nodedb/src/control/server/pgwire/handler/facet.rs
+++ b/nodedb/src/control/server/pgwire/handler/facet.rs
@@ -7,6 +7,7 @@
 //! arguments, builds a `QueryOp::FacetCounts` physical plan, dispatches to
 //! the Data Plane, and formats the response.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use pgwire::api::results::Response;
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use sonic_rs;
@@ -202,9 +203,8 @@ fn parse_search_with_facets_args(sql: &str) -> PgWireResult<SearchWithFacetsArgs
 
 /// Extract a named string argument: `name => 'value'` or `name => ''value with quotes''`.
 fn extract_named_string_arg(sql: &str, name: &str) -> Option<String> {
-    let lower = sql.to_lowercase();
     let pattern = format!("{name} =>");
-    let pos = lower.find(&pattern)?;
+    let pos = find_ascii_case_insensitive(sql, &pattern)?;
     let after = sql[pos + pattern.len()..].trim_start();
 
     // Handle both single-quoted (with SQL escaping) values.
@@ -231,9 +231,8 @@ fn extract_named_string_arg(sql: &str, name: &str) -> Option<String> {
 
 /// Extract a named array argument: `name => ['val1', 'val2']`.
 fn extract_named_array_arg(sql: &str, name: &str) -> Option<Vec<String>> {
-    let lower = sql.to_lowercase();
     let pattern = format!("{name} =>");
-    let pos = lower.find(&pattern)?;
+    let pos = find_ascii_case_insensitive(sql, &pattern)?;
     let after = sql[pos + pattern.len()..].trim_start();
 
     let open = after.find('[')?;
@@ -254,9 +253,8 @@ fn extract_named_array_arg(sql: &str, name: &str) -> Option<Vec<String>> {
 
 /// Extract a named integer argument: `name => 10`.
 fn extract_named_int_arg(sql: &str, name: &str) -> Option<usize> {
-    let lower = sql.to_lowercase();
     let pattern = format!("{name} =>");
-    let pos = lower.find(&pattern)?;
+    let pos = find_ascii_case_insensitive(sql, &pattern)?;
     let after = sql[pos + pattern.len()..].trim_start();
     // Take digits until non-digit.
     let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
@@ -265,10 +263,7 @@ fn extract_named_int_arg(sql: &str, name: &str) -> Option<usize> {
 
 /// Extract collection name and WHERE clause from a SELECT query.
 fn extract_collection_and_filter(query: &str) -> PgWireResult<(String, String)> {
-    let upper = query.to_uppercase();
-
-    let from_pos = upper
-        .find(" FROM ")
+    let from_pos = find_ascii_case_insensitive(query, " FROM ")
         .ok_or_else(|| syntax_error("SEARCH_WITH_FACETS query must contain FROM clause"))?;
 
     let after_from = query[from_pos + 6..].trim_start();
@@ -280,12 +275,12 @@ fn extract_collection_and_filter(query: &str) -> PgWireResult<(String, String)> 
         .trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_')
         .to_string();
 
-    let filter = if let Some(where_pos) = upper.find(" WHERE ") {
+    let filter = if let Some(where_pos) = find_ascii_case_insensitive(query, " WHERE ") {
         // Extract everything between WHERE and ORDER BY / LIMIT / end.
         let after_where = &query[where_pos + 7..];
         let end = ["ORDER BY", "LIMIT", "GROUP BY"]
             .iter()
-            .filter_map(|kw| after_where.to_uppercase().find(kw))
+            .filter_map(|kw| find_ascii_case_insensitive(after_where, kw))
             .min()
             .unwrap_or(after_where.len());
         after_where[..end].trim().to_string()
@@ -317,4 +312,27 @@ fn syntax_error(msg: &str) -> PgWireError {
         "42601".to_owned(),
         msg.to_owned(),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_argument_after_unicode_text_preserves_original_offsets() {
+        let sql = "SELECT SEARCH_WITH_FACETS(note => 'İ', query => 'SELECT * FROM items', facets => ['kind'])";
+        assert_eq!(
+            extract_named_string_arg(sql, "query"),
+            Some("SELECT * FROM items".to_string())
+        );
+    }
+
+    #[test]
+    fn inner_query_keywords_after_unicode_text_preserve_original_offsets() {
+        let (collection, filter) =
+            extract_collection_and_filter("SELECT ﬀﬀ FROM items WHERE kind = 'book' ORDER BY id")
+                .unwrap();
+        assert_eq!(collection, "items");
+        assert_eq!(filter, "kind = 'book'");
+    }
 }

--- a/nodedb/src/control/server/pgwire/handler/returning.rs
+++ b/nodedb/src/control/server/pgwire/handler/returning.rs
@@ -12,6 +12,7 @@
 pub(super) use nodedb_physical::physical_plan::{ReturningColumns, ReturningItem, ReturningSpec};
 
 use crate::Error;
+use nodedb_sql::parser::preprocess::lex::{find_ascii_keyword, keyword_position_outside_literals};
 
 const RETURNING_KEYWORD: &str = "RETURNING";
 
@@ -33,7 +34,7 @@ pub(super) fn strip_returning(sql: &str) -> Result<(String, Option<ReturningSpec
         return Ok((sql.to_string(), None));
     }
 
-    if let Some(pos) = find_returning_keyword(&upper) {
+    if let Some(pos) = keyword_position_outside_literals(sql, RETURNING_KEYWORD) {
         let cleaned = sql[..pos].trim_end().to_string();
         let columns_str = sql[pos + RETURNING_KEYWORD.len()..].trim();
         let spec = parse_returning_columns(columns_str)?;
@@ -77,8 +78,7 @@ fn parse_returning_columns(columns_str: &str) -> Result<ReturningSpec, Error> {
         }
 
         // Parse `name [AS alias]` — case-insensitive AS.
-        let upper_item = item.to_uppercase();
-        if let Some(as_pos) = find_word_boundary(&upper_item, "AS") {
+        if let Some(as_pos) = find_ascii_keyword(item, "AS") {
             let name = item[..as_pos].trim().to_string();
             let alias = item[as_pos + 2..].trim().to_string();
             if name.is_empty() || alias.is_empty() {
@@ -153,77 +153,6 @@ fn is_valid_column_name(name: &str) -> bool {
     }
     name.chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
-}
-
-/// Whether `b` can appear inside a SQL identifier (letter, digit, or `_`).
-///
-/// Underscore is an identifier character, so a keyword match must NOT treat a
-/// neighbouring `_` as a word boundary — otherwise `RETURNING` is falsely found
-/// inside an identifier such as `orders_returning`, splitting the statement at
-/// the wrong place.
-fn is_ident_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
-}
-
-/// Find the byte offset of `word` in `upper_text` respecting word boundaries.
-fn find_word_boundary(upper_text: &str, word: &str) -> Option<usize> {
-    let bytes = upper_text.as_bytes();
-    let wbytes = word.as_bytes();
-    let wlen = wbytes.len();
-
-    let mut i = 0;
-    while i + wlen <= bytes.len() {
-        if &bytes[i..i + wlen] == wbytes {
-            let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
-            let after_ok = i + wlen >= bytes.len() || !is_ident_byte(bytes[i + wlen]);
-            if before_ok && after_ok {
-                return Some(i);
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Find the byte offset of the RETURNING keyword in uppercased SQL.
-///
-/// Skips occurrences inside string literals (single-quoted).
-fn find_returning_keyword(upper: &str) -> Option<usize> {
-    let bytes = upper.as_bytes();
-    let keyword = RETURNING_KEYWORD.as_bytes();
-    let kw_len = keyword.len();
-
-    if bytes.len() < kw_len {
-        return None;
-    }
-
-    let mut in_string = false;
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if bytes[i] == b'\'' {
-            in_string = !in_string;
-            i += 1;
-            continue;
-        }
-
-        if in_string {
-            i += 1;
-            continue;
-        }
-
-        if i + kw_len <= bytes.len()
-            && &bytes[i..i + kw_len] == keyword
-            && (i == 0 || !is_ident_byte(bytes[i - 1]))
-            && (i + kw_len >= bytes.len() || !is_ident_byte(bytes[i + kw_len]))
-        {
-            return Some(i);
-        }
-
-        i += 1;
-    }
-
-    None
 }
 
 #[cfg(test)]
@@ -338,6 +267,25 @@ mod tests {
             ReturningColumns::Named(vec![ReturningItem {
                 name: "id".into(),
                 alias: None
+            }])
+        );
+    }
+
+    #[test]
+    fn unicode_identifier_before_returning_preserves_original_offsets() {
+        let (sql, spec) = strip_returning("DELETE FROM tﬀﬀ RETURNING *").unwrap();
+        assert_eq!(sql, "DELETE FROM tﬀﬀ");
+        assert_eq!(spec.unwrap().columns, ReturningColumns::Star);
+    }
+
+    #[test]
+    fn unicode_returning_column_before_alias_preserves_original_offsets() {
+        let (_, spec) = strip_returning("UPDATE t SET x = 1 RETURNING ﬀﬀ AS alias").unwrap();
+        assert_eq!(
+            spec.unwrap().columns,
+            ReturningColumns::Named(vec![ReturningItem {
+                name: "ﬀﬀ".into(),
+                alias: Some("alias".into()),
             }])
         );
     }

--- a/nodedb/src/control/server/pgwire/handler/routing/check_enforcement.rs
+++ b/nodedb/src/control/server/pgwire/handler/routing/check_enforcement.rs
@@ -9,6 +9,9 @@
 use nodedb_types::DatabaseId;
 use std::collections::HashMap;
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 
 use crate::types::TenantId;
@@ -161,10 +164,10 @@ impl NodeDbPgHandler {
 
 /// Extract column/value pairs from `INSERT INTO x (col1, col2) VALUES (val1, val2)`.
 fn extract_insert_fields(sql: &str) -> Result<HashMap<String, nodedb_types::Value>, String> {
-    let upper = sql.to_uppercase();
-    let cols_start = sql
-        .find('(')
-        .ok_or_else(|| format!("missing '(' in INSERT: {}", &sql[..sql.len().min(60)]))?;
+    let cols_start = sql.find('(').ok_or_else(|| {
+        let preview: String = sql.chars().take(60).collect();
+        format!("missing '(' in INSERT: {preview}")
+    })?;
     let cols_end = sql[cols_start + 1..]
         .find(')')
         .map(|p| cols_start + 1 + p)
@@ -174,8 +177,7 @@ fn extract_insert_fields(sql: &str) -> Result<HashMap<String, nodedb_types::Valu
         .map(|s| s.trim())
         .collect();
 
-    let values_pos = upper
-        .find("VALUES")
+    let values_pos = find_ascii_case_insensitive(sql, "VALUES")
         .ok_or_else(|| "missing VALUES keyword in INSERT".to_string())?
         + 6;
     let vals_start = sql[values_pos..]
@@ -217,17 +219,11 @@ fn extract_insert_fields(sql: &str) -> Result<HashMap<String, nodedb_types::Valu
 
 /// Extract column/value pairs from `UPDATE x SET col1 = val1, col2 = val2 WHERE ...`.
 fn extract_update_fields(sql: &str) -> Result<HashMap<String, nodedb_types::Value>, String> {
-    let upper = sql.to_uppercase();
-
-    let set_pos = upper
-        .find(" SET ")
+    let set_pos = find_ascii_case_insensitive(sql, " SET ")
         .ok_or_else(|| "missing SET keyword in UPDATE".to_string())?
         + 5;
 
-    let where_pos = upper[set_pos..]
-        .find(" WHERE ")
-        .map(|p| set_pos + p)
-        .unwrap_or(sql.len());
+    let where_pos = find_ascii_case_insensitive_from(sql, " WHERE ", set_pos).unwrap_or(sql.len());
     let assignments_str = &sql[set_pos..where_pos];
 
     let mut fields = HashMap::new();
@@ -252,16 +248,12 @@ fn extract_update_fields(sql: &str) -> Result<HashMap<String, nodedb_types::Valu
 ///
 /// Only matches standalone `id` with word boundaries — `userid`, `order_id` etc. won't match.
 fn extract_where_id(sql: &str) -> Option<String> {
-    let upper = sql.to_uppercase();
-    let where_pos = upper.find(" WHERE ")?;
+    let where_pos = find_ascii_case_insensitive(sql, " WHERE ")?;
     let after = &sql[where_pos + 7..];
-    let upper_after = after.to_uppercase();
-
     // Find standalone "ID" with word boundary checks.
     let mut search_start = 0;
     loop {
-        let id_pos = upper_after[search_start..].find("ID")?;
-        let abs_pos = search_start + id_pos;
+        let abs_pos = find_ascii_case_insensitive_from(after, "ID", search_start)?;
 
         // Check word boundary before: must be start or non-alphanumeric/underscore.
         if abs_pos > 0 {
@@ -387,6 +379,12 @@ mod tests {
     }
 
     #[test]
+    fn extract_where_id_after_unicode_value_preserves_original_offsets() {
+        let sql = "UPDATE orders SET note = 'ǰ' WHERE id = 'o1'";
+        assert_eq!(extract_where_id(sql), Some("o1".to_string()));
+    }
+
+    #[test]
     fn extract_insert_fields_basic() {
         let fields = extract_insert_fields("INSERT INTO t (a, b) VALUES ('hello', 42)").unwrap();
         assert_eq!(
@@ -403,6 +401,19 @@ mod tests {
     }
 
     #[test]
+    fn extract_insert_fields_with_unicode_before_values_preserves_original_offsets() {
+        let fields = extract_insert_fields("INSERT INTO tﬀﬀ (a) VALUES (42)").unwrap();
+        assert_eq!(fields.get("a"), Some(&nodedb_types::Value::Integer(42)));
+    }
+
+    #[test]
+    fn malformed_insert_preview_respects_utf8_boundaries() {
+        let sql = format!("INSERT INTO {}é no_parens", "a".repeat(47));
+        assert_eq!(sql.find('é'), Some(59));
+        assert!(extract_insert_fields(&sql).is_err());
+    }
+
+    #[test]
     fn extract_update_fields_basic() {
         let fields = extract_update_fields("UPDATE t SET x = 10, y = 'hi' WHERE id = '1'").unwrap();
         assert_eq!(fields.get("x"), Some(&nodedb_types::Value::Integer(10)));
@@ -410,5 +421,11 @@ mod tests {
             fields.get("y"),
             Some(&nodedb_types::Value::String("hi".into()))
         );
+    }
+
+    #[test]
+    fn extract_update_fields_with_unicode_before_set_preserves_original_offsets() {
+        let fields = extract_update_fields("UPDATE tǰ SET x = 10 WHERE id = '1'").unwrap();
+        assert_eq!(fields.get("x"), Some(&nodedb_types::Value::Integer(10)));
     }
 }

--- a/nodedb/src/control/server/pgwire/handler/sql_exec.rs
+++ b/nodedb/src/control/server/pgwire/handler/sql_exec.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use pgwire::api::results::{DataRowEncoder, QueryResponse, Response, Tag};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 
@@ -116,7 +117,7 @@ impl NodeDbPgHandler {
             let with_hold = upper.contains(" WITH HOLD ");
             let parts: Vec<&str> = sql_trimmed.split_whitespace().collect();
             let cursor_name = parts.get(1).unwrap_or(&"default").to_string();
-            if let Some(for_pos) = upper.find(" FOR ") {
+            if let Some(for_pos) = find_ascii_case_insensitive(sql_trimmed, " FOR ") {
                 let inner_sql = sql_trimmed[for_pos + 5..].trim();
                 match self
                     .execute_query_for_cursor(addr, inner_sql, identity)

--- a/nodedb/src/control/server/pgwire/handler/sql_prepared.rs
+++ b/nodedb/src/control/server/pgwire/handler/sql_prepared.rs
@@ -11,6 +11,7 @@
 //!   DEALLOCATE name
 //!   DEALLOCATE ALL
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use pgwire::api::results::{Response, Tag};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 
@@ -144,8 +145,7 @@ fn parse_prepare_statement(sql: &str) -> PgWireResult<(String, Vec<String>, Stri
     let rest = trimmed[8..].trim(); // skip "PREPARE "
 
     // Find the AS keyword (case-insensitive).
-    let upper_rest = rest.to_uppercase();
-    let as_pos = upper_rest.find(" AS ").ok_or_else(|| {
+    let as_pos = find_ascii_case_insensitive(rest, " AS ").ok_or_else(|| {
         PgWireError::UserError(Box::new(ErrorInfo::new(
             "ERROR".to_owned(),
             "42601".to_owned(),
@@ -329,6 +329,14 @@ mod tests {
         assert_eq!(name, "get_user");
         assert_eq!(types, vec!["BIGINT", "TEXT"]);
         assert_eq!(body, "SELECT * FROM users WHERE id = $1 AND name = $2");
+    }
+
+    #[test]
+    fn parse_prepare_with_unicode_name_preserves_original_offsets() {
+        let (name, types, body) = parse_prepare_statement("PREPARE nﬀﬀ AS SELECT 1").unwrap();
+        assert_eq!(name, "nﬀﬀ");
+        assert!(types.is_empty());
+        assert_eq!(body, "SELECT 1");
     }
 
     #[test]

--- a/nodedb/src/control/server/session_auth/context.rs
+++ b/nodedb/src/control/server/session_auth/context.rs
@@ -3,6 +3,8 @@
 //! `AuthContext` construction, scope enrichment, and per-query `ON DENY`
 //! extraction.
 
+use nodedb_sql::parser::preprocess::lex::rfind_ascii_case_insensitive;
+
 use crate::control::security::auth_context::{AuthContext, generate_session_id};
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::security::util::base64_url_decode;
@@ -112,16 +114,19 @@ pub fn extract_and_apply_on_deny(
     sql: &str,
     auth_ctx: &mut crate::control::security::auth_context::AuthContext,
 ) -> String {
-    // Use lowercase for case-insensitive search to avoid byte-length mismatches
-    // with non-ASCII characters under Unicode case folding.
-    let lower = sql.to_lowercase();
-    let Some(idx) = lower.rfind("on deny ") else {
+    let Some(idx) = rfind_ascii_case_insensitive(sql, "on deny ") else {
         return sql.to_string();
     };
 
     // Only strip ON DENY from SELECT/WITH queries (not CREATE RLS POLICY).
-    let trimmed = lower.trim_start();
-    if !trimmed.starts_with("select") && !trimmed.starts_with("with") {
+    let trimmed = sql.trim_start();
+    if !trimmed
+        .get(.."select".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("select"))
+        && !trimmed
+            .get(.."with".len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("with"))
+    {
         return sql.to_string();
     }
 

--- a/nodedb/src/control/server/shared/check_constraint/simple.rs
+++ b/nodedb/src/control/server/shared/check_constraint/simple.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use crate::control::security::catalog::types::CheckConstraintDef;
 use crate::control::server::shared::ddl::result::DdlError;
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive_from;
 
 use super::enforce::ddl_err;
 
@@ -155,12 +156,23 @@ fn replace_remaining_new_refs(text: &str) -> String {
 
 /// Replace all occurrences of `pattern` in `text` case-insensitively.
 fn replace_case_insensitive(text: &str, pattern: &str, replacement: &str) -> String {
-    let upper_text = text.to_uppercase();
-    let upper_pattern = pattern.to_uppercase();
-    let mut result = String::with_capacity(text.len());
-    let mut last_end = 0;
+    if pattern.is_empty() {
+        return text.to_string();
+    }
 
-    for (start, _) in upper_text.match_indices(&upper_pattern) {
+    let mut result = String::with_capacity(text.len());
+    let mut search_from = 0;
+    let mut copied_until = 0;
+    while let Some(start) = if pattern.is_ascii() {
+        find_ascii_case_insensitive_from(text, pattern, search_from)
+    } else {
+        text[search_from..]
+            .find(pattern)
+            .map(|position| search_from + position)
+    } {
+        let end = start + pattern.len();
+        search_from = end;
+
         // Verify word boundary: the char before must not be alphanumeric/underscore.
         if start > 0 {
             let prev = text.as_bytes()[start - 1];
@@ -169,7 +181,6 @@ fn replace_case_insensitive(text: &str, pattern: &str, replacement: &str) -> Str
             }
         }
         // The char after must not be alphanumeric/underscore.
-        let end = start + pattern.len();
         if end < text.len() {
             let next = text.as_bytes()[end];
             if next.is_ascii_alphanumeric() || next == b'_' {
@@ -177,11 +188,11 @@ fn replace_case_insensitive(text: &str, pattern: &str, replacement: &str) -> Str
             }
         }
 
-        result.push_str(&text[last_end..start]);
+        result.push_str(&text[copied_until..start]);
         result.push_str(replacement);
-        last_end = end;
+        copied_until = end;
     }
-    result.push_str(&text[last_end..]);
+    result.push_str(&text[copied_until..]);
     result
 }
 
@@ -220,6 +231,15 @@ mod tests {
         let sql = "NEW.email LIKE '%@%.%' AND NEW.age >= 18";
         let result = substitute_new_refs(sql, &fields);
         assert_eq!(result, "'alice@example.com' LIKE '%@%.%' AND 25 >= 18");
+    }
+
+    #[test]
+    fn substitute_new_refs_after_expanding_unicode_preserves_original_offsets() {
+        let mut fields = HashMap::new();
+        fields.insert("id".to_string(), nodedb_types::Value::Integer(7));
+
+        let result = substitute_new_refs("'ﬀﬀ' = 'ﬀﬀ' AND NEW.id = 7", &fields);
+        assert_eq!(result, "'ﬀﬀ' = 'ﬀﬀ' AND 7 = 7");
     }
 
     #[test]

--- a/nodedb/src/control/server/shared/check_constraint/subquery.rs
+++ b/nodedb/src/control/server/shared/check_constraint/subquery.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashMap;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::control::security::catalog::types::CheckConstraintDef;
 use crate::control::server::shared::ddl::result::DdlError;
 use crate::control::state::SharedState;
@@ -140,16 +142,15 @@ struct RestructuredCheck {
 /// - `'val' IN (SELECT col FROM tbl ...)` → COUNT > 0 means pass
 /// - `'val' NOT IN (SELECT col FROM tbl ...)` → COUNT = 0 means pass
 fn restructure_subquery_check(expr: &str) -> RestructuredCheck {
-    let upper = expr.to_uppercase();
-
     // Detect NOT IN vs IN.
-    let (in_pos, negate) = if let Some(pos) = upper.find(" NOT IN (SELECT ") {
+    let (in_pos, negate) = if let Some(pos) = find_ascii_case_insensitive(expr, " NOT IN (SELECT ")
+    {
         (pos, true)
-    } else if let Some(pos) = upper.find(" NOT IN(SELECT ") {
+    } else if let Some(pos) = find_ascii_case_insensitive(expr, " NOT IN(SELECT ") {
         (pos, true)
-    } else if let Some(pos) = upper.find(" IN (SELECT ") {
+    } else if let Some(pos) = find_ascii_case_insensitive(expr, " IN (SELECT ") {
         (pos, false)
-    } else if let Some(pos) = upper.find(" IN(SELECT ") {
+    } else if let Some(pos) = find_ascii_case_insensitive(expr, " IN(SELECT ") {
         (pos, false)
     } else {
         // Should not reach here — validated at DDL time.
@@ -164,14 +165,15 @@ fn restructure_subquery_check(expr: &str) -> RestructuredCheck {
     let select_part = &expr[in_pos + keyword_len.len()..];
     let inner = select_part.trim().trim_end_matches(')').trim();
 
-    if let Some(from_pos) = inner.to_uppercase().find(" FROM ") {
+    if let Some(from_pos) = find_ascii_case_insensitive(inner, " FROM ") {
         let col = inner["SELECT ".len()..from_pos].trim();
         let after_from = &inner[from_pos + 6..];
-        let (table, existing_where) = if let Some(w) = after_from.to_uppercase().find(" WHERE ") {
-            (&after_from[..w], Some(&after_from[w + 7..]))
-        } else {
-            (after_from.trim(), None)
-        };
+        let (table, existing_where) =
+            if let Some(w) = find_ascii_case_insensitive(after_from, " WHERE ") {
+                (&after_from[..w], Some(&after_from[w + 7..]))
+            } else {
+                (after_from.trim(), None)
+            };
 
         let sql = if let Some(where_clause) = existing_where {
             format!(

--- a/nodedb/src/control/server/shared/ddl/neutral/chunk_text.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/chunk_text.rs
@@ -7,6 +7,7 @@
 //! per chunk. The handler builds [`DdlResult`] directly and carries no pgwire
 //! types.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::control::server::response_shape::types::{DdlColType, ShapedRows};
@@ -19,9 +20,7 @@ use super::super::result::{DdlError, DdlResult};
 /// delegates to `nodedb_query::chunk_text`, and returns a shaped result set.
 pub fn execute_chunk_text(sql: &str) -> Result<Vec<DdlResult>, DdlError> {
     // Extract the parenthesized args from NDB_CHUNK_TEXT(...).
-    let upper = sql.to_uppercase();
-    let fn_pos = upper
-        .find("NDB_CHUNK_TEXT(")
+    let fn_pos = find_ascii_case_insensitive(sql, "NDB_CHUNK_TEXT(")
         .ok_or_else(|| err("42601", "expected NDB_CHUNK_TEXT(...)"))?;
     let paren_start = fn_pos
         + sql[fn_pos..]

--- a/nodedb/src/control/server/shared/ddl/neutral/collection/create/engine_option/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/collection/create/engine_option/parse.rs
@@ -8,6 +8,8 @@
 //! exactly as it was on the pgwire side; only the error envelope changed from
 //! `PgWireResult` to `Result<_, DdlError>`.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use super::super::super::super::super::result::DdlError;
 use super::validate::canonical_list;
 
@@ -171,9 +173,7 @@ pub fn parse_engine_option(sql: &str, upper: &str) -> Result<Option<&'static str
 ///
 /// Duplicated from `collection::helpers` to avoid `pub(super)` visibility reach.
 fn extract_with_value(sql: &str, key: &str) -> Option<String> {
-    let upper = sql.to_uppercase();
-    let key_upper = key.to_uppercase();
-    let pos = upper.find(&key_upper)?;
+    let pos = find_ascii_case_insensitive(sql, key)?;
     let after = sql[pos + key.len()..].trim_start();
     let after = after.strip_prefix('=')?;
     let after = after.trim_start();

--- a/nodedb/src/control/server/shared/ddl/neutral/collection/dml/parse/statement.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/collection/dml/parse/statement.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::server::shared::ddl::result::DdlError;
 use crate::control::server::shared::ddl::sql_parse::{parse_sql_value, split_values};
@@ -21,8 +23,7 @@ pub(in crate::control::server::shared::ddl::neutral::collection) fn parse_write_
     sql: &str,
     keyword: &str,
 ) -> Option<Result<ParsedInsert, DdlError>> {
-    let upper = sql.to_uppercase();
-    let kw_pos = upper.find(keyword)?;
+    let kw_pos = find_ascii_case_insensitive(sql, keyword)?;
     let after_into = sql[kw_pos + keyword.len()..].trim_start();
     let coll_name_str = after_into.split_whitespace().next()?;
     let coll_name = coll_name_str.to_lowercase();
@@ -53,15 +54,8 @@ pub(in crate::control::server::shared::ddl::neutral::collection) fn parse_write_
     if after_coll_name.starts_with('{') || after_coll_name.starts_with('[') {
         if let Ok(Some(preprocessed)) = nodedb_sql::parser::preprocess::preprocess(sql) {
             let rewritten = preprocessed.sql;
-            let rewritten_upper = rewritten.to_uppercase();
             // The preprocessed SQL is always INSERT INTO regardless of original keyword.
-            return parse_values_form(
-                &rewritten,
-                &rewritten_upper,
-                "INSERT INTO ",
-                &coll_name,
-                coll_type,
-            );
+            return parse_values_form(&rewritten, "INSERT INTO ", &coll_name, coll_type);
         }
         return Some(Err(ddl_err(
             "42601",
@@ -69,13 +63,12 @@ pub(in crate::control::server::shared::ddl::neutral::collection) fn parse_write_
         )));
     }
 
-    parse_values_form(sql, &upper, keyword, &coll_name, coll_type)
+    parse_values_form(sql, keyword, &coll_name, coll_type)
 }
 
 /// Parse the `(cols) VALUES (vals)` form.
 fn parse_values_form(
     sql: &str,
-    upper: &str,
     keyword: &str,
     coll_name: &str,
     coll_type: Option<nodedb_types::CollectionType>,
@@ -89,7 +82,7 @@ fn parse_values_form(
             )));
         }
     };
-    let values_kw = match upper.find("VALUES") {
+    let values_kw = match find_ascii_case_insensitive(sql, "VALUES") {
         Some(p) => p,
         None => return Some(Err(ddl_err("42601", "missing VALUES clause"))),
     };
@@ -147,7 +140,24 @@ fn parse_values_form(
         coll_name: coll_name.to_string(),
         doc_id,
         fields,
-        has_returning: upper.contains("RETURNING"),
+        has_returning: find_ascii_case_insensitive(sql, "RETURNING").is_some(),
         collection_type: coll_type,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn values_keyword_after_unicode_identifier_preserves_original_offsets() {
+        let sql = "INSERT INTO tﬀﬀ (a) VALUES (42)";
+        let parsed = parse_values_form(sql, "INSERT INTO ", "tﬀﬀ", None)
+            .expect("statement should be recognized")
+            .expect("statement should parse");
+        assert_eq!(
+            parsed.fields.get("a"),
+            Some(&nodedb_types::Value::Integer(42))
+        );
+    }
 }

--- a/nodedb/src/control/server/shared/ddl/neutral/collection/helpers.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/collection/helpers.rs
@@ -5,6 +5,9 @@
 //! Relocated verbatim from the pgwire `ddl::collection::helpers` module (now
 //! deleted): its sole external caller was already `neutral::collection::alter::add_column`.
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
 use sonic_rs;
 
 /// Parse a single column definition: `name TYPE [NOT NULL] [PRIMARY KEY] [DEFAULT expr]`
@@ -31,13 +34,13 @@ pub(crate) fn parse_origin_column_def(s: &str) -> crate::Result<nodedb_types::co
         " TIME_KEY",
         " SPATIAL_INDEX",
     ];
+    let type_start = tokens[0].len();
     let type_end = keywords
         .iter()
-        .filter_map(|kw| upper[name.len()..].find(kw))
+        .filter_map(|kw| find_ascii_case_insensitive_from(s, kw, type_start))
         .min()
-        .map(|p| p + name.len())
         .unwrap_or(s.len());
-    let type_str = s[name.len()..type_end].trim();
+    let type_str = s[type_start..type_end].trim();
 
     let column_type: ColumnType =
         type_str
@@ -52,11 +55,11 @@ pub(crate) fn parse_origin_column_def(s: &str) -> crate::Result<nodedb_types::co
     let is_pk = upper.contains("PRIMARY KEY");
     let nullable = !is_not_null && !is_pk;
 
-    let default = if let Some(pos) = upper.find("DEFAULT ") {
+    let default = if let Some(pos) = find_ascii_case_insensitive(s, "DEFAULT ") {
         let after_default = s[pos + 8..].trim();
         let end = keywords
             .iter()
-            .filter_map(|kw| after_default.to_uppercase().find(kw))
+            .filter_map(|kw| find_ascii_case_insensitive(after_default, kw))
             .min()
             .unwrap_or(after_default.len());
         let expr = after_default[..end].trim();
@@ -88,7 +91,7 @@ pub(crate) fn parse_origin_column_def(s: &str) -> crate::Result<nodedb_types::co
         } else {
             "GENERATED AS"
         };
-        if let Some(gen_pos) = upper.find(gen_kw) {
+        if let Some(gen_pos) = find_ascii_case_insensitive(s, gen_kw) {
             let after_gen = s[gen_pos + gen_kw.len()..].trim();
             // Extract parenthesized expression.
             if after_gen.starts_with('(') {

--- a/nodedb/src/control/server/shared/ddl/neutral/collection/vector_metadata.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/collection/vector_metadata.rs
@@ -15,6 +15,7 @@
 //! SQLSTATE codes / messages, and the `ALTER COLLECTION` command tag are
 //! unchanged.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use nodedb_types::DatabaseId;
 use serde_json::{Map, Value as JsonValue};
 
@@ -51,11 +52,8 @@ pub fn handle_set_vector_metadata(
     }
 
     let collection = parts[2].to_lowercase();
-    let upper = sql.to_uppercase();
-
     // Find column name after " ON " (the second ON after "METADATA ON").
-    let metadata_on_pos = upper
-        .find("METADATA ON ")
+    let metadata_on_pos = find_ascii_case_insensitive(sql, "METADATA ON ")
         .ok_or_else(|| err("42601", "expected METADATA ON <column>"))?;
     let after_on = sql[metadata_on_pos + "METADATA ON ".len()..].trim();
     let column = after_on

--- a/nodedb/src/control/server/shared/ddl/neutral/constraint/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/constraint/parse.rs
@@ -5,6 +5,10 @@
 //! Ported verbatim from the pgwire `ddl::constraint::parse`; only the error type
 //! changed from pgwire `PgWireError` to the protocol-neutral [`DdlError`].
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
+
 use crate::control::security::catalog::types::TransitionRule;
 use crate::control::server::shared::ddl::result::DdlError;
 
@@ -101,9 +105,7 @@ pub(super) fn extract_parenthesized_predicate(sql: &str) -> Result<String, DdlEr
 /// Finds `keyword` in `sql`, then extracts the content between the next `(` and
 /// its matching `)`, respecting nesting.
 pub(super) fn extract_check_body(sql: &str, keyword: &str) -> Result<String, DdlError> {
-    let upper = sql.to_uppercase();
-    let kw_pos = upper
-        .find(keyword)
+    let kw_pos = find_ascii_case_insensitive(sql, keyword)
         .ok_or_else(|| err("42601", &format!("missing {keyword} keyword")))?;
     let after = &sql[kw_pos + keyword.len()..];
 
@@ -270,21 +272,16 @@ fn parse_value_ref(s: &str) -> Result<crate::bridge::expr_eval::SqlExpr, DdlErro
 
 /// Split a string at the top-level occurrence of `sep` (respecting parentheses).
 fn split_top_level<'a>(s: &'a str, sep: &str) -> Option<(&'a str, &'a str)> {
-    let upper = s.to_uppercase();
     let mut depth = 0i32;
-    let sep_upper = sep.to_uppercase();
-    let mut i = 0;
-    while i < upper.len() {
-        let ch = upper.as_bytes()[i];
+    for (i, ch) in s.char_indices() {
         match ch {
-            b'(' => depth += 1,
-            b')' => depth -= 1,
+            '(' => depth += 1,
+            ')' => depth -= 1,
             _ => {}
         }
-        if depth == 0 && upper[i..].starts_with(&sep_upper) {
+        if depth == 0 && find_ascii_case_insensitive_from(s, sep, i) == Some(i) {
             return Some((&s[..i], &s[i + sep.len()..]));
         }
-        i += 1;
     }
     None
 }
@@ -315,4 +312,29 @@ fn split_on_operator<'a>(s: &'a str, op: &str) -> Option<(&'a str, &'a str)> {
         return Some((&s[..abs_pos], &s[abs_pos + op.len()..]));
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge::expr_eval::{BinaryOp, SqlExpr};
+
+    #[test]
+    fn logical_separator_after_expanding_unicode_preserves_original_offsets() {
+        let expr = parse_transition_predicate("OLD.ﬀﬀ = TRUE AND OLD.x = TRUE")
+            .expect("transition predicate should parse");
+        assert!(matches!(
+            expr,
+            SqlExpr::BinaryOp {
+                op: BinaryOp::And,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn non_ascii_predicate_does_not_index_inside_utf8() {
+        parse_transition_predicate("OLD.é = TRUE")
+            .expect("non-ASCII transition predicate should parse");
+    }
 }

--- a/nodedb/src/control/server/shared/ddl/neutral/constraint/show.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/constraint/show.rs
@@ -7,6 +7,7 @@
 //! `QueryResponse` (4 text columns via `DataRowEncoder`) to a protocol-neutral
 //! [`DdlResult::Rows`] carrying the same four text columns.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use nodedb_types::DatabaseId;
 use serde_json::{Map, Value as JsonValue};
 
@@ -128,9 +129,7 @@ fn constraint_row(name: &str, kind: &str, field: &str, detail: &str) -> Map<Stri
 
 /// Extract collection name from `SHOW CONSTRAINTS ON <collection>`.
 fn extract_collection_after_on(sql: &str) -> Result<String, DdlError> {
-    let upper = sql.to_uppercase();
-    let on_pos = upper
-        .find(" ON ")
+    let on_pos = find_ascii_case_insensitive(sql, " ON ")
         .ok_or_else(|| err("42601", "SHOW CONSTRAINTS requires ON <collection>"))?;
     let after = sql[on_pos + 4..].trim();
     let end = after

--- a/nodedb/src/control/server/shared/ddl/neutral/continuous_agg/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/continuous_agg/parse.rs
@@ -7,6 +7,10 @@
 //! preserved verbatim; only the error type changed from pgwire
 //! `PgWireError` (via `sqlstate_error`) to the protocol-neutral [`DdlError`].
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from, rfind_ascii_case_insensitive,
+};
+
 use crate::engine::timeseries::continuous_agg::{
     AggFunction, AggregateExpr, ContinuousAggregateDef, RefreshPolicy,
 };
@@ -41,8 +45,7 @@ pub(super) fn parse_create_sql(sql: &str) -> Result<ContinuousAggregateDef, DdlE
     let upper = sql.to_uppercase();
 
     // Extract name: word after "CONTINUOUS AGGREGATE"
-    let ca_pos = upper
-        .find(KW_CONTINUOUS_AGGREGATE)
+    let ca_pos = find_ascii_case_insensitive(sql, KW_CONTINUOUS_AGGREGATE)
         .ok_or_else(|| err("42601", "expected CONTINUOUS AGGREGATE keyword".to_string()))?;
     let after_ca_start = ca_pos + KW_CONTINUOUS_AGGREGATE.len();
     let after_ca = sql[after_ca_start..].trim_start();
@@ -53,10 +56,9 @@ pub(super) fn parse_create_sql(sql: &str) -> Result<ContinuousAggregateDef, DdlE
         .to_lowercase();
 
     // Extract source: word after "ON"
-    let on_pos = upper[after_ca_start..]
-        .find(KW_ON)
+    let on_pos = find_ascii_case_insensitive_from(sql, KW_ON, after_ca_start)
         .ok_or_else(|| err("42601", "expected ON <source> clause".to_string()))?;
-    let after_on_start = after_ca_start + on_pos + KW_ON.len();
+    let after_on_start = on_pos + KW_ON.len();
     let after_on = sql[after_on_start..].trim_start();
     let source = after_on
         .split_whitespace()
@@ -105,8 +107,8 @@ pub(super) fn parse_create_sql(sql: &str) -> Result<ContinuousAggregateDef, DdlE
 }
 
 /// Extract a quoted value after a keyword: `KEYWORD 'value'`.
-pub(super) fn extract_quoted_value(upper: &str, sql: &str, keyword: &str) -> Option<String> {
-    let pos = upper.find(keyword)?;
+pub(super) fn extract_quoted_value(_upper: &str, sql: &str, keyword: &str) -> Option<String> {
+    let pos = find_ascii_case_insensitive(sql, keyword)?;
     let after = sql[pos + keyword.len()..].trim_start();
     let start = after.find('\'')?;
     let end = after[start + 1..].find('\'')?;
@@ -116,24 +118,24 @@ pub(super) fn extract_quoted_value(upper: &str, sql: &str, keyword: &str) -> Opt
 /// Extract aggregate expressions from AGGREGATE clause.
 ///
 /// Parses: `AGGREGATE sum(value) AS value_sum, count(*) AS row_count, avg(cpu)`
-fn extract_aggregates(upper: &str, sql: &str) -> Result<Vec<AggregateExpr>, DdlError> {
+fn extract_aggregates(_upper: &str, sql: &str) -> Result<Vec<AggregateExpr>, DdlError> {
     // Find standalone AGGREGATE keyword. Skip past "CONTINUOUS AGGREGATE" by
     // searching after the BUCKET clause (which always precedes AGGREGATE).
-    let search_start = upper.find(KW_BUCKET).unwrap_or(0);
-    let agg_pos = match upper[search_start..].find(KW_AGGREGATE) {
-        Some(p) => search_start + p,
+    let search_start = find_ascii_case_insensitive(sql, KW_BUCKET).unwrap_or(0);
+    let agg_pos = match find_ascii_case_insensitive_from(sql, KW_AGGREGATE, search_start) {
+        Some(position) => position,
         None => return Ok(Vec::new()),
     };
-    let after_agg = &sql[agg_pos + KW_AGGREGATE.len()..];
+    let after_agg_start = agg_pos + KW_AGGREGATE.len();
 
     // Find end: GROUP BY, WITH, or end of string.
     let end_pos = [KW_GROUP_BY, "WITH (", "WITH("]
         .iter()
-        .filter_map(|kw| upper[agg_pos + KW_AGGREGATE.len()..].find(kw))
+        .filter_map(|kw| find_ascii_case_insensitive_from(sql, kw, after_agg_start))
         .min()
-        .unwrap_or(after_agg.len());
+        .unwrap_or(sql.len());
 
-    let agg_str = after_agg[..end_pos].trim().trim_end_matches(',');
+    let agg_str = sql[after_agg_start..end_pos].trim().trim_end_matches(',');
     let mut exprs = Vec::new();
 
     for part in agg_str.split(',') {
@@ -150,10 +152,8 @@ fn extract_aggregates(upper: &str, sql: &str) -> Result<Vec<AggregateExpr>, DdlE
 
 /// Parse a single aggregate expression: `func(col) [AS alias]`.
 fn parse_single_aggregate(s: &str) -> Result<AggregateExpr, DdlError> {
-    let upper = s.to_uppercase();
-
     // Split on AS for alias.
-    let (func_part, alias) = if let Some(as_pos) = upper.find(KW_AS) {
+    let (func_part, alias) = if let Some(as_pos) = find_ascii_case_insensitive(s, KW_AS) {
         (
             &s[..as_pos],
             Some(s[as_pos + KW_AS.len()..].trim().to_lowercase()),
@@ -204,21 +204,21 @@ fn parse_single_aggregate(s: &str) -> Result<AggregateExpr, DdlError> {
 }
 
 /// Extract GROUP BY columns.
-fn extract_group_by(upper: &str, sql: &str) -> Vec<String> {
-    let gb_pos = match upper.find(KW_GROUP_BY) {
+fn extract_group_by(_upper: &str, sql: &str) -> Vec<String> {
+    let gb_pos = match find_ascii_case_insensitive(sql, KW_GROUP_BY) {
         Some(p) => p,
         None => return Vec::new(),
     };
-    let after_gb = &sql[gb_pos + KW_GROUP_BY.len()..];
+    let after_gb_start = gb_pos + KW_GROUP_BY.len();
 
     // Find end: WITH or end of string.
     let end_pos = ["WITH (", "WITH("]
         .iter()
-        .filter_map(|kw| upper[gb_pos + KW_GROUP_BY.len()..].find(kw))
+        .filter_map(|kw| find_ascii_case_insensitive_from(sql, kw, after_gb_start))
         .min()
-        .unwrap_or(after_gb.len());
+        .unwrap_or(sql.len());
 
-    after_gb[..end_pos]
+    sql[after_gb_start..end_pos]
         .split(',')
         .map(|s| s.trim().to_lowercase())
         .filter(|s| !s.is_empty())
@@ -226,11 +226,11 @@ fn extract_group_by(upper: &str, sql: &str) -> Vec<String> {
 }
 
 /// Extract WITH options: refresh_policy and retention.
-pub(super) fn extract_with_options(upper: &str, sql: &str) -> (RefreshPolicy, u64) {
+pub(super) fn extract_with_options(_upper: &str, sql: &str) -> (RefreshPolicy, u64) {
     let mut refresh = RefreshPolicy::OnFlush;
     let mut retention_ms = 0u64;
 
-    let with_pos = match upper.rfind("WITH") {
+    let with_pos = match rfind_ascii_case_insensitive(sql, "WITH") {
         Some(p) => p,
         None => return (refresh, retention_ms),
     };

--- a/nodedb/src/control/server/shared/ddl/neutral/convert.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/convert.rs
@@ -15,6 +15,9 @@
 //! `Response` / `PgWireError` to the protocol-neutral [`DdlResult`] /
 //! [`DdlError`].
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
 use nodedb_types::DatabaseId;
 use std::time::Duration;
 
@@ -184,11 +187,8 @@ fn parse_convert_sql(
     ),
     DdlError,
 > {
-    let upper = sql.to_uppercase();
-
     // Extract collection name: CONVERT COLLECTION <name> TO ...
-    let coll_pos = upper
-        .find("COLLECTION ")
+    let coll_pos = find_ascii_case_insensitive(sql, "COLLECTION ")
         .ok_or_else(|| err("42601", "expected COLLECTION keyword"))?;
     let after_coll = sql[coll_pos + 11..].trim_start();
     let collection = after_coll
@@ -198,10 +198,9 @@ fn parse_convert_sql(
         .to_lowercase();
 
     // Extract target type: TO <type>
-    let to_pos = upper[coll_pos + 11..]
-        .find(" TO ")
+    let to_pos = find_ascii_case_insensitive_from(sql, " TO ", coll_pos + 11)
         .ok_or_else(|| err("42601", "expected TO <type> clause"))?;
-    let after_to = sql[coll_pos + 11 + to_pos + 4..].trim_start();
+    let after_to = sql[to_pos + 4..].trim_start();
     let target_type = after_to
         .split_whitespace()
         .next()

--- a/nodedb/src/control/server/shared/ddl/neutral/dsl/search_index.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/dsl/search_index.rs
@@ -7,6 +7,7 @@ use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
 use crate::types::{DatabaseId, TraceId};
 use nodedb_physical::physical_plan::TextOp;
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 
 use super::super::super::result::{DdlError, DdlResult};
 use super::support::ddl_err;
@@ -26,16 +27,14 @@ pub async fn create_search_index(
     identity: &AuthenticatedIdentity,
     sql: &str,
 ) -> Result<Vec<DdlResult>, DdlError> {
-    let upper = sql.to_uppercase();
-
-    let on_pos = upper.find(" ON ").ok_or_else(|| {
+    let on_pos = find_ascii_case_insensitive(sql, " ON ").ok_or_else(|| {
         ddl_err(
             "42601",
             "syntax: CREATE SEARCH INDEX ON <collection> FIELDS <field> [ANALYZER 'name'] [FUZZY true]",
         )
     })?;
     let after_on = sql[on_pos + 4..].trim_start();
-    let fields_pos = upper.find(" FIELDS ").ok_or_else(|| {
+    let fields_pos = find_ascii_case_insensitive(sql, " FIELDS ").ok_or_else(|| {
         ddl_err(
             "42601",
             "syntax: CREATE SEARCH INDEX ON <collection> FIELDS <field> [ANALYZER 'name'] [FUZZY true]",
@@ -48,9 +47,9 @@ pub async fn create_search_index(
     }
 
     let after_fields = &sql[fields_pos + 8..];
-    let analyzer_pos = upper[fields_pos + 8..].find(" ANALYZER ");
+    let analyzer_pos = find_ascii_case_insensitive(after_fields, " ANALYZER ");
     let fields_end = analyzer_pos
-        .or_else(|| upper[fields_pos + 8..].find(" FUZZY "))
+        .or_else(|| find_ascii_case_insensitive(after_fields, " FUZZY "))
         .unwrap_or(after_fields.len());
     let fields_str = after_fields[..fields_end].trim();
     let fields: Vec<&str> = fields_str.split(',').map(|s| s.trim()).collect();

--- a/nodedb/src/control/server/shared/ddl/neutral/function/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/function/parse.rs
@@ -12,6 +12,7 @@
 //! self-contained.
 
 use arrow::datatypes::DataType;
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 
 use crate::control::security::catalog::FunctionParam;
 
@@ -193,7 +194,7 @@ pub(super) fn parse_function_header(
     let after_returns_upper = after_returns.to_uppercase();
     let mut earliest = after_returns.len();
     for term in terminators {
-        if let Some(pos) = after_returns_upper.find(term) {
+        if let Some(pos) = find_ascii_case_insensitive(after_returns, term) {
             earliest = earliest.min(pos);
         }
         // Handle keyword at end of string (no trailing space).

--- a/nodedb/src/control/server/shared/ddl/neutral/function/wasm_aggregate.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/function/wasm_aggregate.rs
@@ -12,6 +12,8 @@
 use crate::control::planner::wasm;
 use crate::control::security::catalog::FunctionParam;
 use crate::control::security::catalog::function_types::*;
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
 
@@ -169,10 +171,8 @@ fn parse_aggregate_create(sql: &str) -> Result<ParsedAggregateCreate, DdlError> 
     }
     let after_returns = rest["RETURNS ".len()..].trim();
 
-    let lang_pos = after_returns
-        .to_uppercase()
-        .find("LANGUAGE")
-        .ok_or_else(|| DdlError {
+    let lang_pos =
+        find_ascii_case_insensitive(after_returns, "LANGUAGE").ok_or_else(|| DdlError {
             sqlstate: "42601".to_string(),
             message: "expected LANGUAGE WASM".to_string(),
         })?;

--- a/nodedb/src/control/server/shared/ddl/neutral/kv_sorted_index.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/kv_sorted_index.rs
@@ -13,6 +13,7 @@
 //!   SELECT * FROM RANGE(index_name, score_min, score_max)
 //!   SELECT COUNT(index_name)  -- when index_name is a sorted index
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::control::security::identity::AuthenticatedIdentity;
@@ -42,8 +43,7 @@ pub async fn create_sorted_index(
         .to_lowercase();
 
     // Extract collection name after ON.
-    let on_pos = upper
-        .find(" ON ")
+    let on_pos = find_ascii_case_insensitive(sql, " ON ")
         .ok_or_else(|| ddl_err("42601", "missing ON clause"))?;
     let after_on = sql[on_pos + 4..].trim();
     let collection = after_on

--- a/nodedb/src/control/server/shared/ddl/neutral/maintenance/vector_index.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/maintenance/vector_index.rs
@@ -14,6 +14,7 @@
 //! dispatch paths (`dispatch_to_data_plane`, plan construction, ordering) are
 //! preserved verbatim.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::bridge::envelope::PhysicalPlan;
@@ -206,8 +207,7 @@ pub async fn handle_alter_vector_index_set(
     let (collection, field_name) = parse_collection_column(sql, " ON ")?;
 
     // Parse SET (...) parameters.
-    let upper = sql.to_uppercase();
-    let set_pos = upper.find(" SET ").ok_or_else(|| {
+    let set_pos = find_ascii_case_insensitive(sql, " SET ").ok_or_else(|| {
         ddl_err(
             "42601",
             "ALTER VECTOR INDEX ... SET (...) requires SET clause",
@@ -380,9 +380,7 @@ pub async fn handle_alter_vector_index_set(
 ///
 /// Returns `(collection, field_name)`. If no dot, field_name is empty (default field).
 fn parse_collection_column(sql: &str, keyword: &str) -> Result<(String, String), DdlError> {
-    let upper = sql.to_uppercase();
-    let pos = upper
-        .find(keyword)
+    let pos = find_ascii_case_insensitive(sql, keyword)
         .ok_or_else(|| ddl_err("42601", format!("expected '{keyword}' in statement")))?;
 
     let after = sql[pos + keyword.len()..].trim();

--- a/nodedb/src/control/server/shared/ddl/neutral/materialized_view/streaming_parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/materialized_view/streaming_parse.rs
@@ -11,6 +11,9 @@
 //! failures surface as protocol-neutral [`DdlError`] with SQLSTATE `42601`.
 
 use crate::event::streaming_mv::types::{AggDef, AggFunction};
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, rfind_ascii_case_insensitive,
+};
 
 use super::super::super::result::DdlError;
 
@@ -44,8 +47,7 @@ pub fn parse_streaming_mv(query_sql: &str) -> Result<ParsedStreamingMv, DdlError
     let query_upper = query.to_uppercase();
 
     // Extract FROM <stream>.
-    let from_pos = query_upper
-        .find(" FROM ")
+    let from_pos = find_ascii_case_insensitive(query, " FROM ")
         .ok_or_else(|| parse_err("expected FROM clause"))?;
     let after_from = query[from_pos + 6..].trim();
     let source_stream = after_from
@@ -55,7 +57,7 @@ pub fn parse_streaming_mv(query_sql: &str) -> Result<ParsedStreamingMv, DdlError
         .to_lowercase();
 
     // Extract GROUP BY columns.
-    let group_by_columns = if let Some(gb_pos) = query_upper.find(" GROUP BY ") {
+    let group_by_columns = if let Some(gb_pos) = find_ascii_case_insensitive(query, " GROUP BY ") {
         let gb_str = query[gb_pos + 10..].trim();
         gb_str
             .split(',')
@@ -67,8 +69,8 @@ pub fn parse_streaming_mv(query_sql: &str) -> Result<ParsedStreamingMv, DdlError
     };
 
     // Extract WHERE filter (between FROM <stream> and GROUP BY).
-    let filter_expr = if let Some(where_pos) = query_upper.find(" WHERE ") {
-        let end = query_upper.find(" GROUP BY ").unwrap_or(query.len());
+    let filter_expr = if let Some(where_pos) = find_ascii_case_insensitive(query, " WHERE ") {
+        let end = find_ascii_case_insensitive(query, " GROUP BY ").unwrap_or(query.len());
         if where_pos < end {
             Some(query[where_pos + 7..end].trim().to_string())
         } else {
@@ -115,7 +117,7 @@ fn parse_select_aggregates(select_list: &str) -> Vec<AggDef> {
         }
 
         // Split on AS to get alias.
-        let (expr_part, alias) = if let Some(as_pos) = item.to_uppercase().rfind(" AS ") {
+        let (expr_part, alias) = if let Some(as_pos) = rfind_ascii_case_insensitive(item, " AS ") {
             (
                 item[..as_pos].trim(),
                 item[as_pos + 4..].trim().to_lowercase(),
@@ -194,6 +196,16 @@ mod tests {
         assert_eq!(parsed.aggregates.len(), 2);
         assert_eq!(parsed.aggregates[1].function, AggFunction::Sum);
         assert_eq!(parsed.aggregates[1].input_expr, "total");
+    }
+
+    #[test]
+    fn aggregate_alias_after_unicode_expression_preserves_original_offsets() {
+        let parsed =
+            parse_streaming_mv("SELECT sum(ﬀﬀ) AS total FROM orders_stream GROUP BY event_type")
+                .expect("streaming aggregate should parse");
+        assert_eq!(parsed.aggregates.len(), 1);
+        assert_eq!(parsed.aggregates[0].input_expr, "ﬀﬀ");
+        assert_eq!(parsed.aggregates[0].output_name, "total");
     }
 
     #[test]

--- a/nodedb/src/control/server/shared/ddl/neutral/permission_tree.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/permission_tree.rs
@@ -19,6 +19,7 @@
 //! side effects are preserved verbatim; only the result construction changed
 //! from pgwire `Response` / `Tag` to the protocol-neutral [`DdlResult`].
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use nodedb_types::DatabaseId;
 
 use crate::control::security::identity::AuthenticatedIdentity;
@@ -50,12 +51,9 @@ pub async fn set_permission_tree(
     identity: &AuthenticatedIdentity,
     sql: &str,
 ) -> Result<Vec<DdlResult>, DdlError> {
-    let upper = sql.to_uppercase();
-
     // Extract collection name: between "ALTER COLLECTION " and " SET PERMISSION_TREE".
     let start = "ALTER COLLECTION ".len();
-    let end = upper
-        .find(" SET PERMISSION_TREE")
+    let end = find_ascii_case_insensitive(sql, " SET PERMISSION_TREE")
         .ok_or_else(|| err("42601", "expected SET PERMISSION_TREE"))?;
     let collection = sql[start..end].trim().to_lowercase();
 
@@ -128,11 +126,8 @@ pub async fn drop_permission_tree(
     identity: &AuthenticatedIdentity,
     sql: &str,
 ) -> Result<Vec<DdlResult>, DdlError> {
-    let upper = sql.to_uppercase();
-
     let start = "ALTER COLLECTION ".len();
-    let end = upper
-        .find(" DROP PERMISSION_TREE")
+    let end = find_ascii_case_insensitive(sql, " DROP PERMISSION_TREE")
         .ok_or_else(|| err("42601", "expected DROP PERMISSION_TREE"))?;
     let collection = sql[start..end].trim().to_lowercase();
 

--- a/nodedb/src/control/server/shared/ddl/neutral/query_functions/helpers.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/query_functions/helpers.rs
@@ -8,6 +8,7 @@
 //! single-column `result` output builds a [`DdlResult::Rows`] directly instead
 //! of a pgwire `QueryResponse`. SQLSTATE codes and messages are unchanged.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::control::server::response_shape::types::ShapedRows;
@@ -23,9 +24,7 @@ pub fn err(sqlstate: &str, message: &str) -> DdlError {
 }
 
 pub fn extract_function_args<'a>(sql: &'a str, func_name: &str) -> Result<Vec<&'a str>, DdlError> {
-    let upper = sql.to_uppercase();
-    let pos = upper
-        .find(func_name)
+    let pos = find_ascii_case_insensitive(sql, func_name)
         .ok_or_else(|| err("42601", &format!("missing {func_name}")))?;
     let after = &sql[pos + func_name.len()..];
     let paren_start = after

--- a/nodedb/src/control/server/shared/ddl/neutral/retention_policy/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/retention_policy/parse.rs
@@ -10,6 +10,9 @@ use crate::engine::timeseries::continuous_agg::{AggFunction, AggregateExpr};
 use crate::engine::timeseries::retention_policy::types::{
     ArchiveTarget, RetentionPolicyDef, TierDef,
 };
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
 
 use super::super::super::result::DdlError;
 
@@ -46,11 +49,9 @@ pub(super) fn parse_create_retention_policy(sql: &str) -> Result<ParsedRetention
         .to_lowercase();
 
     // Extract collection: "... ON <collection> (...)"
-    let upper_after = upper[prefix.len()..].to_string();
-    let on_pos = upper_after
-        .find(" ON ")
+    let on_pos = find_ascii_case_insensitive_from(trimmed, " ON ", prefix.len())
         .ok_or_else(|| err("42601", "expected ON <collection>".to_string()))?;
-    let after_on = after_prefix[on_pos + 4..].trim_start();
+    let after_on = trimmed[on_pos + 4..].trim_start();
     let collection = after_on
         .split(|c: char| c.is_whitespace() || c == '(')
         .next()
@@ -187,9 +188,7 @@ fn split_top_level_commas(s: &str) -> Vec<&str> {
 
 /// Extract RETAIN '<duration>' → milliseconds.
 fn extract_retain(clause: &str) -> Result<u64, DdlError> {
-    let upper = clause.to_uppercase();
-    let pos = upper
-        .find("RETAIN")
+    let pos = find_ascii_case_insensitive(clause, "RETAIN")
         .ok_or_else(|| err("42601", "missing RETAIN clause".to_string()))?;
     let after = clause[pos + 6..].trim_start();
     let val = extract_quoted_string(after)?;
@@ -204,9 +203,7 @@ fn extract_retain(clause: &str) -> Result<u64, DdlError> {
 
 /// Extract DOWNSAMPLE TO '<interval>' → milliseconds.
 fn extract_downsample_interval(clause: &str) -> Result<u64, DdlError> {
-    let upper = clause.to_uppercase();
-    let pos = upper
-        .find("TO")
+    let pos = find_ascii_case_insensitive(clause, "TO")
         .ok_or_else(|| err("42601", "expected DOWNSAMPLE TO '<interval>'".to_string()))?;
     let after = clause[pos + 2..].trim_start();
     let val = extract_quoted_string(after)?;
@@ -217,9 +214,7 @@ fn extract_downsample_interval(clause: &str) -> Result<u64, DdlError> {
 
 /// Extract ARCHIVE TO '<url>'.
 fn extract_archive_url(clause: &str) -> Result<String, DdlError> {
-    let upper = clause.to_uppercase();
-    let pos = upper
-        .find("TO")
+    let pos = find_ascii_case_insensitive(clause, "TO")
         .ok_or_else(|| err("42601", "expected ARCHIVE TO '<url>'".to_string()))?;
     let after = clause[pos + 2..].trim_start();
     extract_quoted_string(after)
@@ -227,8 +222,7 @@ fn extract_archive_url(clause: &str) -> Result<String, DdlError> {
 
 /// Extract aggregate expressions from AGGREGATE (...) in a tier clause.
 fn extract_tier_aggregates(clause: &str) -> Result<Vec<AggregateExpr>, DdlError> {
-    let upper = clause.to_uppercase();
-    let agg_pos = match upper.find("AGGREGATE") {
+    let agg_pos = match find_ascii_case_insensitive(clause, "AGGREGATE") {
         Some(p) => p,
         None => return Ok(Vec::new()),
     };
@@ -283,9 +277,7 @@ fn find_matching_paren(s: &str, open: usize) -> Option<usize> {
 
 /// Parse a single aggregate expression: `func(col)` or `func(col) AS alias`.
 pub(super) fn parse_agg_expr(s: &str) -> Result<AggregateExpr, DdlError> {
-    let upper = s.to_uppercase();
-
-    let (func_part, alias) = if let Some(as_pos) = upper.find(" AS ") {
+    let (func_part, alias) = if let Some(as_pos) = find_ascii_case_insensitive(s, " AS ") {
         (&s[..as_pos], Some(s[as_pos + 4..].trim().to_lowercase()))
     } else {
         (s, None)
@@ -345,8 +337,7 @@ fn extract_quoted_string(s: &str) -> Result<String, DdlError> {
 /// Parse optional WITH (EVAL_INTERVAL = '<duration>') after closing ')'.
 fn parse_with_clause(sql: &str, body_end: usize) -> u64 {
     let after_body = &sql[body_end + 1..];
-    let upper = after_body.to_uppercase();
-    let with_pos = match upper.find("WITH") {
+    let with_pos = match find_ascii_case_insensitive(after_body, "WITH") {
         Some(p) => p,
         None => return RetentionPolicyDef::DEFAULT_EVAL_INTERVAL_MS,
     };
@@ -412,6 +403,16 @@ mod tests {
             parsed.eval_interval_ms,
             RetentionPolicyDef::DEFAULT_EVAL_INTERVAL_MS
         );
+    }
+
+    #[test]
+    fn collection_after_unicode_policy_name_preserves_original_offsets() {
+        let parsed = parse_create_retention_policy(
+            "CREATE RETENTION POLICY rpﬀﬀ ON metrics (RAW RETAIN '30 days')",
+        )
+        .expect("retention policy should parse");
+        assert_eq!(parsed.name, "rpﬀﬀ");
+        assert_eq!(parsed.collection, "metrics");
     }
 
     #[test]

--- a/nodedb/src/control/server/shared/ddl/neutral/router/helpers.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/router/helpers.rs
@@ -2,6 +2,8 @@
 
 //! Shared helpers for the DDL router clusters.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
 use crate::types::DatabaseId;
@@ -29,8 +31,7 @@ pub(super) fn collection_exists(
 /// so the parse behaviour stays byte-identical.
 pub(super) fn extract_last_values_arg(sql: &str) -> Option<String> {
     let prefix = "LAST_VALUES(";
-    let upper = sql.to_uppercase();
-    let pos = upper.find(prefix)?;
+    let pos = find_ascii_case_insensitive(sql, prefix)?;
     let after = &sql[pos + prefix.len()..];
     let start = after.find('\'')?;
     let end = after[start + 1..].find('\'')?;
@@ -41,8 +42,7 @@ pub(super) fn extract_last_values_arg(sql: &str) -> Option<String> {
 ///
 /// Mirrors the pgwire router's `extract_lv_args` exactly.
 pub(super) fn extract_last_value_args(sql: &str) -> Option<(String, u64)> {
-    let upper = sql.to_uppercase();
-    let pos = upper.find("LAST_VALUE(")?;
+    let pos = find_ascii_case_insensitive(sql, "LAST_VALUE(")?;
     let after = &sql[pos + 11..];
     let close = after.find(')')?;
     let inner = &after[..close];

--- a/nodedb/src/control/server/shared/ddl/neutral/show_changes.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/show_changes.rs
@@ -9,6 +9,7 @@
 //!
 //! The handler builds [`DdlResult`] directly and carries no pgwire types.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::control::server::response_shape::types::{DdlColType, ShapedRows};
@@ -18,12 +19,10 @@ use super::super::result::{DdlError, DdlResult};
 
 /// Execute `SHOW CHANGES FOR <collection> [SINCE <timestamp>] [LIMIT <n>]`.
 pub fn show_changes(state: &SharedState, sql: &str) -> Result<Vec<DdlResult>, DdlError> {
-    let upper = sql.to_uppercase();
-
     if let Some(coll_name) =
         crate::control::server::shared::ddl::sql_parse::extract_collection_after(sql, " FOR ")
     {
-        let since_ms: u64 = if let Some(since_pos) = upper.find(" SINCE ") {
+        let since_ms: u64 = if let Some(since_pos) = find_ascii_case_insensitive(sql, " SINCE ") {
             let since_str = sql[since_pos + 7..]
                 .split_whitespace()
                 .next()
@@ -46,8 +45,7 @@ pub fn show_changes(state: &SharedState, sql: &str) -> Result<Vec<DdlResult>, Dd
             now_ms.saturating_sub(86_400 * 1000)
         };
 
-        let limit = upper
-            .find(" LIMIT ")
+        let limit = find_ascii_case_insensitive(sql, " LIMIT ")
             .and_then(|pos| sql[pos + 7..].split_whitespace().next())
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(1000);

--- a/nodedb/src/control/server/shared/ddl/neutral/timeseries/helpers.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/timeseries/helpers.rs
@@ -2,6 +2,8 @@
 
 //! Internal helpers for the protocol-neutral timeseries DDL handlers.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_keyword;
+
 use super::super::super::result::DdlError;
 
 /// Build a [`DdlError`] from an ANSI SQLSTATE code and a message.
@@ -17,8 +19,7 @@ pub(super) fn ddl_err(sqlstate: &str, message: impl Into<String>) -> DdlError {
 /// Returns `None` if no WITH clause is present or if the clause is empty.
 pub(super) fn parse_with_clause(parts: &[&str]) -> Option<String> {
     let sql = parts.join(" ");
-    let upper = sql.to_uppercase();
-    let with_pos = upper.find("WITH")?;
+    let with_pos = find_ascii_keyword(&sql, "WITH")?;
     let after_with = sql[with_pos + 4..].trim();
 
     let open = after_with.find('(')?;
@@ -54,11 +55,9 @@ pub(super) fn parse_with_clause(parts: &[&str]) -> Option<String> {
 /// Supported types: TIMESTAMP, FLOAT, FLOAT8, INT, INTEGER, VARCHAR, TEXT, BOOLEAN.
 pub(super) fn parse_column_defs(parts: &[&str]) -> Option<Vec<(String, String)>> {
     let sql = parts.join(" ");
-    let upper = sql.to_uppercase();
-
     // Column defs start after name (index 2 in parts) and before WITH.
     // Find the first `(` that is NOT part of a WITH clause.
-    let with_pos = upper.find("WITH").unwrap_or(sql.len());
+    let with_pos = find_ascii_keyword(&sql, "WITH").unwrap_or(sql.len());
     let before_with = &sql[..with_pos];
 
     let open = before_with.find('(')?;

--- a/nodedb/src/control/server/shared/ddl/neutral/topic/create.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/topic/create.rs
@@ -16,6 +16,7 @@ use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
 use crate::event::cdc::stream_def::RetentionConfig;
 use crate::event::topic::TopicDef;
+use nodedb_sql::parser::preprocess::lex::{find_ascii_case_insensitive, find_ascii_keyword};
 
 use super::super::super::result::{DdlError, DdlResult};
 use super::super::auth_support::{require_tenant_admin, status};
@@ -52,24 +53,21 @@ pub fn create_topic(
         max_age_secs: 3_600, // 1 hour default for topics.
     };
 
-    let upper = sql.to_uppercase();
-    if let Some(with_pos) = upper.find("WITH") {
+    if let Some(with_pos) = find_ascii_keyword(sql, "WITH") {
         let with_section = sql[with_pos + 4..].trim();
         if let Some(inner) = with_section
             .strip_prefix('(')
             .and_then(|s| s.split_once(')'))
             .map(|(inner, _)| inner)
+            && let Some(ret_pos) = find_ascii_case_insensitive(inner, "RETENTION")
         {
-            let inner_upper = inner.to_uppercase();
-            if let Some(ret_pos) = inner_upper.find("RETENTION") {
-                let after = inner[ret_pos + 9..].trim().trim_start_matches('=').trim();
-                let val = after
-                    .trim_start_matches('\'')
-                    .split('\'')
-                    .next()
-                    .unwrap_or("");
-                retention.max_age_secs = parse_duration_secs(val);
-            }
+            let after = inner[ret_pos + 9..].trim().trim_start_matches('=').trim();
+            let val = after
+                .trim_start_matches('\'')
+                .split('\'')
+                .next()
+                .unwrap_or("");
+            retention.max_age_secs = parse_duration_secs(val);
         }
     }
 

--- a/nodedb/src/control/server/shared/ddl/neutral/topic_subscribe.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/topic_subscribe.rs
@@ -17,6 +17,7 @@
 //! from pgwire `Response` / `PgWireError` to the protocol-neutral
 //! [`DdlResult`] / [`DdlError`]; the SQLSTATE codes are unchanged.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::control::security::identity::AuthenticatedIdentity;
@@ -40,16 +41,13 @@ pub fn subscribe_to(
     parts: &[&str],
 ) -> Result<Vec<DdlResult>, DdlError> {
     let topic_name = parts.get(2).unwrap_or(&"").to_lowercase();
-    let upper = sql.to_uppercase();
-    let since_seq: u64 = upper
-        .find(" SINCE ")
+    let since_seq: u64 = find_ascii_case_insensitive(sql, " SINCE ")
         .and_then(|pos| sql[pos + 7..].split_whitespace().next())
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
 
     // Check for GROUP clause: SUBSCRIBE TO topic GROUP group_name [SINCE seq]
-    let group_name = upper
-        .find(" GROUP ")
+    let group_name = find_ascii_case_insensitive(sql, " GROUP ")
         .map(|pos| sql[pos + 7..].split_whitespace().next().unwrap_or(""))
         .filter(|g| !g.is_empty())
         .map(|g| g.to_lowercase());

--- a/nodedb/src/control/server/shared/ddl/neutral/tree_ops/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/tree_ops/parse.rs
@@ -2,6 +2,8 @@
 
 //! Parsing helpers shared across the tree-ops DDL entry points.
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use super::super::super::result::DdlError;
 use super::support::ddl_err;
 
@@ -47,12 +49,11 @@ pub(super) fn parse_edge_columns(sql: &str) -> Result<(String, String), DdlError
 
 /// Extract function arguments from `FUNC_NAME(arg1, arg2, arg3)`.
 pub(super) fn extract_function_args<'a>(
-    upper: &str,
+    _upper: &str,
     original: &'a str,
     func_name: &str,
 ) -> Result<Vec<&'a str>, DdlError> {
-    let pos = upper
-        .find(func_name)
+    let pos = find_ascii_case_insensitive(original, func_name)
         .ok_or_else(|| ddl_err("42601", format!("missing {func_name}")))?;
     let after = &original[pos + func_name.len()..];
     let paren_start = after

--- a/nodedb/src/control/server/shared/ddl/neutral/typeguard/handlers.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/typeguard/handlers.rs
@@ -29,6 +29,7 @@
 //! SHOW TYPEGUARDS;
 //! ```
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use nodedb_types::DatabaseId;
 
 use serde_json::{Map, Value as JsonValue};
@@ -116,12 +117,9 @@ pub fn alter_typeguard_add(
     identity: &AuthenticatedIdentity,
     sql: &str,
 ) -> Result<Vec<DdlResult>, DdlError> {
-    let upper = sql.to_uppercase();
-
     let coll_name = extract_collection_name(sql)?;
 
-    let add_pos = upper
-        .find(" ADD ")
+    let add_pos = find_ascii_case_insensitive(sql, " ADD ")
         .ok_or_else(|| err("42601", "ALTER TYPEGUARD requires ADD <field> <type>"))?;
     let after_add = sql[add_pos + 5..].trim();
 
@@ -170,12 +168,9 @@ pub fn alter_typeguard_drop(
     identity: &AuthenticatedIdentity,
     sql: &str,
 ) -> Result<Vec<DdlResult>, DdlError> {
-    let upper = sql.to_uppercase();
-
     let coll_name = extract_collection_name(sql)?;
 
-    let drop_pos = upper
-        .find(" DROP ")
+    let drop_pos = find_ascii_case_insensitive(sql, " DROP ")
         .ok_or_else(|| err("42601", "ALTER TYPEGUARD requires DROP <field>"))?;
     let field_name = sql[drop_pos + 6..].trim().to_lowercase();
 

--- a/nodedb/src/control/server/shared/ddl/neutral/typeguard/parse.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/typeguard/parse.rs
@@ -6,15 +6,16 @@
 //! error construction changed from pgwire `PgWireError` to the protocol-neutral
 //! [`DdlError`].
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
 use nodedb_types::TypeGuardFieldDef;
 
 use super::super::super::result::DdlError;
 
 /// Extract collection name from `... TYPEGUARD [IF EXISTS] ON <collection> ...`.
 pub(super) fn extract_collection_name(sql: &str) -> Result<String, DdlError> {
-    let upper = sql.to_uppercase();
-    let on_pos = upper
-        .find(" ON ")
+    let on_pos = find_ascii_case_insensitive(sql, " ON ")
         .ok_or_else(|| err("42601", "TYPEGUARD requires ON <collection>"))?;
     let after_on = sql[on_pos + 4..].trim_start();
     // Collection name ends at whitespace or '('
@@ -112,15 +113,15 @@ pub(super) fn parse_single_field(s: &str) -> Result<TypeGuardFieldDef, DdlError>
         ));
     }
 
-    let upper_rest = rest.to_uppercase();
-
     // Detect REQUIRED keyword (must be standalone token, not part of type expr).
-    let required = upper_rest.split_whitespace().any(|t| t == "REQUIRED");
+    let required = rest
+        .split_whitespace()
+        .any(|token| token.eq_ignore_ascii_case("REQUIRED"));
 
     // Extract CHECK expression if present.
     // Find CHECK in the original-case `rest` to preserve case in the expression,
     // using case-insensitive search to avoid byte-offset mismatch with `upper_rest`.
-    let check_expr = if let Some(check_pos) = find_word_boundary(&upper_rest, "CHECK") {
+    let check_expr = if let Some(check_pos) = find_word_boundary(rest, "CHECK") {
         let after_check = &rest[check_pos + 5..];
         let paren_start = after_check
             .find('(')
@@ -154,9 +155,9 @@ pub(super) fn parse_single_field(s: &str) -> Result<TypeGuardFieldDef, DdlError>
 
     // The type expression is everything before REQUIRED, CHECK, DEFAULT, VALUE.
     let type_end = {
-        let mut end = upper_rest.len();
+        let mut end = rest.len();
         for kw in &["REQUIRED", "CHECK", "DEFAULT", "VALUE"] {
-            if let Some(pos) = find_word_boundary(&upper_rest, kw) {
+            if let Some(pos) = find_word_boundary(rest, kw) {
                 end = end.min(pos);
             }
         }
@@ -173,7 +174,7 @@ pub(super) fn parse_single_field(s: &str) -> Result<TypeGuardFieldDef, DdlError>
     }
 
     // Extract DEFAULT expression if present.
-    let default_expr = if let Some(def_pos) = find_word_boundary(&upper_rest, "DEFAULT") {
+    let default_expr = if let Some(def_pos) = find_word_boundary(rest, "DEFAULT") {
         let after_default = rest[def_pos + 7..].trim_start();
         // DEFAULT value extends until the next keyword (REQUIRED, CHECK, VALUE) or end.
         let default_end = find_next_keyword(after_default);
@@ -183,7 +184,7 @@ pub(super) fn parse_single_field(s: &str) -> Result<TypeGuardFieldDef, DdlError>
     };
 
     // Extract VALUE expression if present.
-    let value_expr = if let Some(val_pos) = find_word_boundary(&upper_rest, "VALUE") {
+    let value_expr = if let Some(val_pos) = find_word_boundary(rest, "VALUE") {
         let after_value = rest[val_pos + 5..].trim_start();
         let value_end = find_next_keyword(after_value);
         Some(after_value[..value_end].trim().to_string())
@@ -212,8 +213,7 @@ pub(super) fn parse_single_field(s: &str) -> Result<TypeGuardFieldDef, DdlError>
 /// Find the byte position of `word` as a standalone token (preceded by whitespace or start).
 fn find_word_boundary(haystack: &str, word: &str) -> Option<usize> {
     let mut start = 0;
-    while let Some(pos) = haystack[start..].find(word) {
-        let abs_pos = start + pos;
+    while let Some(abs_pos) = find_ascii_case_insensitive_from(haystack, word, start) {
         let before_ok = abs_pos == 0
             || haystack
                 .as_bytes()
@@ -235,10 +235,9 @@ fn find_word_boundary(haystack: &str, word: &str) -> Option<usize> {
 /// Find the end of a DEFAULT/VALUE expression — stops at the next keyword
 /// (REQUIRED, CHECK, DEFAULT, VALUE) or end of string.
 fn find_next_keyword(s: &str) -> usize {
-    let upper = s.to_uppercase();
     let mut end = s.len();
     for kw in &["REQUIRED", "CHECK", "DEFAULT", "VALUE"] {
-        if let Some(pos) = find_word_boundary(&upper, kw) {
+        if let Some(pos) = find_word_boundary(s, kw) {
             end = end.min(pos);
         }
     }
@@ -250,5 +249,27 @@ pub(super) fn err(code: &str, msg: &str) -> DdlError {
     DdlError {
         sqlstate: code.to_owned(),
         message: msg.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_after_unicode_text_preserves_original_offsets() {
+        let name = extract_collection_name("CREATE TYPEGUARD rpﬀﬀ ON metrics (v INT)")
+            .expect("collection name should parse");
+        assert_eq!(name, "metrics");
+    }
+
+    #[test]
+    fn field_keywords_after_unicode_default_preserve_original_offsets() {
+        let field = parse_single_field("label STRING DEFAULT 'ﬀﬀ' CHECK (label <> '') REQUIRED")
+            .expect("typeguard field should parse");
+        assert_eq!(field.type_expr, "STRING");
+        assert_eq!(field.default_expr.as_deref(), Some("'ﬀﬀ'"));
+        assert_eq!(field.check_expr.as_deref(), Some("label <> ''"));
+        assert!(field.required);
     }
 }

--- a/nodedb/src/control/server/shared/ddl/neutral/version_history/at_version.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/version_history/at_version.rs
@@ -4,6 +4,7 @@
 
 use std::time::Duration;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::bridge::envelope::PhysicalPlan;
@@ -99,24 +100,18 @@ pub(super) fn resolve_checkpoint_vv(
 
 /// Parse: SELECT * FROM collection AT VERSION 'checkpoint' WHERE id = 'doc-id'
 fn parse_at_version(sql: &str) -> Result<(String, String, String), DdlError> {
-    let upper = sql.to_uppercase();
-
     // Find "AT VERSION"
-    let at_pos = upper
-        .find("AT VERSION")
+    let at_pos = find_ascii_case_insensitive(sql, "AT VERSION")
         .ok_or_else(|| err("42601", "expected AT VERSION".to_string()))?;
 
     // Collection: between "FROM " and " AT VERSION"
-    let from_pos = upper
-        .find("FROM ")
+    let from_pos = find_ascii_case_insensitive(sql, "FROM ")
         .ok_or_else(|| err("42601", "expected FROM <collection>".to_string()))?;
     let collection = sql[from_pos + 5..at_pos].trim().to_lowercase();
 
     // Checkpoint name: after "AT VERSION " until "WHERE"
     let after_at = sql[at_pos + 10..].trim();
-    let where_pos = after_at
-        .to_uppercase()
-        .find("WHERE")
+    let where_pos = find_ascii_case_insensitive(after_at, "WHERE")
         .ok_or_else(|| err("42601", "expected WHERE id = '<doc_id>'".to_string()))?;
     let checkpoint_part = after_at[..where_pos].trim();
     let checkpoint = checkpoint_part

--- a/nodedb/src/control/server/shared/ddl/neutral/version_history/checkpoint.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/version_history/checkpoint.rs
@@ -9,6 +9,8 @@
 
 use std::time::Duration;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::bridge::envelope::PhysicalPlan;
 use crate::control::security::catalog::types::CheckpointRecord;
 use crate::control::security::identity::AuthenticatedIdentity;
@@ -147,9 +149,7 @@ fn parse_checkpoint_sql(sql: &str, prefix: &str) -> Result<(String, String, Stri
     }
     let after_on = after_name[3..].trim();
 
-    let where_pos = after_on
-        .to_uppercase()
-        .find("WHERE")
+    let where_pos = find_ascii_case_insensitive(after_on, "WHERE")
         .ok_or_else(|| err("42601", "expected WHERE id = '<doc_id>'".to_string()))?;
     let collection = after_on[..where_pos].trim().to_lowercase();
     let where_clause = after_on[where_pos + 5..].trim();

--- a/nodedb/src/control/server/shared/ddl/neutral/version_history/compact.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/version_history/compact.rs
@@ -4,6 +4,8 @@
 
 use std::time::Duration;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use crate::bridge::envelope::PhysicalPlan;
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::server::shared::ddl::sync_dispatch::dispatch_async;
@@ -85,17 +87,13 @@ fn parse_compact(sql: &str) -> Result<(String, String, String), DdlError> {
     let rest = sql["COMPACT HISTORY ON ".len()..].trim();
 
     // Collection: before WHERE.
-    let where_pos = rest
-        .to_uppercase()
-        .find("WHERE")
+    let where_pos = find_ascii_case_insensitive(rest, "WHERE")
         .ok_or_else(|| err("42601", "expected WHERE".to_string()))?;
     let collection = rest[..where_pos].trim().to_lowercase();
     let after_where = rest[where_pos + 5..].trim();
 
     // id = 'doc-id' BEFORE 'checkpoint'
-    let before_pos = after_where
-        .to_uppercase()
-        .find("BEFORE")
+    let before_pos = find_ascii_case_insensitive(after_where, "BEFORE")
         .ok_or_else(|| err("42601", "expected BEFORE '<checkpoint>'".to_string()))?;
     let id_clause = after_where[..before_pos].trim();
     let checkpoint_part = after_where[before_pos + 6..]

--- a/nodedb/src/control/server/shared/ddl/neutral/version_history/restore.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/version_history/restore.rs
@@ -12,6 +12,7 @@ use crate::control::state::SharedState;
 use crate::control::wal_replication::{propose_replicated_entry, to_replicated_entry};
 use crate::types::{DatabaseId, TenantId, VShardId};
 use nodedb_physical::physical_plan::CrdtOp;
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use nodedb_types::Surrogate;
 
 use super::super::super::result::{DdlError, DdlResult};
@@ -183,9 +184,7 @@ fn parse_restore(sql: &str) -> Result<(String, String, String), DdlError> {
     let rest = sql["RESTORE ".len()..].trim();
 
     // Collection: before "SET VERSION"
-    let set_pos = rest
-        .to_uppercase()
-        .find("SET VERSION")
+    let set_pos = find_ascii_case_insensitive(rest, "SET VERSION")
         .ok_or_else(|| err("42601", "expected SET VERSION".to_string()))?;
     let collection = rest[..set_pos].trim().to_lowercase();
 
@@ -196,9 +195,7 @@ fn parse_restore(sql: &str) -> Result<(String, String, String), DdlError> {
         .ok_or_else(|| err("42601", "expected '=' after SET VERSION".to_string()))?;
     let after_eq = after_set[eq_pos + 1..].trim();
 
-    let where_pos = after_eq
-        .to_uppercase()
-        .find("WHERE")
+    let where_pos = find_ascii_case_insensitive(after_eq, "WHERE")
         .ok_or_else(|| err("42601", "expected WHERE id = '<doc_id>'".to_string()))?;
     let checkpoint = after_eq[..where_pos]
         .trim()
@@ -228,6 +225,16 @@ mod tests {
     use super::*;
     use crate::bridge::dispatch::Dispatcher;
     use crate::wal::WalManager;
+
+    #[test]
+    fn restore_keywords_after_unicode_values_preserve_original_offsets() {
+        let (collection, checkpoint, doc_id) =
+            parse_restore("RESTORE recordsﬀﬀ SET VERSION = 'versionﬀﬀ' WHERE id = 'doc-1'")
+                .expect("restore statement should parse");
+        assert_eq!(collection, "recordsﬀﬀ");
+        assert_eq!(checkpoint, "versionﬀﬀ");
+        assert_eq!(doc_id, "doc-1");
+    }
 
     /// Build a `SharedState` with a real single-node `WalManager` and no Raft
     /// proposer configured, so `persist_restore_delta` takes the WAL-append

--- a/nodedb/src/control/server/shared/ddl/neutral/version_history/show_versions.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/version_history/show_versions.rs
@@ -2,6 +2,7 @@
 
 //! SHOW VERSIONS OF collection WHERE id = 'doc-id' [LIMIT N]
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
 use serde_json::{Map, Value as JsonValue};
 
 use crate::control::security::identity::AuthenticatedIdentity;
@@ -84,15 +85,13 @@ pub fn show_versions(
 fn parse_show_versions(sql: &str) -> Result<(String, String, usize), DdlError> {
     let rest = sql["SHOW VERSIONS OF ".len()..].trim();
 
-    let where_pos = rest
-        .to_uppercase()
-        .find("WHERE")
+    let where_pos = find_ascii_case_insensitive(rest, "WHERE")
         .ok_or_else(|| err("42601", "expected WHERE id = '<doc_id>'".to_string()))?;
     let collection = rest[..where_pos].trim().to_lowercase();
     let after_where = rest[where_pos + 5..].trim();
 
     // Parse "id = 'doc-id'" potentially followed by "LIMIT N"
-    let limit_pos = after_where.to_uppercase().find("LIMIT");
+    let limit_pos = find_ascii_case_insensitive(after_where, "LIMIT");
     let (id_clause, limit) = if let Some(lp) = limit_pos {
         let id_part = &after_where[..lp];
         let limit_part = after_where[lp + 5..].trim().trim_end_matches(';').trim();

--- a/nodedb/src/control/server/shared/ddl/sql_parse.rs
+++ b/nodedb/src/control/server/shared/ddl/sql_parse.rs
@@ -2,6 +2,10 @@
 
 //! SQL parsing helpers shared across DDL handlers.
 
+use nodedb_sql::parser::preprocess::lex::{
+    find_ascii_case_insensitive, find_ascii_case_insensitive_from,
+};
+
 /// Split VALUES content respecting quoted strings and brackets.
 ///
 /// `'hello', 42, 'it''s'` → `["'hello'", "42", "'it''s'"]`
@@ -156,13 +160,13 @@ fn sql_value_to_ndb_value(v: nodedb_sql::types::SqlValue) -> nodedb_types::Value
 ///
 /// `all_keywords` lists every keyword that can terminate the value.
 pub(crate) fn extract_clause(
-    upper: &str,
+    _upper: &str,
     original: &str,
     keyword: &str,
     all_keywords: &[&str],
 ) -> Option<String> {
     let kw_with_space = format!("{keyword} ");
-    let start = upper.find(&kw_with_space)?;
+    let start = find_ascii_case_insensitive(original, &kw_with_space)?;
     let value_start = start + kw_with_space.len();
 
     let end = all_keywords
@@ -170,9 +174,7 @@ pub(crate) fn extract_clause(
         .filter(|&&k| !k.eq_ignore_ascii_case(keyword))
         .filter_map(|k| {
             let needle = format!("{k} ");
-            upper[value_start..]
-                .find(&needle)
-                .map(|pos| value_start + pos)
+            find_ascii_case_insensitive_from(original, &needle, value_start)
         })
         .min()
         .unwrap_or(original.len());
@@ -187,8 +189,7 @@ pub(crate) fn extract_clause(
 /// returns `Some("users")`. Returns `None` if the marker is missing or
 /// the collection name is empty.
 pub(crate) fn extract_collection_after(sql: &str, marker: &str) -> Option<String> {
-    let upper = sql.to_uppercase();
-    let pos = upper.find(marker)?;
+    let pos = find_ascii_case_insensitive(sql, marker)?;
     let after = sql[pos + marker.len()..].trim();
     let name = after.split_whitespace().next()?.to_lowercase();
     if name.is_empty() { None } else { Some(name) }
@@ -229,7 +230,7 @@ pub fn hex_decode(s: &str) -> Option<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_sql_value;
+    use super::{extract_clause, parse_sql_value};
 
     #[test]
     fn parse_sql_value_decodes_numeric_array_literals() {
@@ -258,6 +259,16 @@ mod tests {
                     nodedb_types::Value::Integer(2),
                 ]),
             ])
+        );
+    }
+
+    #[test]
+    fn extract_clause_with_unicode_value_preserves_original_offsets() {
+        let original = "TYPE ﬀﬀ DEFAULT 0 ASSERT $value > 0";
+        let upper = original.to_uppercase();
+        assert_eq!(
+            extract_clause(&upper, original, "TYPE", &["TYPE", "DEFAULT", "ASSERT"]),
+            Some("ﬀﬀ".to_string())
         );
     }
 }

--- a/nodedb/src/control/server/shared/session/params.rs
+++ b/nodedb/src/control/server/shared/session/params.rs
@@ -4,6 +4,8 @@
 
 use std::net::SocketAddr;
 
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive;
+
 use super::store::SessionStore;
 
 impl SessionStore {
@@ -61,8 +63,7 @@ pub fn parse_set_command(sql: &str) -> Option<(String, String)> {
         (k, v)
     } else {
         // Try TO separator.
-        let upper_rest = rest.to_uppercase();
-        let to_pos = upper_rest.find(" TO ")?;
+        let to_pos = find_ascii_case_insensitive(rest, " TO ")?;
         let k = rest[..to_pos].trim();
         let v = rest[to_pos + 4..].trim();
         (k, v)
@@ -251,6 +252,13 @@ mod tests {
         let (k, v) = parse_set_command("SET search_path TO public").unwrap();
         assert_eq!(k, "search_path");
         assert_eq!(v, "public");
+    }
+
+    #[test]
+    fn parse_set_to_after_unicode_key_preserves_original_offsets() {
+        let (k, v) = parse_set_command("SET custom.ﬀﬀ TO enabled").unwrap();
+        assert_eq!(k, "custom.ﬀﬀ");
+        assert_eq!(v, "enabled");
     }
 
     #[test]

--- a/nodedb/src/control/trigger/when_parse.rs
+++ b/nodedb/src/control/trigger/when_parse.rs
@@ -17,6 +17,7 @@
 //! - Same with `OLD.` prefix
 
 use nodedb_query::scan_filter::{FilterOp, ScanFilter};
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive_from;
 use nodedb_types::Value;
 
 /// Which row side the WHEN condition targets.
@@ -56,12 +57,11 @@ pub fn try_parse_when_to_filters(condition: &str) -> Option<(WhenTarget, Vec<Sca
 
 /// Split a string on case-insensitive ` AND ` boundaries.
 fn split_and(s: &str) -> Vec<&str> {
-    let upper = s.to_uppercase();
     let mut parts = Vec::new();
     let mut start = 0;
-    while let Some(pos) = upper[start..].find(" AND ") {
-        parts.push(s[start..start + pos].trim());
-        start += pos + 5; // " AND " is 5 chars
+    while let Some(position) = find_ascii_case_insensitive_from(s, " AND ", start) {
+        parts.push(s[start..position].trim());
+        start = position + 5; // " AND " is 5 ASCII bytes
     }
     parts.push(s[start..].trim());
     parts.retain(|p| !p.is_empty());
@@ -417,6 +417,15 @@ mod tests {
         assert_eq!(filters[0].value, Value::String("active".into()));
         assert_eq!(filters[1].field, "type");
         assert_eq!(filters[1].value, Value::String("order".into()));
+    }
+
+    #[test]
+    fn and_after_unicode_literal_preserves_original_offsets() {
+        let (target, filters) = parse_multi("NEW.status = 'ﬀﬀ' AND NEW.type = 'order'").unwrap();
+        assert_eq!(target, WhenTarget::New);
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0].value, Value::String("ﬀﬀ".into()));
+        assert_eq!(filters[1].field, "type");
     }
 
     #[test]

--- a/nodedb/src/engine/graph/pattern/compiler/clauses.rs
+++ b/nodedb/src/engine/graph/pattern/compiler/clauses.rs
@@ -5,6 +5,7 @@
 use super::super::ast::*;
 use super::helpers::{split_by_and, split_top_level_commas};
 use super::parse_match_clauses;
+use nodedb_sql::parser::preprocess::lex::rfind_ascii_case_insensitive;
 
 /// Parse WHERE predicates.
 pub(super) fn parse_where(text: &str) -> crate::Result<Vec<WherePredicate>> {
@@ -117,8 +118,7 @@ pub(super) fn parse_return(text: &str) -> (Vec<ReturnColumn>, bool) {
         .into_iter()
         .map(|col| {
             let col = col.trim();
-            let upper = col.to_uppercase();
-            if let Some(as_pos) = upper.rfind(" AS ") {
+            if let Some(as_pos) = rfind_ascii_case_insensitive(col, " AS ") {
                 let expr = col[..as_pos].trim().to_string();
                 let alias = col[as_pos + 4..].trim().to_string();
                 ReturnColumn {

--- a/nodedb/src/engine/graph/pattern/compiler/helpers.rs
+++ b/nodedb/src/engine/graph/pattern/compiler/helpers.rs
@@ -2,81 +2,78 @@
 
 //! Parser utility functions: keyword search, comma splitting, etc.
 
-/// Find a keyword at top level (not inside parentheses/brackets/braces).
-pub(super) fn find_top_level_keyword(upper: &str, keyword: &str) -> Option<usize> {
-    let mut depth = 0i32;
-    let kw_len = keyword.len();
-    let bytes = upper.as_bytes();
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive_from;
 
-    for i in 0..upper.len().saturating_sub(kw_len - 1) {
-        match bytes[i] {
+/// Find a keyword at top level (not inside parentheses/brackets/braces).
+pub(super) fn find_top_level_keyword(text: &str, keyword: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    let keyword_len = keyword.len();
+    let bytes = text.as_bytes();
+
+    for index in 0..text.len().saturating_sub(keyword_len.saturating_sub(1)) {
+        match bytes[index] {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
-            b'\'' => {
-                if let Some(end) = upper[i + 1..].find('\'') {
-                    let _ = end;
-                }
-            }
             _ => {}
         }
 
-        if depth == 0 && upper[i..].starts_with(keyword) {
-            let before_ok = i == 0 || bytes[i - 1].is_ascii_whitespace();
-            let after_ok = i + kw_len >= upper.len()
-                || bytes[i + kw_len].is_ascii_whitespace()
-                || bytes[i + kw_len] == b'(';
+        if depth == 0 && find_ascii_case_insensitive_from(text, keyword, index) == Some(index) {
+            let before_ok = index == 0 || bytes[index - 1].is_ascii_whitespace();
+            let after = index + keyword_len;
+            let after_ok =
+                after >= text.len() || bytes[after].is_ascii_whitespace() || bytes[after] == b'(';
             if before_ok && after_ok {
-                return Some(i);
+                return Some(index);
             }
         }
     }
     None
 }
 
-/// Find `IN 'collection'` clause position in uppercase MATCH text.
+/// Find `IN 'collection'` clause position in MATCH text.
 ///
 /// Accepts `)` or whitespace before `IN` (unlike `find_top_level_keyword`
 /// which only accepts whitespace). Only matches at top-level (depth == 0).
-pub(super) fn find_in_clause(upper: &str) -> Option<usize> {
+pub(super) fn find_in_clause(text: &str) -> Option<usize> {
     let mut depth = 0i32;
-    let bytes = upper.as_bytes();
-    let len = upper.len();
+    let bytes = text.as_bytes();
+    let len = text.len();
 
-    for i in 0..len.saturating_sub(1) {
-        match bytes[i] {
+    for index in 0..len.saturating_sub(1) {
+        match bytes[index] {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
             _ => {}
         }
 
         if depth == 0
-            && upper[i..].starts_with("IN")
-            && (i == 0 || bytes[i - 1].is_ascii_whitespace() || bytes[i - 1] == b')')
-            && (i + 2 >= len || bytes[i + 2].is_ascii_whitespace())
+            && find_ascii_case_insensitive_from(text, "IN", index) == Some(index)
+            && (index == 0 || bytes[index - 1].is_ascii_whitespace() || bytes[index - 1] == b')')
+            && (index + 2 >= len || bytes[index + 2].is_ascii_whitespace())
         {
-            return Some(i);
+            return Some(index);
         }
     }
     None
 }
 
 /// Find the next MATCH or OPTIONAL MATCH keyword in text.
-pub(super) fn find_next_match_keyword(upper: &str) -> Option<usize> {
-    let trimmed_offset = upper.len() - upper.trim_start().len();
-    let search = &upper[trimmed_offset..];
+pub(super) fn find_next_match_keyword(text: &str) -> Option<usize> {
+    let trimmed_offset = text.len() - text.trim_start().len();
+    let search = &text[trimmed_offset..];
 
-    for (i, _) in search.char_indices() {
-        if i == 0 {
+    for (index, _) in search.char_indices() {
+        if index == 0 {
             continue;
         }
-        let remaining = &search[i..];
-        if (remaining.starts_with("OPTIONAL MATCH") || remaining.starts_with("MATCH"))
+        if (find_ascii_case_insensitive_from(search, "OPTIONAL MATCH", index) == Some(index)
+            || find_ascii_case_insensitive_from(search, "MATCH", index) == Some(index))
             && search
                 .as_bytes()
-                .get(i.wrapping_sub(1))
-                .is_none_or(|b| b.is_ascii_whitespace())
+                .get(index.wrapping_sub(1))
+                .is_none_or(|byte| byte.is_ascii_whitespace())
         {
-            return Some(trimmed_offset + i);
+            return Some(trimmed_offset + index);
         }
     }
     None
@@ -88,13 +85,13 @@ pub(super) fn split_top_level_commas(text: &str) -> Vec<&str> {
     let mut depth = 0i32;
     let mut start = 0;
 
-    for (i, ch) in text.char_indices() {
-        match ch {
+    for (index, character) in text.char_indices() {
+        match character {
             '(' | '[' | '{' => depth += 1,
             ')' | ']' | '}' => depth -= 1,
             ',' if depth == 0 => {
-                parts.push(&text[start..i]);
-                start = i + 1;
+                parts.push(&text[start..index]);
+                start = index + 1;
             }
             _ => {}
         }
@@ -105,22 +102,20 @@ pub(super) fn split_top_level_commas(text: &str) -> Vec<&str> {
 
 /// Split text by AND at top level.
 pub(super) fn split_by_and(text: &str) -> Vec<&str> {
-    let upper = text.to_uppercase();
     let mut parts = Vec::new();
     let mut start = 0;
     let mut depth = 0i32;
 
-    let bytes = upper.as_bytes();
-    for i in 0..text.len() {
-        match bytes[i] {
-            b'(' | b'[' | b'{' => depth += 1,
-            b')' | b']' | b'}' => depth -= 1,
+    for (index, character) in text.char_indices() {
+        match character {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
             _ => {}
         }
 
-        if depth == 0 && upper[i..].starts_with(" AND ") {
-            parts.push(&text[start..i]);
-            start = i + 5;
+        if depth == 0 && find_ascii_case_insensitive_from(text, " AND ", index) == Some(index) {
+            parts.push(&text[start..index]);
+            start = index + 5;
         }
     }
     parts.push(&text[start..]);

--- a/nodedb/src/engine/graph/pattern/compiler/mod.rs
+++ b/nodedb/src/engine/graph/pattern/compiler/mod.rs
@@ -25,6 +25,7 @@ use clauses::{parse_order_by, parse_return, parse_where};
 use helpers::{
     find_in_clause, find_next_match_keyword, find_top_level_keyword, split_top_level_commas,
 };
+use nodedb_sql::parser::preprocess::lex::find_ascii_case_insensitive_from;
 
 /// Parse a MATCH query string into a `MatchQuery` AST.
 ///
@@ -38,15 +39,13 @@ pub fn parse(sql: &str) -> crate::Result<MatchQuery> {
     let mut collection = None;
 
     let trimmed = sql.trim();
-    let upper = trimmed.to_uppercase();
-
-    let where_pos = find_top_level_keyword(&upper, "WHERE");
-    let return_pos = find_top_level_keyword(&upper, "RETURN");
-    let limit_pos = find_top_level_keyword(&upper, "LIMIT");
-    let order_pos = find_top_level_keyword(&upper, "ORDER BY");
+    let where_pos = find_top_level_keyword(trimmed, "WHERE");
+    let return_pos = find_top_level_keyword(trimmed, "RETURN");
+    let limit_pos = find_top_level_keyword(trimmed, "LIMIT");
+    let order_pos = find_top_level_keyword(trimmed, "ORDER BY");
     // `IN 'collection'` clause: appears after the last closing `)` and before RETURN/WHERE.
     // Use a boundary-aware scan that accepts `)` before `IN`.
-    let in_pos = find_in_clause(&upper);
+    let in_pos = find_in_clause(trimmed);
 
     // Extract collection name from `IN 'collection'` if present.
     if let Some(ip) = in_pos {
@@ -121,26 +120,27 @@ pub fn parse(sql: &str) -> crate::Result<MatchQuery> {
 /// Parse MATCH and OPTIONAL MATCH clauses from the pattern section.
 pub(super) fn parse_match_clauses(section: &str) -> crate::Result<Vec<MatchClause>> {
     let mut clauses = Vec::new();
-    let upper = section.to_uppercase();
-
     let mut pos = 0;
     while pos < section.len() {
-        let remaining_upper = &upper[pos..];
         let remaining = &section[pos..];
+        let whitespace = remaining.len() - remaining.trim_start().len();
+        let keyword_start = pos + whitespace;
 
-        let (optional, match_start) = if remaining_upper.trim_start().starts_with("OPTIONAL MATCH")
-        {
-            let ws = remaining.len() - remaining.trim_start().len();
-            (true, pos + ws + 14)
-        } else if remaining_upper.trim_start().starts_with("MATCH") {
-            let ws = remaining.len() - remaining.trim_start().len();
-            (false, pos + ws + 5)
-        } else {
-            break;
-        };
+        let (optional, match_start) =
+            if find_ascii_case_insensitive_from(section, "OPTIONAL MATCH", keyword_start)
+                == Some(keyword_start)
+            {
+                (true, keyword_start + 14)
+            } else if find_ascii_case_insensitive_from(section, "MATCH", keyword_start)
+                == Some(keyword_start)
+            {
+                (false, keyword_start + 5)
+            } else {
+                break;
+            };
 
-        let rest_upper = &upper[match_start..];
-        let next_match = find_next_match_keyword(rest_upper)
+        let rest = &section[match_start..];
+        let next_match = find_next_match_keyword(rest)
             .map(|offset| match_start + offset)
             .unwrap_or(section.len());
 
@@ -247,6 +247,37 @@ mod tests {
         assert_eq!(edge.min_hops, 1);
         assert_eq!(edge.max_hops, 3);
         assert!(edge.is_variable_length());
+    }
+
+    #[test]
+    fn optional_match_after_unicode_binding_preserves_original_offsets() {
+        let q =
+            parse("MATCH (ﬀﬀ:Person)-[:KNOWS]->(b) OPTIONAL MATCH (b)-[:LIKES]->(c) RETURN b, c")
+                .expect("graph pattern should parse");
+        assert_eq!(q.clauses.len(), 2);
+        assert!(q.clauses[1].optional);
+    }
+
+    #[test]
+    fn in_and_predicates_after_unicode_binding_preserve_original_offsets() {
+        let q = parse(
+            "MATCH (ﬀﬀ:Person)-[:KNOWS]->(b) IN 'people' \
+             WHERE ﬀﬀ.name = 'a' AND ﬀﬀ.age > 1 RETURN ﬀﬀ",
+        )
+        .expect("graph IN and WHERE predicates should parse");
+        assert_eq!(q.collection.as_deref(), Some("people"));
+        assert_eq!(q.where_predicates.len(), 2);
+        assert_eq!(q.return_columns.len(), 1);
+        assert_eq!(q.return_columns[0].expr, "ﬀﬀ");
+    }
+
+    #[test]
+    fn return_alias_after_unicode_expression_preserves_original_offsets() {
+        let q = parse("MATCH (a:Person)-[:KNOWS]->(b) RETURN ﬀﬀ AS alias")
+            .expect("graph RETURN alias should parse");
+        assert_eq!(q.return_columns.len(), 1);
+        assert_eq!(q.return_columns[0].expr, "ﬀﬀ");
+        assert_eq!(q.return_columns[0].alias.as_deref(), Some("alias"));
     }
 
     #[test]

--- a/nodedb/tests/native_show_dispatch.rs
+++ b/nodedb/tests/native_show_dispatch.rs
@@ -37,6 +37,28 @@ fn is_session_param_fallback(response: &nodedb_types::protocol::NativeResponse) 
 }
 
 #[tokio::test]
+async fn native_set_to_after_unicode_key_preserves_original_offsets() {
+    let server = NativeTestServer::start().await;
+    let (mut stream, _ack) = do_handshake(server.addr, &HelloFrame::current())
+        .await
+        .expect("handshake");
+
+    let set = send_sql(&mut stream, 1, "SET custom.ﬀﬀ TO enabled").await;
+    assert_eq!(set.status, ResponseStatus::Ok, "Unicode SET must succeed");
+    let show = send_sql(&mut stream, 2, "SHOW custom.ﬀﬀ").await;
+    server.shutdown().await;
+
+    assert_eq!(show.status, ResponseStatus::Ok, "Unicode SHOW must succeed");
+    assert!(
+        matches!(
+            show.rows.as_deref(),
+            Some([row]) if matches!(row.as_slice(), [nodedb_types::value::Value::String(value)] if value == "enabled")
+        ),
+        "SHOW must return the value stored by SET, got {show:?}"
+    );
+}
+
+#[tokio::test]
 async fn native_show_stats_not_session_fallback() {
     let server = NativeTestServer::start().await;
     let (mut stream, _ack) = do_handshake(server.addr, &HelloFrame::current())

--- a/nodedb/tests/pgwire_returning_dml.rs
+++ b/nodedb/tests/pgwire_returning_dml.rs
@@ -244,6 +244,24 @@ async fn extended_query_update_returning_star() {
 }
 
 // ---------------------------------------------------------------------------
+// UTF-8 statement boundaries
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn unicode_identifier_before_returning_preserves_connection() {
+    let server = TestServer::start().await;
+
+    server
+        .expect_error("DELETE FROM missingﬀﬀ RETURNING *", "not found")
+        .await;
+    let rows = server
+        .query_text("SELECT 1")
+        .await
+        .expect("connection must remain usable after the statement error");
+    assert_eq!(rows, vec!["1"]);
+}
+
+// ---------------------------------------------------------------------------
 // Arithmetic expression in RETURNING — error path
 // ---------------------------------------------------------------------------
 

--- a/nodedb/tests/sql_cursors.rs
+++ b/nodedb/tests/sql_cursors.rs
@@ -28,6 +28,27 @@ async fn declare_fetch_close() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unicode_cursor_name_before_for_preserves_query_boundary() {
+    let server = TestServer::start().await;
+
+    server.exec("CREATE COLLECTION data").await.unwrap();
+    server
+        .exec("INSERT INTO data (id) VALUES ('d1')")
+        .await
+        .unwrap();
+
+    server.exec("BEGIN").await.unwrap();
+    server
+        .exec("DECLARE cﬀﬀ CURSOR FOR SELECT * FROM data")
+        .await
+        .unwrap();
+    let rows = server.query_text("FETCH ALL FROM cﬀﬀ").await.unwrap();
+    assert!(!rows.is_empty(), "Unicode cursor should return data");
+    server.exec("CLOSE cﬀﬀ").await.unwrap();
+    server.exec("COMMIT").await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fetch_all_returns_data() {
     let server = TestServer::start().await;
 

--- a/nodedb/tests/sql_prepared_statements.rs
+++ b/nodedb/tests/sql_prepared_statements.rs
@@ -27,6 +27,25 @@ async fn prepare_execute_deallocate_lifecycle() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sql_prepare_unicode_name_preserves_connection() {
+    let server = TestServer::start().await;
+
+    server
+        .exec("PREPARE qﬀﬀ AS SELECT 1")
+        .await
+        .expect("Unicode prepared-statement name should parse");
+    server
+        .exec("DEALLOCATE qﬀﬀ")
+        .await
+        .expect("prepared statement should remain addressable");
+    let rows = server
+        .query_text("SELECT 1")
+        .await
+        .expect("connection must remain usable");
+    assert_eq!(rows, vec!["1"]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn prepared_search_vector_dsl() {
     let server = TestServer::start().await;
 


### PR DESCRIPTION
## Summary
- derive SQL byte offsets only from the original input string
- centralize ASCII case-insensitive forward, reverse, keyword, and literal-aware scanning
- repair affected typed DDL, Control Plane, protocol, trigger, and graph parser paths
- add expanding-Unicode regressions and persistent-connection protocol coverage

## Validation
- `cargo nextest run -p nodedb-sql --no-fail-fast` (728 passed)
- `cargo nextest run -p nodedb --lib --no-fail-fast` (4299 passed)
- focused pgwire RETURNING, SQL PREPARE, cursor, and native SET/SHOW integration regressions
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- exhaustive static security review: pass
- regression coverage and layout review: pass
