### PR TITLE
fix(pgwire): bypass cache for data-dependent point plans

### DIFF
--- a/nodedb-sql/src/types/mod.rs
+++ b/nodedb-sql/src/types/mod.rs
@@ -14,7 +14,8 @@ pub use collection::{CollectionInfo, ColumnInfo, IndexSpec, IndexState};
 pub use filter::{CompareOp, Filter, FilterExpr};
 pub use plan::{
     ArrayPrefilter, DistanceMetric, KvInsertIntent, MergeClauseKind, MergePlanAction,
-    MergePlanClause, SqlPlan, VectorAnnOptions, VectorPrimaryRow, VectorQuantization,
+    MergePlanClause, PlanCacheEligibility, SqlPlan, VectorAnnOptions, VectorPrimaryRow,
+    VectorQuantization,
 };
 pub use query::{
     AggOutputSlot, AggregateExpr, EngineType, JoinType, Projection, SortKey, SpatialPredicate,

--- a/nodedb-sql/src/types/plan/cacheability.rs
+++ b/nodedb-sql/src/types/plan/cacheability.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::query::EngineType;
+
+use super::SqlPlan;
+
+/// Whether a logical plan may be lowered once and reused from the physical-plan cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanCacheEligibility {
+    /// Lowering depends only on schema/catalog descriptors tracked by the cache.
+    Cacheable,
+    /// Lowering consults mutable row identity and must run for every execution.
+    DataDependent,
+}
+
+impl PlanCacheEligibility {
+    /// Whether the lowered physical tasks may be admitted to the plan cache.
+    pub fn is_cacheable(self) -> bool {
+        self == Self::Cacheable
+    }
+
+    fn combine(self, other: Self) -> Self {
+        if self == Self::DataDependent || other == Self::DataDependent {
+            Self::DataDependent
+        } else {
+            Self::Cacheable
+        }
+    }
+}
+
+impl SqlPlan {
+    /// Classify dependencies that are not represented by descriptor versions.
+    ///
+    /// Document point operations resolve primary-key bytes to a surrogate while
+    /// lowering. That binding can appear after an earlier miss without any
+    /// schema-version change, so those physical tasks cannot be cached.
+    pub fn cache_eligibility(&self) -> PlanCacheEligibility {
+        use PlanCacheEligibility::{Cacheable, DataDependent};
+
+        match self {
+            Self::PointGet {
+                engine: EngineType::DocumentSchemaless | EngineType::DocumentStrict,
+                ..
+            } => DataDependent,
+            Self::Update {
+                engine,
+                target_keys,
+                ..
+            }
+            | Self::Delete {
+                engine,
+                target_keys,
+                ..
+            } if !target_keys.is_empty()
+                && matches!(
+                    engine,
+                    EngineType::DocumentSchemaless | EngineType::DocumentStrict
+                ) =>
+            {
+                DataDependent
+            }
+            Self::InsertSelect { source, .. }
+            | Self::UpdateFrom { source, .. }
+            | Self::Aggregate { input: source, .. }
+            | Self::Merge { source, .. } => source.cache_eligibility(),
+            Self::Join { left, right, .. }
+            | Self::Intersect { left, right, .. }
+            | Self::Except { left, right, .. } => {
+                left.cache_eligibility().combine(right.cache_eligibility())
+            }
+            Self::Union { inputs, .. } => inputs.iter().fold(Cacheable, |eligibility, input| {
+                eligibility.combine(input.cache_eligibility())
+            }),
+            Self::Cte { definitions, outer } => definitions
+                .iter()
+                .fold(outer.cache_eligibility(), |eligibility, (_, plan)| {
+                    eligibility.combine(plan.cache_eligibility())
+                }),
+            Self::LateralTopK { outer, .. } => outer.cache_eligibility(),
+            Self::LateralLoop { outer, inner, .. } => {
+                outer.cache_eligibility().combine(inner.cache_eligibility())
+            }
+            Self::ConstantResult { .. }
+            | Self::Scan { .. }
+            | Self::PointGet { .. }
+            | Self::DocumentIndexLookup { .. }
+            | Self::RangeScan { .. }
+            | Self::Insert { .. }
+            | Self::KvInsert { .. }
+            | Self::Upsert { .. }
+            | Self::Update { .. }
+            | Self::Delete { .. }
+            | Self::Truncate { .. }
+            | Self::TimeseriesScan { .. }
+            | Self::TimeseriesIngest { .. }
+            | Self::VectorSearch { .. }
+            | Self::MultiVectorSearch { .. }
+            | Self::SparseSearch { .. }
+            | Self::TextSearch { .. }
+            | Self::HybridSearch { .. }
+            | Self::HybridSearchTriple { .. }
+            | Self::SpatialScan { .. }
+            | Self::RecursiveScan { .. }
+            | Self::RecursiveValue { .. }
+            | Self::CreateArray { .. }
+            | Self::DropArray { .. }
+            | Self::AlterArray { .. }
+            | Self::InsertArray { .. }
+            | Self::DeleteArray { .. }
+            | Self::ArraySlice { .. }
+            | Self::ArrayProject { .. }
+            | Self::ArrayAgg { .. }
+            | Self::ArrayElementwise { .. }
+            | Self::ArrayFlush { .. }
+            | Self::ArrayCompact { .. }
+            | Self::VectorPrimaryInsert { .. }
+            | Self::CreateIndex { .. }
+            | Self::DropIndex { .. } => Cacheable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types_expr::SqlValue;
+
+    fn point_get(engine: EngineType) -> SqlPlan {
+        SqlPlan::PointGet {
+            collection: "docs".into(),
+            alias: None,
+            engine,
+            key_column: "id".into(),
+            key_value: SqlValue::String("k".into()),
+            projection: Vec::new(),
+        }
+    }
+
+    fn update(engine: EngineType, target_keys: Vec<SqlValue>) -> SqlPlan {
+        SqlPlan::Update {
+            collection: "docs".into(),
+            engine,
+            assignments: Vec::new(),
+            filters: Vec::new(),
+            target_keys,
+            returning: false,
+        }
+    }
+
+    fn delete(engine: EngineType, target_keys: Vec<SqlValue>) -> SqlPlan {
+        SqlPlan::Delete {
+            collection: "docs".into(),
+            engine,
+            filters: Vec::new(),
+            target_keys,
+        }
+    }
+
+    #[test]
+    fn document_point_get_is_data_dependent() {
+        assert_eq!(
+            point_get(EngineType::DocumentStrict).cache_eligibility(),
+            PlanCacheEligibility::DataDependent
+        );
+    }
+
+    #[test]
+    fn key_value_point_get_is_cacheable() {
+        assert_eq!(
+            point_get(EngineType::KeyValue).cache_eligibility(),
+            PlanCacheEligibility::Cacheable
+        );
+    }
+
+    #[test]
+    fn document_point_update_is_data_dependent() {
+        assert_eq!(
+            update(
+                EngineType::DocumentSchemaless,
+                vec![SqlValue::String("k".into())]
+            )
+            .cache_eligibility(),
+            PlanCacheEligibility::DataDependent
+        );
+    }
+
+    #[test]
+    fn document_predicate_update_is_cacheable() {
+        assert_eq!(
+            update(EngineType::DocumentStrict, Vec::new()).cache_eligibility(),
+            PlanCacheEligibility::Cacheable
+        );
+    }
+
+    #[test]
+    fn document_point_delete_is_data_dependent() {
+        assert_eq!(
+            delete(
+                EngineType::DocumentStrict,
+                vec![SqlValue::String("k".into())]
+            )
+            .cache_eligibility(),
+            PlanCacheEligibility::DataDependent
+        );
+    }
+
+    #[test]
+    fn nested_point_dependency_propagates() {
+        let plan = SqlPlan::Cte {
+            definitions: vec![("selected".into(), point_get(EngineType::DocumentStrict))],
+            outer: Box::new(point_get(EngineType::KeyValue)),
+        };
+        assert_eq!(
+            plan.cache_eligibility(),
+            PlanCacheEligibility::DataDependent
+        );
+    }
+}

--- a/nodedb-sql/src/types/plan/mod.rs
+++ b/nodedb-sql/src/types/plan/mod.rs
@@ -2,11 +2,13 @@
 
 //! SqlPlan intermediate representation and supporting types.
 
+mod cacheability;
 mod merge_types;
 mod row_types;
 mod variants;
 mod vector_opts;
 
+pub use cacheability::PlanCacheEligibility;
 pub use merge_types::{MergeClauseKind, MergePlanAction, MergePlanClause};
 pub use row_types::{KvInsertIntent, VectorPrimaryRow};
 pub use variants::{DistanceMetric, SqlPlan};

--- a/nodedb/src/control/planner/context/query/planning.rs
+++ b/nodedb/src/control/planner/context/query/planning.rs
@@ -38,7 +38,7 @@ impl QueryContext {
         OutputSchema,
     )> {
         self.plan_with_nodedb_sql(sql, tenant_id, database_id)
-            .map(|(t, schema, _)| (t, schema))
+            .map(|(t, schema, _, _)| (t, schema))
     }
 
     /// Core planning via nodedb-sql: parse → plan → optimize → convert.
@@ -58,6 +58,7 @@ impl QueryContext {
         Vec<nodedb_physical::physical_task::PhysicalTask>,
         OutputSchema,
         crate::control::planner::descriptor_set::DescriptorVersionSet,
+        nodedb_sql::types::PlanCacheEligibility,
     )> {
         let inputs = match &self.catalog_inputs {
             Some(i) => i,
@@ -146,8 +147,16 @@ impl QueryContext {
                 &catalog,
                 database_id,
             );
+        let cache_eligibility = if plans
+            .iter()
+            .all(|plan| plan.cache_eligibility().is_cacheable())
+        {
+            nodedb_sql::types::PlanCacheEligibility::Cacheable
+        } else {
+            nodedb_sql::types::PlanCacheEligibility::DataDependent
+        };
         let tasks = crate::control::planner::sql_plan_convert::convert(&plans, tenant_id, &ctx)?;
-        Ok((tasks, output_schema, version_set))
+        Ok((tasks, output_schema, version_set, cache_eligibility))
     }
 
     /// Parse SQL, inject RLS predicates, convert to physical plan.
@@ -184,7 +193,7 @@ impl QueryContext {
     )> {
         self.plan_sql_with_rls_and_versions(sql, tenant_id, database_id, sec, returning)
             .await
-            .map(|(tasks, schema, _)| (tasks, schema))
+            .map(|(tasks, schema, _, _)| (tasks, schema))
     }
 
     /// Variant of [`plan_sql_with_rls_returning`] that also
@@ -204,8 +213,9 @@ impl QueryContext {
         Vec<nodedb_physical::physical_task::PhysicalTask>,
         OutputSchema,
         crate::control::planner::descriptor_set::DescriptorVersionSet,
+        nodedb_sql::types::PlanCacheEligibility,
     )> {
-        let (mut tasks, output_schema, version_set) =
+        let (mut tasks, output_schema, version_set, cache_eligibility) =
             self.plan_with_nodedb_sql(sql, tenant_id, database_id)?;
 
         // Inject RLS predicates.
@@ -218,7 +228,7 @@ impl QueryContext {
             )?;
         }
 
-        Ok((tasks, output_schema, version_set))
+        Ok((tasks, output_schema, version_set, cache_eligibility))
     }
 
     /// Plan SQL with bound parameters and RLS injection.

--- a/nodedb/src/control/server/pgwire/handler/routing/planning.rs
+++ b/nodedb/src/control/server/pgwire/handler/routing/planning.rs
@@ -171,7 +171,7 @@ impl NodeDbPgHandler {
             let scope = self.state.acquire_plan_lease_scope(&versions);
             (tasks, output_schema, scope)
         } else {
-            let (planned, output_schema, versions) =
+            let (planned, output_schema, versions, cache_eligibility) =
                 super::super::retry::retry_on_schema_change(|| async {
                     let perm_cache = self.state.permission_cache.read().await;
                     let sec = crate::control::planner::context::PlanSecurityContext {
@@ -203,11 +203,12 @@ impl NodeDbPgHandler {
                 })?;
 
             let scope = self.state.acquire_plan_lease_scope(&versions);
-            // Do not cache a plan built under a strategy-knob override (force
-            // shuffle, or a non-default broadcast threshold) — the cache key
-            // does not encode the session knob, so caching it would leak a
-            // strategy-specific plan into later default queries on this session.
-            if !bypass_cache {
+            // Strategy overrides and data-dependent identity lowering are not
+            // represented by the cache key. Document point plans resolve a
+            // mutable PK→surrogate binding while lowering, so caching either a
+            // sentinel miss or a partially resolved target set would preserve
+            // stale row identity across later writes.
+            if !bypass_cache && cache_eligibility.is_cacheable() {
                 self.sessions.put_cached_plan(
                     addr,
                     &clean_sql,

--- a/nodedb/tests/point_get_after_miss_then_insert.rs
+++ b/nodedb/tests/point_get_after_miss_then_insert.rs
@@ -76,6 +76,235 @@ async fn assert_miss_then_insert_then_hit(srv: &TestServer, create: &str, pk_col
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn strict_simple_query_replans_absent_point_identity_after_insert() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_identity (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_strict')",
+    )
+    .await
+    .expect("create strict collection");
+
+    let lookup = "SELECT v FROM cached_identity WHERE id = 'k1'";
+    let miss = srv.query_rows(lookup).await.expect("initial point miss");
+    assert!(miss.is_empty(), "key must initially be absent: {miss:?}");
+
+    srv.exec("INSERT INTO cached_identity (id, v) VALUES ('k1', 'visible')")
+        .await
+        .expect("insert previously absent key");
+
+    let hit = srv
+        .query_rows(lookup)
+        .await
+        .expect("identical point lookup after insert");
+    assert_eq!(
+        hit,
+        vec![vec!["visible".to_string()]],
+        "byte-identical simple query must resolve the identity created by the committed insert"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn schemaless_simple_query_replans_absent_point_identity_after_insert() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_schemaless (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_schemaless')",
+    )
+    .await
+    .expect("create schemaless collection");
+
+    let lookup = "SELECT v FROM cached_schemaless WHERE id = 'k1'";
+    assert!(
+        srv.query_rows(lookup)
+            .await
+            .expect("initial point miss")
+            .is_empty()
+    );
+    srv.exec("INSERT INTO cached_schemaless (id, v) VALUES ('k1', 'visible')")
+        .await
+        .expect("insert previously absent key");
+
+    let hit = srv
+        .query_rows(lookup)
+        .await
+        .expect("identical point lookup after insert");
+    assert_eq!(
+        hit,
+        vec![vec!["visible".to_string()]],
+        "schemaless point lookup must resolve the identity created after its initial miss"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parameterless_extended_query_replans_absent_point_identity_after_insert() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_extended (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_strict')",
+    )
+    .await
+    .expect("create strict collection");
+
+    let statement = srv
+        .client
+        .prepare("SELECT v FROM cached_extended WHERE id = 'k1'")
+        .await
+        .expect("prepare literal point lookup");
+    let miss = srv
+        .client
+        .query(&statement, &[])
+        .await
+        .expect("initial prepared point miss");
+    assert!(miss.is_empty(), "key must initially be absent");
+
+    srv.exec("INSERT INTO cached_extended (id, v) VALUES ('k1', 'visible')")
+        .await
+        .expect("insert previously absent key");
+
+    let hit = srv
+        .client
+        .query(&statement, &[])
+        .await
+        .expect("repeat prepared point lookup after insert");
+    assert_eq!(
+        hit.len(),
+        1,
+        "parameterless extended query must observe the committed insert"
+    );
+    let value: &str = hit[0].get("v");
+    assert_eq!(value, "visible");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn point_update_replans_identity_created_after_initial_no_match() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_update (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_strict')",
+    )
+    .await
+    .expect("create strict collection");
+
+    let update = "UPDATE cached_update SET v = 'updated' WHERE id = 'k1'";
+    srv.exec(update).await.expect("initial no-match update");
+    srv.exec("INSERT INTO cached_update (id, v) VALUES ('k1', 'initial')")
+        .await
+        .expect("insert previously absent key");
+    srv.exec(update)
+        .await
+        .expect("repeat identical update after insert");
+
+    let rows = srv
+        .query_rows("SELECT v FROM cached_update WHERE id = 'k1'")
+        .await
+        .expect("read updated row");
+    assert_eq!(
+        rows,
+        vec![vec!["updated".to_string()]],
+        "point UPDATE must resolve a key created after the statement first matched no row"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn point_delete_replans_identity_created_after_initial_no_match() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_delete (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_strict')",
+    )
+    .await
+    .expect("create strict collection");
+
+    let delete = "DELETE FROM cached_delete WHERE id = 'k1'";
+    srv.exec(delete).await.expect("initial no-match delete");
+    srv.exec("INSERT INTO cached_delete (id, v) VALUES ('k1', 'present')")
+        .await
+        .expect("insert previously absent key");
+    srv.exec(delete)
+        .await
+        .expect("repeat identical delete after insert");
+
+    let rows = srv
+        .query_rows("SELECT v FROM cached_delete WHERE id = 'k1'")
+        .await
+        .expect("verify point delete");
+    assert!(
+        rows.is_empty(),
+        "point DELETE must resolve and remove a key created after the statement first matched no row: {rows:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multi_key_update_replans_identities_missing_from_initial_target_set() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_multi_update (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_strict')",
+    )
+    .await
+    .expect("create strict collection");
+    srv.exec("INSERT INTO cached_multi_update (id, v) VALUES ('a', 'initial')")
+        .await
+        .expect("insert initial key");
+
+    let update = "UPDATE cached_multi_update SET v = 'updated' WHERE id IN ('a', 'b')";
+    srv.exec(update)
+        .await
+        .expect("initial partial-target update");
+    srv.exec("INSERT INTO cached_multi_update (id, v) VALUES ('b', 'initial')")
+        .await
+        .expect("insert key missing from initial target set");
+    srv.exec(update)
+        .await
+        .expect("repeat identical multi-key update");
+
+    let rows = srv
+        .query_rows("SELECT v FROM cached_multi_update WHERE id = 'b'")
+        .await
+        .expect("read later-created target");
+    assert_eq!(
+        rows,
+        vec![vec!["updated".to_string()]],
+        "multi-key UPDATE must not permanently omit identities absent during initial planning"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multi_key_delete_replans_identities_missing_from_initial_target_set() {
+    let srv = TestServer::start().await;
+    srv.exec(
+        "CREATE COLLECTION cached_multi_delete (id STRING PRIMARY KEY, v STRING) \
+         WITH (engine='document_strict')",
+    )
+    .await
+    .expect("create strict collection");
+    srv.exec("INSERT INTO cached_multi_delete (id, v) VALUES ('a', 'present')")
+        .await
+        .expect("insert initial key");
+
+    let delete = "DELETE FROM cached_multi_delete WHERE id IN ('a', 'b')";
+    srv.exec(delete)
+        .await
+        .expect("initial partial-target delete");
+    srv.exec("INSERT INTO cached_multi_delete (id, v) VALUES ('b', 'present')")
+        .await
+        .expect("insert key missing from initial target set");
+    srv.exec(delete)
+        .await
+        .expect("repeat identical multi-key delete");
+
+    let rows = srv
+        .query_rows("SELECT v FROM cached_multi_delete WHERE id = 'b'")
+        .await
+        .expect("verify later-created target deletion");
+    assert!(
+        rows.is_empty(),
+        "multi-key DELETE must not permanently omit identities absent during initial planning: {rows:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn schemaless_point_get_after_miss_then_insert_is_visible() {
     let srv = TestServer::start().await;
     assert_miss_then_insert_then_hit(


### PR DESCRIPTION
## Summary
- classify document point reads and PK-targeted mutations as data-dependent plans
- keep mutable PK-to-surrogate bindings out of the schema-only physical-plan cache
- cover simple and extended query reads plus point and multi-key UPDATE/DELETE regressions

## Validation
- `cargo nextest run -p nodedb --test point_get_after_miss_then_insert`
- `cargo nextest run -p nodedb-sql -E 'test(cacheability)'`\n- `cargo clippy -p nodedb -p nodedb-sql --all-targets -- -D warnings`\n- `cargo fmt --all --check`