### PR TITLE
fix: join LIMIT applied before WHERE, and same-named output columns collapsing

### DIFF
--- a/nodedb/src/control/server/http/routes/query_stream.rs
+++ b/nodedb/src/control/server/http/routes/query_stream.rs
@@ -122,6 +122,9 @@ pub(super) fn ndjson_body_stream(
                     return;
                 }
             };
+            // Row maps are keyed by `ShapedRows::cell_keys`, so each NDJSON
+            // line serializes as-is; two output columns sharing a name emit
+            // `{"id": …, "id_1": …}` rather than collapsing to one cell.
             let shaped = shape_decoded_rows(&value, projection.as_ref());
             for row in shaped.rows {
                 if emitted >= limit {

--- a/nodedb/src/control/server/http/routes/result_shape.rs
+++ b/nodedb/src/control/server/http/routes/result_shape.rs
@@ -47,6 +47,11 @@ pub(super) fn shape_http_payload(
         database_id,
         tenant_id,
     )? {
+        // Each row map is already keyed by `ShapedRows::cell_keys`, so it
+        // serializes to JSON as-is. When two output columns share a name the
+        // later one carries a `_<n>` suffix (`SELECT w.id, b.id` →
+        // `{"id": …, "id_1": …}`) — a JSON object cannot repeat a key, and
+        // dropping the duplicate would silently lose a projected column.
         ShapeOutcome::Rows(shaped) => Ok(HttpShaped::Rows(
             shaped
                 .rows
@@ -111,6 +116,8 @@ pub(super) fn ddl_results_to_json(
                     "tag": command,
                 }));
             }
+            // Keyed by `ShapedRows::cell_keys`, same JSON contract as
+            // `shape_http_payload` above (duplicate names take a `_<n>` key).
             DdlResult::Rows(shaped) => {
                 for row in shaped.rows {
                     rows.push(serde_json::Value::Object(row));

--- a/nodedb/src/control/server/native/dispatch/conversion.rs
+++ b/nodedb/src/control/server/native/dispatch/conversion.rs
@@ -146,15 +146,18 @@ pub(crate) fn calvin_native_response(
 /// `json_to_value_display`; a column absent from a given row's map becomes
 /// `Value::Null`.
 pub(crate) fn to_native_columns_rows(shaped: &ShapedRows) -> (Vec<String>, Vec<Vec<Value>>) {
+    // Cells live in the row maps under unique per-column keys (display names
+    // may repeat across columns, e.g. `SELECT w.id, b.id`); derive the same
+    // keys the shaper used so every column reads its own cell.
+    let cell_keys = crate::control::server::response_shape::project::cell_keys(&shaped.columns);
     let rows = shaped
         .rows
         .iter()
         .map(|row| {
-            shaped
-                .columns
+            cell_keys
                 .iter()
-                .map(|col| {
-                    row.get(col.as_str())
+                .map(|key| {
+                    row.get(key.as_str())
                         .map(json_to_value_display)
                         .unwrap_or(Value::Null)
                 })

--- a/nodedb/src/control/server/native/dispatch/conversion.rs
+++ b/nodedb/src/control/server/native/dispatch/conversion.rs
@@ -146,10 +146,10 @@ pub(crate) fn calvin_native_response(
 /// `json_to_value_display`; a column absent from a given row's map becomes
 /// `Value::Null`.
 pub(crate) fn to_native_columns_rows(shaped: &ShapedRows) -> (Vec<String>, Vec<Vec<Value>>) {
-    // Cells live in the row maps under unique per-column keys (display names
-    // may repeat across columns, e.g. `SELECT w.id, b.id`); derive the same
-    // keys the shaper used so every column reads its own cell.
-    let cell_keys = crate::control::server::response_shape::project::cell_keys(&shaped.columns);
+    // Cells live in the row maps under per-column keys (display names may
+    // repeat across columns, e.g. `SELECT w.id, b.id`), so read through the
+    // shared accessor rather than by display name.
+    let cell_keys = shaped.cell_keys();
     let rows = shaped
         .rows
         .iter()

--- a/nodedb/src/control/server/pgwire/handler/shape_encode.rs
+++ b/nodedb/src/control/server/pgwire/handler/shape_encode.rs
@@ -146,6 +146,10 @@ pub(in crate::control::server::pgwire) fn shaped_query_response(
     shaped: ShapedRows,
     formats: &[FieldFormat],
 ) -> (Response, Option<String>) {
+    // Cells live in the row maps under per-column keys that differ from the
+    // display names only when two columns share a name; derived here before
+    // the struct is destructured.
+    let keys = shaped.cell_keys();
     let ShapedRows {
         columns,
         column_types,
@@ -164,9 +168,6 @@ pub(in crate::control::server::pgwire) fn shaped_query_response(
         .collect();
     let schema = Arc::new(fields);
 
-    // Cells live in the row maps under unique per-column keys (display names
-    // may repeat across columns); derive the same keys the shaper used.
-    let keys = crate::control::server::response_shape::project::cell_keys(&columns);
     let encoded_rows: Vec<PgWireResult<DataRow>> = rows
         .iter()
         .map(|row| encode_shaped_row(&schema, &keys, &column_types, formats, row))

--- a/nodedb/src/control/server/pgwire/handler/shape_encode.rs
+++ b/nodedb/src/control/server/pgwire/handler/shape_encode.rs
@@ -28,22 +28,27 @@ use crate::control::server::response_shape::types::{DdlColType, ShapedRows};
 
 use super::super::ddl_encode::col_type_to_field_with_format;
 
-/// Encode one flat row object into a pgwire `DataRow`, using `columns` (in
-/// order) to look up cells in `row` and `column_types` (parallel to `columns`)
-/// to pick each cell's text rendering.
+/// Encode one flat row object into a pgwire `DataRow`, using `cell_keys` (in
+/// order) to look up cells in `row` and `column_types` (parallel to
+/// `cell_keys`) to pick each cell's text rendering.
+///
+/// `cell_keys` are the per-column unique row-map keys derived from the
+/// display names via `response_shape::project::cell_keys` — identical to the
+/// display names except where those repeat (`SELECT w.id, b.id`), in which
+/// case later duplicates carry a `_n` suffix so both cells survive the map.
 ///
 /// Missing keys and explicit JSON `null` both encode as SQL NULL. Every other
 /// cell renders per its column type via [`encode_typed_cell`]; a
 /// missing/short `column_types` entry defaults to `Text`.
 pub(in crate::control::server::pgwire) fn encode_shaped_row(
     schema: &Arc<Vec<FieldInfo>>,
-    columns: &[String],
+    cell_keys: &[String],
     column_types: &[DdlColType],
     formats: &[FieldFormat],
     row: &serde_json::Map<String, serde_json::Value>,
 ) -> PgWireResult<DataRow> {
     let mut encoder = DataRowEncoder::new(schema.clone());
-    for (idx, name) in columns.iter().enumerate() {
+    for (idx, name) in cell_keys.iter().enumerate() {
         let ct = column_types.get(idx).copied().unwrap_or(DdlColType::Text);
         let format = formats.get(idx).copied().unwrap_or(FieldFormat::Text);
         match row.get(name) {
@@ -159,9 +164,12 @@ pub(in crate::control::server::pgwire) fn shaped_query_response(
         .collect();
     let schema = Arc::new(fields);
 
+    // Cells live in the row maps under unique per-column keys (display names
+    // may repeat across columns); derive the same keys the shaper used.
+    let keys = crate::control::server::response_shape::project::cell_keys(&columns);
     let encoded_rows: Vec<PgWireResult<DataRow>> = rows
         .iter()
-        .map(|row| encode_shaped_row(&schema, &columns, &column_types, formats, row))
+        .map(|row| encode_shaped_row(&schema, &keys, &column_types, formats, row))
         .collect();
 
     let response = Response::Query(QueryResponse::new(

--- a/nodedb/src/control/server/pgwire/handler/stream_response.rs
+++ b/nodedb/src/control/server/pgwire/handler/stream_response.rs
@@ -107,6 +107,10 @@ pub(crate) fn streaming_shaped_response(
         .iter()
         .map(|c| c.display_name.clone())
         .collect();
+    // Cells live in the shaped row maps under unique per-column keys
+    // (display names may repeat across columns, e.g. `SELECT w.id, b.id`);
+    // derive the same keys the shaper used so every column reads its own cell.
+    let cell_keys = crate::control::server::response_shape::project::cell_keys(&display_columns);
     // Advertise each projected column's real catalog type so the streaming
     // path's RowDescription OIDs match the non-streaming `shaped_query_response`
     // (and the extended-query Describe path); `column_types` also drives the
@@ -160,7 +164,7 @@ pub(crate) fn streaming_shaped_response(
                     break;
                 }
                 let encoded =
-                    encode_shaped_row(&row_schema, &display_columns, &column_types, &row_formats, row)?;
+                    encode_shaped_row(&row_schema, &cell_keys, &column_types, &row_formats, row)?;
                 emitted += 1;
                 yield encoded;
             }

--- a/nodedb/src/control/server/response_shape/compose.rs
+++ b/nodedb/src/control/server/response_shape/compose.rs
@@ -244,9 +244,15 @@ pub fn shape_decoded_rows(decoded: &JsonValue, projection: Option<&OutputSchema>
             let lookup_keys: Vec<String> = s.columns.iter().map(|c| c.lookup_key.clone()).collect();
             let display_names: Vec<String> =
                 s.columns.iter().map(|c| c.display_name.clone()).collect();
+            // Row cells are stored under per-column unique keys, not display
+            // names: duplicate display names (`SELECT w.id, b.id` → `id`,
+            // `id`) would collide in the row map and collapse both wire
+            // columns to the last value. Encoders re-derive the same keys via
+            // `cell_keys` when reading cells.
+            let keys = super::project::cell_keys(&display_names);
             let projected_rows = rows
                 .iter()
-                .map(|row| project_row(row, &lookup_keys, &display_names))
+                .map(|row| project_row(row, &lookup_keys, &display_names, &keys))
                 .collect();
             // Carry each projected column's real catalog type, aligned in
             // order with `display_names`. Only the pgwire encoder consumes
@@ -280,10 +286,15 @@ pub fn shape_decoded_rows(decoded: &JsonValue, projection: Option<&OutputSchema>
 /// Select and rename one flat row's fields per the projection lists, trying
 /// each candidate key in order: the full lookup key, then the bare
 /// (post-dot) column name, then the SELECT alias.
+///
+/// Cells are inserted under `cell_keys` (unique per column, see
+/// [`super::project::cell_keys`]) rather than the display names, which may
+/// repeat across columns and would otherwise collapse in the output map.
 fn project_row(
     row: &Map<String, JsonValue>,
     lookup_keys: &[String],
     display_names: &[String],
+    cell_keys: &[String],
 ) -> Map<String, JsonValue> {
     let mut out = Map::new();
     for (i, lookup_key) in lookup_keys.iter().enumerate() {
@@ -313,7 +324,8 @@ fn project_row(
             })
             .cloned()
             .unwrap_or(JsonValue::Null);
-        out.insert(display_name.to_string(), value);
+        let cell_key = cell_keys.get(i).map(String::as_str).unwrap_or(display_name);
+        out.insert(cell_key.to_string(), value);
     }
     out
 }
@@ -370,5 +382,46 @@ fn single_result_row(text: String) -> ShapedRows {
         column_types: ShapedRows::text_types(1),
         rows: vec![map],
         notice: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two projected columns sharing the display name `id` (`SELECT w.id,
+    /// b.id`) must keep both values in the shaped row instead of collapsing
+    /// to the last table's value.
+    #[test]
+    fn project_row_keeps_both_columns_with_duplicate_display_names() {
+        let mut row = Map::new();
+        row.insert("w.id".to_string(), JsonValue::String("w1".to_string()));
+        row.insert("b.id".to_string(), JsonValue::String("b1".to_string()));
+
+        let lookup_keys = vec!["w.id".to_string(), "b.id".to_string()];
+        let display_names = vec!["id".to_string(), "id".to_string()];
+        let keys = super::super::project::cell_keys(&display_names);
+
+        let out = project_row(&row, &lookup_keys, &display_names, &keys);
+        assert_eq!(out.len(), 2, "both cells must survive the projection");
+        assert_eq!(out.get("id"), Some(&JsonValue::String("w1".to_string())));
+        assert_eq!(out.get("id_1"), Some(&JsonValue::String("b1".to_string())));
+    }
+
+    /// Duplicate-free projections still store cells under the display name
+    /// (`cell_keys` is the identity), so existing readers are unaffected.
+    #[test]
+    fn project_row_uses_display_names_when_unique() {
+        let mut row = Map::new();
+        row.insert("w.id".to_string(), JsonValue::String("w1".to_string()));
+        row.insert("b.title".to_string(), JsonValue::String("t".to_string()));
+
+        let lookup_keys = vec!["w.id".to_string(), "b.title".to_string()];
+        let display_names = vec!["id".to_string(), "title".to_string()];
+        let keys = super::super::project::cell_keys(&display_names);
+
+        let out = project_row(&row, &lookup_keys, &display_names, &keys);
+        assert_eq!(out.get("id"), Some(&JsonValue::String("w1".to_string())));
+        assert_eq!(out.get("title"), Some(&JsonValue::String("t".to_string())));
     }
 }

--- a/nodedb/src/control/server/response_shape/project.rs
+++ b/nodedb/src/control/server/response_shape/project.rs
@@ -55,3 +55,69 @@ pub fn is_scan_wrapper(map: &serde_json::Map<String, serde_json::Value>) -> bool
         && matches!(map.get("id"), Some(serde_json::Value::String(_)))
         && matches!(map.get("data"), Some(serde_json::Value::Object(_)))
 }
+
+/// Unique per-column cell keys for a shaped column list.
+///
+/// SQL output column names may legally repeat — `SELECT w.id, b.id` displays
+/// both columns as `id` — but a shaped row is a JSON map and cannot hold two
+/// cells under one key: inserting the second cell would overwrite the first,
+/// making both wire columns render the last value. The shaper therefore
+/// stores the first occurrence of a name under the name itself and each later
+/// duplicate under `<name>_<n>` (n = 1, 2, …), skipping any candidate that
+/// collides with another column's name. Row writers and every protocol
+/// encoder derive keys through this one function so they always agree; for a
+/// duplicate-free column list this is the identity mapping.
+pub fn cell_keys(columns: &[String]) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let names: HashSet<&str> = columns.iter().map(String::as_str).collect();
+    let mut used: HashSet<String> = HashSet::with_capacity(columns.len());
+    columns
+        .iter()
+        .map(|name| {
+            if used.insert(name.clone()) {
+                return name.clone();
+            }
+            let mut n = 1usize;
+            loop {
+                let candidate = format!("{name}_{n}");
+                if !names.contains(candidate.as_str()) && used.insert(candidate.clone()) {
+                    return candidate;
+                }
+                n += 1;
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cell_keys;
+
+    fn keys(cols: &[&str]) -> Vec<String> {
+        cell_keys(&cols.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    }
+
+    /// Duplicate-free column lists map to themselves.
+    #[test]
+    fn cell_keys_is_identity_without_duplicates() {
+        assert_eq!(keys(&["id", "name", "score"]), ["id", "name", "score"]);
+        assert_eq!(keys(&[]), Vec::<String>::new());
+    }
+
+    /// Later duplicates get a `_n` suffix; the first occurrence keeps the
+    /// bare name (`SELECT w.id, b.id` → `id`, `id_1`).
+    #[test]
+    fn cell_keys_suffixes_later_duplicates() {
+        assert_eq!(keys(&["id", "id"]), ["id", "id_1"]);
+        assert_eq!(keys(&["id", "id", "id"]), ["id", "id_1", "id_2"]);
+    }
+
+    /// A suffix candidate never collides with a real column of that name:
+    /// with columns `id, id, id_1` the second `id` skips `id_1` (taken by a
+    /// real column) and becomes `id_2`.
+    #[test]
+    fn cell_keys_skips_candidates_that_shadow_real_columns() {
+        assert_eq!(keys(&["id", "id", "id_1"]), ["id", "id_2", "id_1"]);
+    }
+}

--- a/nodedb/src/control/server/response_shape/types.rs
+++ b/nodedb/src/control/server/response_shape/types.rs
@@ -228,6 +228,10 @@ pub struct ShapedRows {
     /// type OIDs; the native and http entrypoints ignore it. `Text` is used
     /// wherever the source type is unknown.
     pub column_types: Vec<DdlColType>,
+    /// One map per row. Cells are keyed by [`ShapedRows::cell_keys`], NOT by
+    /// `columns` directly — SQL output names may repeat (`SELECT w.id, b.id`
+    /// displays both as `id`) and a map cannot hold two cells under one key.
+    /// Read cells through `cell_keys` so each column reads its own value.
     pub rows: Vec<serde_json::Map<String, serde_json::Value>>,
     pub notice: Option<String>,
 }
@@ -237,5 +241,25 @@ impl ShapedRows {
     /// construction sites whose consumers (native/http) ignore column types.
     pub fn text_types(n: usize) -> Vec<DdlColType> {
         vec![DdlColType::Text; n]
+    }
+
+    /// Per-column keys for reading cells out of [`ShapedRows::rows`], parallel
+    /// to `columns`.
+    ///
+    /// This is the single source of truth every consumer shares — the pgwire
+    /// encoders, the native converter, and the HTTP JSON serializers all key
+    /// rows through it, so the row-map layout can never drift from what a
+    /// consumer expects.
+    ///
+    /// Identical to `columns` unless two output columns share a name, in which
+    /// case later duplicates take a `_<n>` suffix (see
+    /// [`super::project::cell_keys`]). Because the HTTP transports serialize a
+    /// row map directly to JSON, that suffix is user-visible there: a
+    /// duplicate-name `SELECT w.id, b.id` emits `{"id": …, "id_1": …}`, since
+    /// a JSON object likewise cannot carry the same key twice. pgwire and
+    /// native are positional on the wire and still report both columns as
+    /// `id`, matching PostgreSQL.
+    pub fn cell_keys(&self) -> Vec<String> {
+        super::project::cell_keys(&self.columns)
     }
 }

--- a/nodedb/src/data/executor/handlers/join/hash_handlers.rs
+++ b/nodedb/src/data/executor/handlers/join/hash_handlers.rs
@@ -333,7 +333,17 @@ impl CoreLoop {
         // budget) and, if the probe fills it, surface a deterministic
         // `ResourcesExhausted` rather than dropping the excess rows. A budget
         // of 0 means "unlimited" → truly unbounded output.
-        let (probe_limit, enforce_output_budget) = if join.limit != usize::MAX {
+        //
+        // A user LIMIT may only cap the probe when there are no post-join
+        // WHERE filters: `filter_and_project` runs AFTER the probe, so
+        // truncating to `n` first would emit the first `n` ON-matched rows and
+        // then discard those failing the WHERE clause — under-filling (or
+        // emptying) the result even though later probe rows match. With
+        // post-filters present the probe runs under the budget ceiling and the
+        // user LIMIT is applied after filtering, below.
+        let has_post_filters = !join.post_filter_bytes.is_empty();
+        let (probe_limit, enforce_output_budget) = if join.limit != usize::MAX && !has_post_filters
+        {
             (join.limit, false)
         } else if budget == 0 {
             (usize::MAX, false)
@@ -372,6 +382,13 @@ impl CoreLoop {
                     detail: e.to_string(),
                 },
             );
+        }
+
+        // Deferred user LIMIT: when post-join WHERE filters exist the probe
+        // ran unbounded (see above) so the LIMIT must be applied here, after
+        // the filters have retained the matching rows.
+        if has_post_filters && join.limit != usize::MAX {
+            results.truncate(join.limit);
         }
 
         let payload = super::super::super::response_codec::encode_binary_rows(&results);

--- a/nodedb/tests/http_result_projection.rs
+++ b/nodedb/tests/http_result_projection.rs
@@ -220,3 +220,76 @@ async fn http_vector_search_serializes_distance() {
         "distance must be numeric, got {distance:?}"
     );
 }
+
+// ── duplicate output column names ────────────────────────────────────────────
+
+/// POST `sql` to `/v1/query/stream` and return one parsed JSON value per
+/// NDJSON line.
+async fn query_stream_lines(http_port: u16, sql: &str) -> Vec<serde_json::Value> {
+    let url = format!("http://127.0.0.1:{http_port}/v1/query/stream");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({ "sql": sql }))
+        .send()
+        .await
+        .expect("POST /v1/query/stream");
+    assert!(
+        resp.status().is_success(),
+        "stream query must succeed over HTTP: {} — sql={sql}",
+        resp.status()
+    );
+    let body = resp.text().await.expect("read NDJSON body");
+    body.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("parse NDJSON line {l:?}: {e}")))
+        .collect()
+}
+
+/// Two joined collections both projecting `id` must keep BOTH values in the
+/// HTTP JSON row. A JSON object cannot repeat a key, so the second column
+/// lands under the `_<n>`-suffixed cell key (`id_1`) — dropping it would
+/// silently lose a projected column, which is what the row map did before
+/// cells were keyed independently of the display name.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_keeps_both_cells_for_duplicate_column_names() {
+    let srv = TestServer::start().await;
+    srv.exec("CREATE COLLECTION nb_dup_w (id TEXT PRIMARY KEY, wname TEXT) WITH (engine='document_strict')")
+        .await
+        .expect("create nb_dup_w");
+    srv.exec("CREATE COLLECTION nb_dup_b (id TEXT PRIMARY KEY, ref TEXT) WITH (engine='document_strict')")
+        .await
+        .expect("create nb_dup_b");
+    srv.exec("INSERT INTO nb_dup_w (id, wname) VALUES ('w1','alpha')")
+        .await
+        .expect("insert nb_dup_w");
+    srv.exec("INSERT INTO nb_dup_b (id, ref) VALUES ('b1','w1')")
+        .await
+        .expect("insert nb_dup_b");
+
+    let sql = "SELECT w.id, b.id FROM nb_dup_w w JOIN nb_dup_b b ON b.ref = w.id";
+    let rows = query_rows(srv.http_port, sql).await;
+    let stream_rows = query_stream_lines(srv.http_port, sql).await;
+    srv.graceful_shutdown().await;
+
+    assert_eq!(rows.len(), 1, "one joined row expected: {rows:?}");
+    let obj = rows[0].as_object().expect("row is a JSON object");
+    assert_eq!(
+        obj.get("id").and_then(|v| v.as_str()),
+        Some("w1"),
+        "first `id` must carry the left table's value: {obj:?}"
+    );
+    assert_eq!(
+        obj.get("id_1").and_then(|v| v.as_str()),
+        Some("b1"),
+        "the duplicate `id` must survive under the suffixed key: {obj:?}"
+    );
+
+    // The NDJSON streaming path serializes the same row maps, so it carries
+    // the identical contract.
+    assert_eq!(stream_rows.len(), 1, "one streamed row: {stream_rows:?}");
+    let stream_obj = stream_rows[0]
+        .as_object()
+        .expect("streamed row is an object");
+    assert_eq!(stream_obj.get("id").and_then(|v| v.as_str()), Some("w1"));
+    assert_eq!(stream_obj.get("id_1").and_then(|v| v.as_str()), Some("b1"));
+}

--- a/nodedb/tests/pg_catalog_reflection.rs
+++ b/nodedb/tests/pg_catalog_reflection.rs
@@ -548,6 +548,86 @@ async fn cross_vtable_join_filters_on_joined_column() {
     );
 }
 
+/// A JOIN carrying BOTH a WHERE predicate and a LIMIT must still return the
+/// matching rows. The WHERE clause on a catalog join is evaluated after the
+/// join (there is no scan to push it into), so a LIMIT applied during the
+/// probe would cap the output before filtering and drop — often empty — the
+/// rows that actually match.
+#[tokio::test]
+async fn cross_vtable_join_with_where_and_limit_returns_matching_rows() {
+    let srv = TestServer::start().await;
+    srv.exec("CREATE COLLECTION reflect_join_where_limit (id INTEGER PRIMARY KEY)")
+        .await
+        .expect("create collection");
+
+    let unlimited = srv
+        .query_text(
+            "SELECT t.typname FROM pg_type t \
+             LEFT JOIN pg_range r ON t.oid = r.rngtypid \
+             WHERE t.typname = 'int4'",
+        )
+        .await
+        .expect("join with WHERE evaluates");
+    assert_eq!(
+        unlimited,
+        vec!["int4".to_string()],
+        "baseline: the unlimited join must return the matching type"
+    );
+
+    let limited = srv
+        .query_text(
+            "SELECT t.typname FROM pg_type t \
+             LEFT JOIN pg_range r ON t.oid = r.rngtypid \
+             WHERE t.typname = 'int4' LIMIT 5",
+        )
+        .await
+        .expect("join with WHERE and LIMIT evaluates");
+    assert_eq!(
+        limited, unlimited,
+        "a LIMIT wider than the result must not drop rows that satisfy the WHERE clause"
+    );
+}
+
+/// A LIMIT narrower than the filtered result set still truncates — the LIMIT
+/// moves after the post-join filter, it is not discarded.
+#[tokio::test]
+async fn cross_vtable_join_with_where_honors_narrow_limit() {
+    let srv = TestServer::start().await;
+    srv.exec("CREATE COLLECTION reflect_narrow_limit_a (id INTEGER PRIMARY KEY)")
+        .await
+        .expect("create collection");
+    srv.exec("CREATE COLLECTION reflect_narrow_limit_b (id INTEGER PRIMARY KEY)")
+        .await
+        .expect("create collection");
+
+    let unlimited = srv
+        .query_text(
+            "SELECT c.relname FROM pg_class c \
+             JOIN pg_namespace n ON n.oid = c.relnamespace \
+             WHERE n.nspname = 'public'",
+        )
+        .await
+        .expect("join with WHERE evaluates");
+    assert!(
+        unlimited.len() > 1,
+        "test needs a multi-row baseline to check truncation, got {unlimited:?}"
+    );
+
+    let limited = srv
+        .query_text(
+            "SELECT c.relname FROM pg_class c \
+             JOIN pg_namespace n ON n.oid = c.relnamespace \
+             WHERE n.nspname = 'public' LIMIT 1",
+        )
+        .await
+        .expect("join with WHERE and LIMIT evaluates");
+    assert_eq!(
+        limited.len(),
+        1,
+        "LIMIT 1 must truncate the filtered rows to one: {limited:?}"
+    );
+}
+
 /// The three-way `pg_class ⋈ pg_attribute ⋈ pg_type` join is the literal
 /// shape `\d <table>` emits to describe a relation's columns and their types.
 #[tokio::test]

--- a/nodedb/tests/sql_join_correctness.rs
+++ b/nodedb/tests/sql_join_correctness.rs
@@ -338,3 +338,60 @@ async fn natural_join_is_not_cartesian() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// LIMIT with post-join filters
+// ---------------------------------------------------------------------------
+
+/// A join carrying both a post-join WHERE predicate and a LIMIT must return
+/// the matching rows: the LIMIT applies to the filtered result, never to the
+/// pre-filter probe output.
+#[tokio::test]
+async fn join_with_post_filter_and_wide_limit_keeps_matching_rows() {
+    let server = TestServer::start().await;
+    setup_join_tables(&server).await;
+
+    let unlimited = server
+        .query_text(
+            "SELECT j_t2.id FROM j_t1 \
+             JOIN j_t2 ON j_t2.t1_id = j_t1.id \
+             WHERE j_t2.y = 200",
+        )
+        .await
+        .expect("join with WHERE evaluates");
+    assert_eq!(unlimited, vec!["q".to_string()]);
+
+    let limited = server
+        .query_text(
+            "SELECT j_t2.id FROM j_t1 \
+             JOIN j_t2 ON j_t2.t1_id = j_t1.id \
+             WHERE j_t2.y = 200 LIMIT 5",
+        )
+        .await
+        .expect("join with WHERE and LIMIT evaluates");
+    assert_eq!(
+        limited, unlimited,
+        "a LIMIT wider than the filtered result must not drop matching rows"
+    );
+}
+
+/// A LIMIT narrower than the filtered result still truncates.
+#[tokio::test]
+async fn join_with_post_filter_honors_narrow_limit() {
+    let server = TestServer::start().await;
+    setup_join_tables(&server).await;
+
+    let rows = server
+        .query_text(
+            "SELECT j_t2.id FROM j_t1 \
+             JOIN j_t2 ON j_t2.t1_id = j_t1.id \
+             WHERE j_t2.y > 0 LIMIT 1",
+        )
+        .await
+        .expect("join with WHERE and LIMIT evaluates");
+    assert_eq!(
+        rows.len(),
+        1,
+        "LIMIT 1 must truncate the filtered rows to one: {rows:?}"
+    );
+}

--- a/nodedb/tests/sql_join_correctness.rs
+++ b/nodedb/tests/sql_join_correctness.rs
@@ -340,6 +340,55 @@ async fn natural_join_is_not_cartesian() {
 }
 
 // ---------------------------------------------------------------------------
+// Qualified same-name projections
+// ---------------------------------------------------------------------------
+
+/// Unaliased table-qualified projections of same-named columns must each
+/// resolve to their own table's value: `SELECT j_t1.id, j_t2.id` returns the
+/// left value in the first column and the right value in the second, not the
+/// last table's value in both. (Aliased projections already behaved; this
+/// pins the unaliased path, where both output columns display as `id`.)
+#[tokio::test]
+async fn qualified_same_name_columns_resolve_per_table_without_aliases() {
+    let server = TestServer::start().await;
+    setup_join_tables(&server).await;
+
+    let rows = server
+        .query_rows(
+            "SELECT j_t1.id, j_t2.id FROM j_t1 \
+             JOIN j_t2 ON j_t2.t1_id = j_t1.id \
+             WHERE j_t2.id = 'p'",
+        )
+        .await
+        .expect("join with unaliased qualified same-name projections");
+
+    assert_eq!(
+        rows,
+        vec![vec!["a".to_string(), "p".to_string()]],
+        "each qualified `id` projection must carry its own table's value"
+    );
+}
+
+/// The aliased spelling of the same projection stays correct (guard against
+/// the unaliased fix regressing the alias path).
+#[tokio::test]
+async fn qualified_same_name_columns_resolve_per_table_with_aliases() {
+    let server = TestServer::start().await;
+    setup_join_tables(&server).await;
+
+    let rows = server
+        .query_rows(
+            "SELECT j_t1.id AS t1_id, j_t2.id AS t2_id FROM j_t1 \
+             JOIN j_t2 ON j_t2.t1_id = j_t1.id \
+             WHERE j_t2.id = 'p'",
+        )
+        .await
+        .expect("join with aliased qualified same-name projections");
+
+    assert_eq!(rows, vec![vec!["a".to_string(), "p".to_string()]]);
+}
+
+// ---------------------------------------------------------------------------
 // LIMIT with post-join filters
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #200
Closes #201

## What this changes and why

Two independent SELECT correctness bugs, one commit each, both with reproducing tests.

### 1. `fix(sql)`: join LIMIT was applied before post-join WHERE filters

`execute_hash_join` passed the user `LIMIT n` straight into the probe, so the probe emitted the first `n` ON-matched rows and `filter_and_project` evaluated the WHERE predicate on that already-truncated set. Rows satisfying the WHERE clause that sorted after the first `n` probe matches were dropped — usually emptying the result.

Real-collection joins push their WHERE into the scanned side, leaving `post_filters` empty, so the ordering was harmless there. Virtual catalog joins keep both sides as inline `ProviderScan`s and carry the WHERE as a join post-filter, which is where it bit:

```sql
-- returns 1 row
SELECT t.typname FROM pg_type t
  LEFT JOIN pg_range r ON t.oid = r.rngtypid
  WHERE t.typname = 'int4';

-- returns 0 rows (expected: the same 1 row)
SELECT t.typname FROM pg_type t
  LEFT JOIN pg_range r ON t.oid = r.rngtypid
  WHERE t.typname = 'int4' LIMIT 5;
```

The probe now runs under the byte-budget ceiling whenever post-filters are present, and the user LIMIT is applied after filtering. A narrow LIMIT still truncates; a wide one no longer under-fills. The no-post-filter path is untouched, so the existing `ResourcesExhausted` budget semantics are unchanged.

### 2. `fix(pgwire)`: two output columns sharing a name collapsed to one value

```sql
CREATE COLLECTION w (id TEXT PRIMARY KEY, wname TEXT) WITH (engine='document_strict');
CREATE COLLECTION b (id TEXT PRIMARY KEY, w_id TEXT) WITH (engine='document_strict');
INSERT INTO w (id, wname) VALUES ('w1','alpha');
INSERT INTO b (id, w_id) VALUES ('b1','w1');

SELECT w.id, b.id FROM w JOIN b ON b.w_id = w.id;
--  b1 | b1     (expected: w1 | b1)

SELECT w.id AS w_id, b.id AS b_id FROM w JOIN b ON b.w_id = w.id;
--  w1 | b1     (correct)
```

The planner and join executor were both correct — the merged row carries `w.id` and `b.id`, and `project_row` reads each by its qualified lookup key. The loss happened at the last step: a shaped row is a `Map<String, JsonValue>` keyed by the column's *display* name, and an unaliased qualified projection displays as its bare last segment. Both columns keyed on `id`, so the second insert overwrote the first, and every encoder then re-read that single cell by name. Aliasing produced distinct display names, which is why only the unaliased spelling was wrong.

Shaped rows now store each column's cell under a unique key from `response_shape::project::cell_keys` — the display name for the first occurrence, `<name>_<n>` for later duplicates, skipping any candidate that would shadow another column's real name. Every consumer reads cells through `ShapedRows::cell_keys()` so they stay aligned: the pgwire non-streaming and streaming encoders, the native converter, and the HTTP serializers. Because HTTP writes a row map directly to JSON, the suffix is user-visible there — a duplicate-name projection emits `{"id": …, "id_1": …}`, since a JSON object cannot repeat a key either and dropping the duplicate would lose a projected column. pgwire and native are positional on the wire and still report both columns as `id`. For a duplicate-free column list the mapping is the identity, so nothing else changes; wire column names are untouched (duplicates still describe as `id`, `id`, matching PostgreSQL).

## How to test it

```bash
cargo nextest run -p nodedb --test pg_catalog_reflection --test sql_join_correctness
cargo nextest run -p nodedb --lib -E 'test(cell_keys) or test(project_row)'
```

New coverage:

- `pg_catalog_reflection`: catalog join + WHERE + wide LIMIT (returns the matching rows) and + narrow LIMIT (still truncates).
- `sql_join_correctness`: real-collection analogues of both, plus unaliased and aliased qualified same-name projections.
- unit tests for `cell_keys` (identity without duplicates, `_n` suffixing, shadow-avoidance) and duplicate-name `project_row`.

Verified as genuine regression guards: with the two source changes reverted and the tests kept, exactly the two bug repros fail and the rest stay green.

## Tradeoffs / alternatives considered

- **LIMIT fix**: pushing the post-filter into the probe predicate would let the probe stop early and stay O(n). That is a larger change to `probe_hash_index`'s filter handling; this PR takes the minimal correct ordering fix. Cost is that a post-filtered join with a small LIMIT now probes up to the budget ceiling instead of stopping at `n` — correctness over an early exit that was producing wrong answers.
- **Duplicate-name fix**: the structurally cleaner fix is a positional row representation (`Vec<JsonValue>` instead of a name-keyed `Map`), which removes the failure mode by construction. That touches every `ShapedRows` producer and consumer in the tree; the `cell_keys` indirection is contained and keeps that refactor open as a follow-up.

## Verified against the reported reproductions

Both issues' exact reproduction scripts were re-run against this branch:

**#200** — catalog join + `LIMIT`, both reported shapes:

```
SELECT t.oid, t.typname FROM pg_type as t LEFT JOIN pg_range as r ON oid = rngtypid
 WHERE t.typname IN ('int2','text') LIMIT 5;
--  21 | int2
--  25 | text          (was 0 rows)

SELECT a.attname FROM pg_attribute a
  LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attrelid = 'wk_probe'::regclass LIMIT 5;
--  id / name / qty    (was 0 rows)
```

Each matches its no-LIMIT result exactly.

**#201** — unaliased qualified same-name projection:

```
SELECT w.id, b.id, w.name, b.ref FROM wk_probe w JOIN wk_b b ON b.ref = w.id;
--  a | b1 | n | a     (was b1 | b1 | n | a)

SELECT w.id AS w_id, b.id AS b_id FROM wk_probe w LEFT JOIN wk_b b ON b.ref = w.id;
--  a | b1             (unchanged, still correct)
```

## Test results

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run -p nodedb --lib` — 4627/4628 pass
- integration sweep (catalog reflection/regclass/oid-stability/select-semantics, join correctness, subquery, lateral, recursive CTE, kv select, http + native result projection) — 81/81 pass

The one lib failure is `control::catalog_entry::tests::collection::purge_collection_is_scoped_to_database`, which fails identically on unmodified `bece8812d` (verified in a clean worktree) and is untouched by this PR.
