### PR TITLE
fix(sync): make sync listener address configurable and bind failure boot-fatal

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -237,6 +237,10 @@ resp = true
 ilp = false                       # Example: disable TLS for ILP ingest
 ```
 
+Every listener binds during startup, before the server accepts any
+connection. If a configured port is already in use, startup fails with that
+port named — the server never comes up missing a protocol.
+
 **Server settings:**
 
 | Config field       | Environment variable      | Default                                               |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -223,6 +223,7 @@ log_format = "text"               # "text" or "json"
 native = 6433                     # Always-on protocols have defaults
 pgwire = 6432
 http = 6480
+sync = 9090                       # Always on
 resp = 6381                       # Optional: set to enable, omit to disable
 ilp = 8086                        # Optional: set to enable, omit to disable
 
@@ -244,6 +245,7 @@ ilp = false                       # Example: disable TLS for ILP ingest
 | `ports.native`     | `NODEDB_PORT_NATIVE`      | `6433`                                                |
 | `ports.pgwire`     | `NODEDB_PORT_PGWIRE`      | `6432`                                                |
 | `ports.http`       | `NODEDB_PORT_HTTP`        | `6480`                                                |
+| `ports.sync`       | `NODEDB_PORT_SYNC`        | `9090`                                                |
 | `ports.resp`       | `NODEDB_PORT_RESP`        | disabled                                              |
 | `ports.ilp`        | `NODEDB_PORT_ILP`         | disabled                                              |
 | `data_dir`         | `NODEDB_DATA_DIR`         | `~/.nodedb/data` (binary), `/var/lib/nodedb` (Docker) |

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -223,7 +223,7 @@ SELECT * FROM cpu WHERE ts > now() - INTERVAL '1 hour';
 
 CRDT sync protocol for NodeDB-Lite clients (mobile, WASM, desktop). Bidirectional delta exchange over WebSocket.
 
-**Port:** 9090 (default)
+**Port:** 9090 (default). Configurable via `[server.ports] sync` or `NODEDB_PORT_SYNC`.
 
 **Flow:**
 
@@ -256,6 +256,7 @@ host = "127.0.0.1"
 pgwire = 6432       # Always on
 native = 6433       # Always on
 http = 6480         # Always on
+sync = 9090         # Always on
 resp = 6381         # Set to enable (omit to disable)
 ilp = 8086          # Set to enable (omit to disable)
 
@@ -269,7 +270,7 @@ resp = true
 ilp = false         # Example: disable TLS for ILP ingest
 ```
 
-Environment variables override config: `NODEDB_PORT_PGWIRE`, `NODEDB_PORT_NATIVE`, `NODEDB_PORT_HTTP`, `NODEDB_PORT_RESP`, `NODEDB_PORT_ILP`.
+Environment variables override config: `NODEDB_PORT_PGWIRE`, `NODEDB_PORT_NATIVE`, `NODEDB_PORT_HTTP`, `NODEDB_PORT_SYNC`, `NODEDB_PORT_RESP`, `NODEDB_PORT_ILP`.
 
 ## Native Protocol Opcodes (SDK Reference)
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -173,7 +173,7 @@ const db = new NodeDbLite();
 
 // Configure sync to Origin
 await db.sync_config({
-  server_url: "ws://localhost:6433",
+  server_url: "ws://localhost:9090",
   auth_token: "your-token",
   auto_sync: true,
   sync_interval_ms: 5000,

--- a/nodedb/src/bootstrap/listeners.rs
+++ b/nodedb/src/bootstrap/listeners.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use anyhow::Context;
 use tracing::info;
 
 use crate::ServerConfig;
@@ -34,6 +35,11 @@ pub struct ListenerInfra {
 ///
 /// The native listener is not spawned here — it is run on the main task
 /// by the caller after this returns.
+///
+/// Returns `Err` if the sync WebSocket listener fails to bind — that
+/// failure is boot-fatal rather than a silent warning, since a server
+/// that comes up without a reachable sync listener leaves NodeDB-Lite
+/// clients unable to connect with no indication anything is wrong.
 pub async fn spawn_protocol_listeners(
     listeners: ProtocolListeners,
     shared: Arc<SharedState>,
@@ -41,7 +47,7 @@ pub async fn spawn_protocol_listeners(
     infra: ListenerInfra,
     base_acceptor: Option<tokio_rustls::TlsAcceptor>,
     cluster_handle: &Option<Arc<ClusterHandle>>,
-) {
+) -> anyhow::Result<()> {
     let ProtocolListeners {
         pg_listener,
         ilp_listener,
@@ -157,7 +163,10 @@ pub async fn spawn_protocol_listeners(
     }
 
     // Sync WebSocket listener for NodeDB-Lite clients.
-    let sync_config = crate::control::server::sync::listener::SyncListenerConfig::default();
+    let sync_config = crate::control::server::sync::listener::SyncListenerConfig {
+        listen_addr: config.sync_addr(),
+        ..Default::default()
+    };
     match crate::control::server::sync::listener::start_sync_listener(
         sync_config,
         Some(Arc::clone(&shared)),
@@ -172,7 +181,7 @@ pub async fn spawn_protocol_listeners(
             );
         }
         Err(e) => {
-            tracing::warn!(error = %e, "sync listener failed to start (non-fatal)");
+            return Err(e).context("sync listener failed to bind");
         }
     }
 
@@ -182,6 +191,8 @@ pub async fn spawn_protocol_listeners(
         handle.lifecycle.to_ready(nodes);
     }
     nodedb_cluster::readiness::notify_ready();
+
+    Ok(())
 }
 
 /// Bind all protocol listeners to their configured addresses.

--- a/nodedb/src/bootstrap/listeners.rs
+++ b/nodedb/src/bootstrap/listeners.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
+use tokio::net::TcpListener;
 use tracing::info;
 
 use crate::ServerConfig;
@@ -17,9 +18,14 @@ use crate::control::shutdown::ShutdownBus;
 use crate::control::startup::StartupGate;
 use crate::control::state::SharedState;
 
-/// The three protocol listeners passed to [`spawn_protocol_listeners`].
+/// The pre-bound protocol listeners passed to [`spawn_protocol_listeners`].
+///
+/// Every socket here is already bound by [`bind_listeners`], so spawning
+/// cannot fail on a port conflict.
 pub struct ProtocolListeners {
     pub pg_listener: PgListener,
+    pub http_listener: TcpListener,
+    pub sync_listener: TcpListener,
     pub ilp_listener: Option<IlpListener>,
     pub resp_listener: Option<RespListener>,
 }
@@ -36,10 +42,9 @@ pub struct ListenerInfra {
 /// The native listener is not spawned here — it is run on the main task
 /// by the caller after this returns.
 ///
-/// Returns `Err` if the sync WebSocket listener fails to bind — that
-/// failure is boot-fatal rather than a silent warning, since a server
-/// that comes up without a reachable sync listener leaves NodeDB-Lite
-/// clients unable to connect with no indication anything is wrong.
+/// Infallible by construction: every socket was bound by [`bind_listeners`]
+/// before this point, so a port conflict has already aborted boot while
+/// nothing was exposed. Nothing here may silently swallow a bind failure.
 pub async fn spawn_protocol_listeners(
     listeners: ProtocolListeners,
     shared: Arc<SharedState>,
@@ -47,9 +52,11 @@ pub async fn spawn_protocol_listeners(
     infra: ListenerInfra,
     base_acceptor: Option<tokio_rustls::TlsAcceptor>,
     cluster_handle: &Option<Arc<ClusterHandle>>,
-) -> anyhow::Result<()> {
+) {
     let ProtocolListeners {
         pg_listener,
+        http_listener,
+        sync_listener,
         ilp_listener,
         resp_listener,
     } = listeners;
@@ -90,10 +97,9 @@ pub async fn spawn_protocol_listeners(
         }
     });
 
-    // HTTP API server.
+    // HTTP API server (on the socket bound by `bind_listeners`).
     let shared_http = Arc::clone(&shared);
     let http_auth_mode = config.auth.mode.clone();
-    let http_listen = config.http_addr();
     let http_tls = if http_tls_enabled {
         config.server.tls.clone()
     } else {
@@ -102,7 +108,7 @@ pub async fn spawn_protocol_listeners(
     let bus_http = shutdown_bus.clone();
     tokio::spawn(async move {
         if let Err(e) = crate::control::server::http::server::run(
-            http_listen,
+            http_listener,
             shared_http,
             http_auth_mode,
             http_tls.as_ref(),
@@ -162,28 +168,22 @@ pub async fn spawn_protocol_listeners(
         });
     }
 
-    // Sync WebSocket listener for NodeDB-Lite clients.
+    // Sync WebSocket listener for NodeDB-Lite clients (socket already bound).
     let sync_config = crate::control::server::sync::listener::SyncListenerConfig {
         listen_addr: config.sync_addr(),
         ..Default::default()
     };
-    match crate::control::server::sync::listener::start_sync_listener(
+    let sync_state = crate::control::server::sync::listener::serve_sync_listener(
+        sync_listener,
         sync_config,
         Some(Arc::clone(&shared)),
     )
-    .await
-    {
-        Ok(sync_state) => {
-            info!(
-                addr = %sync_state.config.listen_addr,
-                max_sessions = sync_state.config.max_sessions,
-                "sync WebSocket listener started"
-            );
-        }
-        Err(e) => {
-            return Err(e).context("sync listener failed to bind");
-        }
-    }
+    .await;
+    info!(
+        addr = %sync_state.config.listen_addr,
+        max_sessions = sync_state.config.max_sessions,
+        "sync WebSocket listener started"
+    );
 
     // Signal readiness to systemd and cluster lifecycle.
     if let Some(handle) = cluster_handle {
@@ -191,22 +191,36 @@ pub async fn spawn_protocol_listeners(
         handle.lifecycle.to_ready(nodes);
     }
     nodedb_cluster::readiness::notify_ready();
+}
 
-    Ok(())
+/// Every protocol socket, bound before any accept loop starts.
+pub struct BoundListeners {
+    pub native: Listener,
+    pub pgwire: PgListener,
+    pub http: TcpListener,
+    pub sync: TcpListener,
+    pub ilp: Option<IlpListener>,
+    pub resp: Option<RespListener>,
 }
 
 /// Bind all protocol listeners to their configured addresses.
-pub async fn bind_listeners(
-    config: &ServerConfig,
-) -> anyhow::Result<(
-    Listener,
-    PgListener,
-    Option<IlpListener>,
-    Option<RespListener>,
-)> {
+///
+/// This is the single fail-fast point for listener setup: it runs before the
+/// node waits on cluster readiness and before any accept loop is spawned, so
+/// a port conflict on *any* protocol — including HTTP and sync, which serve
+/// from detached tasks — aborts boot while nothing is exposed yet. Never
+/// move a bind out of here into a spawned task; that is how a server ends up
+/// running for days missing a listener behind one warning line.
+pub async fn bind_listeners(config: &ServerConfig) -> anyhow::Result<BoundListeners> {
     let native = crate::control::server::listener::Listener::bind(config.native_addr()).await?;
     let pgwire =
         crate::control::server::pgwire::listener::PgListener::bind(config.pgwire_addr()).await?;
+    let http = TcpListener::bind(config.http_addr())
+        .await
+        .with_context(|| format!("bind HTTP API listener to {}", config.http_addr()))?;
+    let sync = crate::control::server::sync::listener::bind_sync_listener(config.sync_addr())
+        .await
+        .context("sync listener failed to bind")?;
     let ilp = if let Some(ilp_addr) = config.ilp_addr() {
         Some(crate::control::server::ilp_listener::IlpListener::bind(ilp_addr).await?)
     } else {
@@ -217,5 +231,12 @@ pub async fn bind_listeners(
     } else {
         None
     };
-    Ok((native, pgwire, ilp, resp))
+    Ok(BoundListeners {
+        native,
+        pgwire,
+        http,
+        sync,
+        ilp,
+        resp,
+    })
 }

--- a/nodedb/src/config/server/config.rs
+++ b/nodedb/src/config/server/config.rs
@@ -39,6 +39,7 @@ use crate::config::EngineConfig;
 /// pgwire = 6432
 /// native = 6433
 /// http   = 6480
+/// sync   = 9090
 ///
 /// [auth]
 /// # ...
@@ -161,6 +162,11 @@ impl ServerConfig {
         self.addr(self.server.ports.http)
     }
 
+    /// Sync WebSocket listen address (NodeDB-Lite clients).
+    pub fn sync_addr(&self) -> SocketAddr {
+        self.addr(self.server.ports.sync)
+    }
+
     /// RESP listen address (None if disabled).
     pub fn resp_addr(&self) -> Option<SocketAddr> {
         self.server.ports.resp.map(|p| self.addr(p))
@@ -200,6 +206,7 @@ mod tests {
         assert_eq!(cfg.server.ports.native, 6433);
         assert_eq!(cfg.server.ports.pgwire, 6432);
         assert_eq!(cfg.server.ports.http, 6480);
+        assert_eq!(cfg.server.ports.sync, 9090);
         assert!(cfg.server.ports.resp.is_none());
         assert!(cfg.server.ports.ilp.is_none());
         assert!(cfg.server.data_plane_cores >= 1);

--- a/nodedb/src/config/server/env.rs
+++ b/nodedb/src/config/server/env.rs
@@ -180,6 +180,7 @@ fn apply_bool_env(var: &str, target: &mut bool) {
 /// - `NODEDB_PORT_NATIVE`      — overrides `config.ports.native` (default 6433)
 /// - `NODEDB_PORT_PGWIRE`      — overrides `config.ports.pgwire` (default 6432)
 /// - `NODEDB_PORT_HTTP`        — overrides `config.ports.http` (default 6480)
+/// - `NODEDB_PORT_SYNC`        — overrides `config.ports.sync` (default 9090)
 /// - `NODEDB_PORT_RESP`        — overrides `config.ports.resp` (set to enable RESP)
 /// - `NODEDB_PORT_ILP`         — overrides `config.ports.ilp` (set to enable ILP)
 /// - `NODEDB_DATA_DIR`         — overrides `config.data_dir`
@@ -235,6 +236,7 @@ pub fn apply_env_overrides(config: &mut ServerConfig) {
     apply_port_env("NODEDB_PORT_NATIVE", &mut config.server.ports.native);
     apply_port_env("NODEDB_PORT_PGWIRE", &mut config.server.ports.pgwire);
     apply_port_env("NODEDB_PORT_HTTP", &mut config.server.ports.http);
+    apply_port_env("NODEDB_PORT_SYNC", &mut config.server.ports.sync);
     apply_optional_port_env("NODEDB_PORT_RESP", &mut config.server.ports.resp);
     apply_optional_port_env("NODEDB_PORT_ILP", &mut config.server.ports.ilp);
 
@@ -677,6 +679,29 @@ mod tests {
         );
 
         unsafe { std::env::remove_var("NODEDB_MEMORY_LIMIT") };
+    }
+
+    /// Tests valid and malformed `NODEDB_PORT_SYNC` sequentially to avoid
+    /// env-var races (env vars are process-global, Rust tests run in parallel).
+    #[test]
+    fn env_sync_port_overrides() {
+        // ── Valid value → overrides ports.sync ──
+        unsafe { std::env::set_var("NODEDB_PORT_SYNC", "19090") };
+        let mut cfg = ServerConfig::default();
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.server.ports.sync, 19090);
+
+        // ── Malformed value → ports.sync unchanged ──
+        unsafe { std::env::set_var("NODEDB_PORT_SYNC", "notaport") };
+        let mut cfg = ServerConfig::default();
+        let before = cfg.server.ports.sync;
+        apply_env_overrides(&mut cfg);
+        assert_eq!(
+            cfg.server.ports.sync, before,
+            "malformed value must not change config"
+        );
+
+        unsafe { std::env::remove_var("NODEDB_PORT_SYNC") };
     }
 
     #[test]

--- a/nodedb/src/config/server/mod.rs
+++ b/nodedb/src/config/server/mod.rs
@@ -25,7 +25,7 @@ pub use observability::{
     ObservabilityConfig, OtlpConfig, OtlpExportConfig, OtlpReceiverConfig, PromqlConfig,
     apply_observability_env, validate_feature_availability,
 };
-pub use ports::PortsConfig;
+pub use ports::{DEFAULT_SYNC_PORT, PortsConfig};
 pub use retention::RetentionSettings;
 pub use scheduler::{CronTimezone, SchedulerConfig};
 pub use section::ServerSection;

--- a/nodedb/src/config/server/ports.rs
+++ b/nodedb/src/config/server/ports.rs
@@ -4,6 +4,13 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Default sync WebSocket port.
+///
+/// Exported because the sync listener's own `SyncListenerConfig::default()`
+/// must agree with the config default — one constant, not two literals that
+/// can drift apart.
+pub const DEFAULT_SYNC_PORT: u16 = 9090;
+
 /// Port configuration for all protocol listeners.
 ///
 /// Always-on protocols have a default port. Optional protocols (RESP, ILP)
@@ -54,7 +61,7 @@ fn default_http_port() -> u16 {
     6480
 }
 fn default_sync_port() -> u16 {
-    9090
+    DEFAULT_SYNC_PORT
 }
 
 #[cfg(test)]

--- a/nodedb/src/config/server/ports.rs
+++ b/nodedb/src/config/server/ports.rs
@@ -20,6 +20,9 @@ pub struct PortsConfig {
     /// HTTP API port (REST, SSE, WebSocket). Default: 6480.
     #[serde(default = "default_http_port")]
     pub http: u16,
+    /// Sync WebSocket port (NodeDB-Lite clients). Default: 9090.
+    #[serde(default = "default_sync_port")]
+    pub sync: u16,
     /// RESP (Redis-compatible) port. Disabled by default. Set to enable.
     #[serde(default)]
     pub resp: Option<u16>,
@@ -34,6 +37,7 @@ impl Default for PortsConfig {
             native: default_native_port(),
             pgwire: default_pgwire_port(),
             http: default_http_port(),
+            sync: default_sync_port(),
             resp: None,
             ilp: None,
         }
@@ -49,6 +53,9 @@ fn default_pgwire_port() -> u16 {
 fn default_http_port() -> u16 {
     6480
 }
+fn default_sync_port() -> u16 {
+    9090
+}
 
 #[cfg(test)]
 mod tests {
@@ -60,6 +67,7 @@ mod tests {
         assert_eq!(p.native, 6433);
         assert_eq!(p.pgwire, 6432);
         assert_eq!(p.http, 6480);
+        assert_eq!(p.sync, 9090);
         assert!(p.resp.is_none());
         assert!(p.ilp.is_none());
     }

--- a/nodedb/src/control/server/http/server.rs
+++ b/nodedb/src/control/server/http/server.rs
@@ -37,7 +37,6 @@
 //! middleware (auth, startup-gate, tracing) must apply uniformly across
 //! versions.
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::Router;
@@ -213,8 +212,8 @@ async fn startup_gate_middleware(
 
 /// Start the HTTP API server from an already-bound [`tokio::net::TcpListener`].
 ///
-/// Useful in tests where an ephemeral-port listener is bound before the server
-/// task is spawned, making the port available to the test without a race.
+/// Alias of [`run`], kept for call sites (tests, harnesses) that bind an
+/// ephemeral-port listener first so the port is known without a race.
 pub async fn run_with_listener(
     listener: tokio::net::TcpListener,
     shared: Arc<SharedState>,
@@ -222,11 +221,22 @@ pub async fn run_with_listener(
     tls_settings: Option<&crate::config::server::TlsSettings>,
     bus: crate::control::shutdown::ShutdownBus,
 ) -> crate::Result<()> {
-    if tls_settings.is_some() {
-        return Err(crate::Error::Config {
-            detail: "run_with_listener does not support TLS; use run() instead".into(),
-        });
-    }
+    run(listener, shared, auth_mode, tls_settings, bus).await
+}
+
+/// Start the HTTP API server (plain HTTP or HTTPS) on a pre-bound listener.
+///
+/// The socket is bound by `bootstrap::listeners::bind_listeners` before any
+/// accept loop starts, so a port conflict is boot-fatal rather than an error
+/// logged from inside an already-detached task. If `tls_settings` is provided,
+/// serves HTTPS via axum-server + rustls; otherwise plain HTTP via axum::serve.
+pub async fn run(
+    listener: tokio::net::TcpListener,
+    shared: Arc<SharedState>,
+    auth_mode: AuthMode,
+    tls_settings: Option<&crate::config::server::TlsSettings>,
+    bus: crate::control::shutdown::ShutdownBus,
+) -> crate::Result<()> {
     let drain_guard = bus.register_task(
         crate::control::shutdown::ShutdownPhase::DrainingListeners,
         "http",
@@ -244,54 +254,9 @@ pub async fn run_with_listener(
     };
     let router = build_router(state);
     let local_addr = listener.local_addr()?;
-    info!(%local_addr, "HTTP API server listening (pre-bound listener)");
-    // `with_connect_info` is required so routes that take
-    // `ConnectInfo<SocketAddr>` (e.g. `/api/auth/session` for the
-    // fingerprint-bound session handle path) resolve the peer address.
-    // Without it, axum rejects those requests with 500.
-    axum::serve(
-        listener,
-        router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-    )
-    .with_graceful_shutdown(async move {
-        let _ = shutdown_rx.changed().await;
-    })
-    .await
-    .map_err(crate::Error::Io)?;
-    drain_guard.report_drained();
-    Ok(())
-}
-
-/// Start the HTTP API server (plain HTTP or HTTPS).
-///
-/// If `tls_settings` is provided, serves HTTPS via axum-server + rustls.
-/// Otherwise serves plain HTTP via axum::serve.
-pub async fn run(
-    listen: SocketAddr,
-    shared: Arc<SharedState>,
-    auth_mode: AuthMode,
-    tls_settings: Option<&crate::config::server::TlsSettings>,
-    bus: crate::control::shutdown::ShutdownBus,
-) -> crate::Result<()> {
-    let drain_guard = bus.register_task(
-        crate::control::shutdown::ShutdownPhase::DrainingListeners,
-        "http",
-        None,
-    );
-    let mut shutdown_rx = bus.handle().flat_watch().raw_receiver();
-
-    let query_ctx = Arc::new(crate::control::planner::context::QueryContext::for_state(
-        &shared,
-    ));
-    let state = AppState {
-        shared,
-        auth_mode,
-        query_ctx,
-    };
-    let router = build_router(state);
 
     if let Some(tls) = tls_settings {
-        // HTTPS via axum-server + rustls.
+        // HTTPS via axum-server + rustls, on the pre-bound socket.
         let rustls_config =
             axum_server::tls_rustls::RustlsConfig::from_pem_file(&tls.cert_path, &tls.key_path)
                 .await
@@ -299,7 +264,7 @@ pub async fn run(
                     detail: format!("HTTP TLS config error: {e}"),
                 })?;
 
-        info!(%listen, tls = true, "HTTPS API server listening");
+        info!(%local_addr, tls = true, "HTTPS API server listening");
 
         let handle = axum_server::Handle::new();
         let shutdown_handle = handle.clone();
@@ -308,17 +273,22 @@ pub async fn run(
             shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(5)));
         });
 
-        axum_server::bind_rustls(listen, rustls_config)
+        // `into_std` keeps the socket in nonblocking mode, which is what
+        // axum-server needs to hand it back to Tokio.
+        axum_server::from_tcp_rustls(listener.into_std()?, rustls_config)
+            .map_err(crate::Error::Io)?
             .handle(handle)
             .serve(router.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await
             .map_err(crate::Error::Io)?;
     } else {
         // Plain HTTP.
-        let listener = tokio::net::TcpListener::bind(listen).await?;
-        let local_addr = listener.local_addr()?;
         info!(%local_addr, "HTTP API server listening");
 
+        // `with_connect_info` is required so routes that take
+        // `ConnectInfo<SocketAddr>` (e.g. `/api/auth/session` for the
+        // fingerprint-bound session handle path) resolve the peer address.
+        // Without it, axum rejects those requests with 500.
         axum::serve(
             listener,
             router.into_make_service_with_connect_info::<std::net::SocketAddr>(),

--- a/nodedb/src/control/server/sync/listener.rs
+++ b/nodedb/src/control/server/sync/listener.rs
@@ -163,3 +163,36 @@ async fn accept_loop(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Binding to an address that's already occupied must surface as `Err`,
+    /// not panic or silently succeed — this is the behavior
+    /// `spawn_protocol_listeners` relies on to treat a sync-listener bind
+    /// failure as boot-fatal instead of a silent non-fatal warning.
+    #[tokio::test]
+    async fn start_sync_listener_returns_err_on_occupied_port() {
+        // Reserve an ephemeral port via a real listener so we know it's taken.
+        let occupied = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .expect("bind ephemeral listener to reserve a port");
+        let addr = occupied
+            .local_addr()
+            .expect("local addr of reserved listener");
+
+        let cfg = SyncListenerConfig {
+            listen_addr: addr,
+            ..Default::default()
+        };
+        let result = start_sync_listener(cfg, None).await;
+
+        assert!(
+            result.is_err(),
+            "expected start_sync_listener to return Err when the address is already bound"
+        );
+
+        drop(occupied);
+    }
+}

--- a/nodedb/src/control/server/sync/listener.rs
+++ b/nodedb/src/control/server/sync/listener.rs
@@ -31,7 +31,14 @@ pub struct SyncListenerConfig {
 impl Default for SyncListenerConfig {
     fn default() -> Self {
         Self {
-            listen_addr: std::net::SocketAddr::from(([0, 0, 0, 0], 9090)),
+            // Loopback, not `0.0.0.0`: the listen address always comes from
+            // `ServerConfig::sync_addr()` in production, so the default must
+            // be the conservative one rather than an implicit all-interfaces
+            // bind for anything that fills it in from `Default`.
+            listen_addr: std::net::SocketAddr::from((
+                std::net::Ipv4Addr::LOCALHOST,
+                crate::config::server::DEFAULT_SYNC_PORT,
+            )),
             max_sessions: 1024,
             idle_timeout_secs: 300,
             jwt_config: JwtConfig::default(),
@@ -76,18 +83,42 @@ impl SyncListenerState {
     }
 }
 
+/// Bind the sync WebSocket listener socket.
+///
+/// Separate from [`serve_sync_listener`] so boot can bind every protocol
+/// socket up front — before any accept loop is spawned and before the node
+/// joins the cluster — and fail loudly on a port conflict while nothing is
+/// yet exposed. See `bootstrap::listeners::bind_listeners`.
+pub async fn bind_sync_listener(addr: SocketAddr) -> crate::Result<TcpListener> {
+    TcpListener::bind(&addr)
+        .await
+        .map_err(|e| crate::Error::Config {
+            detail: format!("bind sync listener to {addr}: {e}"),
+        })
+}
+
 /// Start the sync WebSocket listener with full security context.
+///
+/// Binds and serves in one step. Boot uses [`bind_sync_listener`] +
+/// [`serve_sync_listener`] instead so the bind is fail-fast; this is the
+/// convenience path for callers that own the whole lifecycle (tests, tools).
 pub async fn start_sync_listener(
     config: SyncListenerConfig,
     shared: Option<Arc<SharedState>>,
 ) -> crate::Result<Arc<SyncListenerState>> {
-    let listener =
-        TcpListener::bind(&config.listen_addr)
-            .await
-            .map_err(|e| crate::Error::Config {
-                detail: format!("bind sync listener to {}: {e}", config.listen_addr),
-            })?;
+    let listener = bind_sync_listener(config.listen_addr).await?;
+    Ok(serve_sync_listener(listener, config, shared).await)
+}
 
+/// Serve sync sessions on an already-bound listener.
+///
+/// Infallible: the only failure mode is the bind, which the caller has
+/// already cleared.
+pub async fn serve_sync_listener(
+    listener: TcpListener,
+    config: SyncListenerConfig,
+    shared: Option<Arc<SharedState>>,
+) -> Arc<SyncListenerState> {
     // Surface the actually-bound address. For a fixed port this is a no-op; for
     // an ephemeral port (`:0`) it records the OS-assigned port so the caller can
     // discover where the listener is reachable.
@@ -123,7 +154,7 @@ pub async fn start_sync_listener(
         accept_loop(listener, state_clone, shared).await;
     });
 
-    Ok(state)
+    state
 }
 
 async fn accept_loop(
@@ -166,16 +197,37 @@ async fn accept_loop(
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use super::*;
 
     /// Binding to an address that's already occupied must surface as `Err`,
-    /// not panic or silently succeed — this is the behavior
-    /// `spawn_protocol_listeners` relies on to treat a sync-listener bind
-    /// failure as boot-fatal instead of a silent non-fatal warning.
+    /// not panic or silently succeed — this is the behavior `bind_listeners`
+    /// relies on to fail boot on a sync port conflict instead of logging a
+    /// non-fatal warning and coming up sync-less.
+    #[tokio::test]
+    async fn bind_sync_listener_returns_err_on_occupied_port() {
+        // Reserve an ephemeral port via a real listener so we know it's taken.
+        let occupied = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .expect("bind ephemeral listener to reserve a port");
+        let addr = occupied
+            .local_addr()
+            .expect("local addr of reserved listener");
+
+        let result = bind_sync_listener(addr).await;
+
+        assert!(
+            result.is_err(),
+            "expected bind_sync_listener to return Err when the address is already bound"
+        );
+    }
+
+    /// `start_sync_listener` must propagate the same bind failure — it is the
+    /// path tests and tools use, and it must not diverge from the boot path.
     #[tokio::test]
     async fn start_sync_listener_returns_err_on_occupied_port() {
-        // Reserve an ephemeral port via a real listener so we know it's taken.
-        let occupied = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        let occupied = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .await
             .expect("bind ephemeral listener to reserve a port");
         let addr = occupied
@@ -186,13 +238,24 @@ mod tests {
             listen_addr: addr,
             ..Default::default()
         };
-        let result = start_sync_listener(cfg, None).await;
 
         assert!(
-            result.is_err(),
+            start_sync_listener(cfg, None).await.is_err(),
             "expected start_sync_listener to return Err when the address is already bound"
         );
+    }
 
-        drop(occupied);
+    /// The default must not be an implicit all-interfaces bind: production
+    /// always sets `listen_addr` from `ServerConfig::sync_addr()`, so anything
+    /// falling back to `Default` should get the conservative address, and its
+    /// port must agree with the config default.
+    #[test]
+    fn default_listen_addr_is_loopback_on_the_config_default_port() {
+        let cfg = SyncListenerConfig::default();
+        assert_eq!(cfg.listen_addr.ip(), Ipv4Addr::LOCALHOST);
+        assert_eq!(
+            cfg.listen_addr.port(),
+            crate::config::server::DEFAULT_SYNC_PORT
+        );
     }
 }

--- a/nodedb/src/main.rs
+++ b/nodedb/src/main.rs
@@ -224,7 +224,7 @@ async fn main() -> anyhow::Result<()> {
         base_acceptor.clone(),
         &cluster_handle,
     )
-    .await;
+    .await?;
 
     // Native protocol TLS.
     let native_tls = tls_for(native_tls_enabled);

--- a/nodedb/src/main.rs
+++ b/nodedb/src/main.rs
@@ -171,6 +171,8 @@ async fn main() -> anyhow::Result<()> {
         admission_registry,
         listener,
         pg_listener,
+        http_listener,
+        sync_listener,
         ilp_listener,
         resp_listener,
         base_acceptor,
@@ -211,6 +213,8 @@ async fn main() -> anyhow::Result<()> {
     nodedb::bootstrap::listeners::spawn_protocol_listeners(
         nodedb::bootstrap::listeners::ProtocolListeners {
             pg_listener,
+            http_listener,
+            sync_listener,
             ilp_listener,
             resp_listener,
         },
@@ -224,7 +228,7 @@ async fn main() -> anyhow::Result<()> {
         base_acceptor.clone(),
         &cluster_handle,
     )
-    .await?;
+    .await;
 
     // Native protocol TLS.
     let native_tls = tls_for(native_tls_enabled);

--- a/nodedb/src/main_boot/listeners.rs
+++ b/nodedb/src/main_boot/listeners.rs
@@ -25,6 +25,8 @@ pub(crate) struct ListenerSetup {
     pub(crate) admission_registry: Arc<nodedb::control::server::admission::AdmissionRegistry>,
     pub(crate) listener: Listener,
     pub(crate) pg_listener: PgListener,
+    pub(crate) http_listener: tokio::net::TcpListener,
+    pub(crate) sync_listener: tokio::net::TcpListener,
     pub(crate) ilp_listener: Option<IlpListener>,
     pub(crate) resp_listener: Option<RespListener>,
     pub(crate) base_acceptor: Option<tokio_rustls::TlsAcceptor>,
@@ -54,9 +56,17 @@ pub(crate) async fn setup(
         "connection limit configured"
     );
 
-    // Bind all listeners before starting accept loops.
-    let (listener, pg_listener, ilp_listener, resp_listener) =
-        bootstrap::listeners::bind_listeners(config).await?;
+    // Bind all listeners — every protocol, including HTTP and sync — before
+    // starting any accept loop, so a port conflict fails boot here rather
+    // than after the node is already serving other protocols.
+    let bootstrap::listeners::BoundListeners {
+        native: listener,
+        pgwire: pg_listener,
+        http: http_listener,
+        sync: sync_listener,
+        ilp: ilp_listener,
+        resp: resp_listener,
+    } = bootstrap::listeners::bind_listeners(config).await?;
 
     // Startup banner (and trust-mode warning if applicable).
     bootstrap::credentials::print_startup_banner(config, cluster_mode_str);
@@ -99,6 +109,8 @@ pub(crate) async fn setup(
         admission_registry,
         listener,
         pg_listener,
+        http_listener,
+        sync_listener,
         ilp_listener,
         resp_listener,
         base_acceptor,

--- a/nodedb/tests/crash_harness/mod.rs
+++ b/nodedb/tests/crash_harness/mod.rs
@@ -72,6 +72,11 @@ pub struct CrashHarness {
     pub http_port: u16,
     pub pgwire_port: u16,
     pub native_port: u16,
+    /// The sync WebSocket port. Unused by the tests themselves, but it must
+    /// be unique per harness: every protocol bind is boot-fatal, so two
+    /// concurrent harnesses left on the default sync port would collide and
+    /// one server would refuse to boot.
+    pub sync_port: u16,
     child: Option<std::process::Child>,
     /// Extra server env applied on EVERY spawn, including `reopen`. A test that
     /// tunes the server (short checkpoint interval, small WAL segments) needs
@@ -90,6 +95,7 @@ impl CrashHarness {
             http_port: free_port(),
             pgwire_port: free_port(),
             native_port: free_port(),
+            sync_port: free_port(),
             child: None,
             extra_env: Vec::new(),
         }
@@ -141,6 +147,7 @@ impl CrashHarness {
             .env("NODEDB_PORT_HTTP", self.http_port.to_string())
             .env("NODEDB_PORT_PGWIRE", self.pgwire_port.to_string())
             .env("NODEDB_PORT_NATIVE", self.native_port.to_string())
+            .env("NODEDB_PORT_SYNC", self.sync_port.to_string())
             // Pin the superuser password so the test can authenticate. Without
             // this the binary auto-generates a random password into
             // `<data_dir>/.superuser_password` (default auth mode is Password),

--- a/nodedb/tests/shutdown_abort_offender.rs
+++ b/nodedb/tests/shutdown_abort_offender.rs
@@ -63,6 +63,9 @@ fn offender_task_aborted_at_500ms_budget() {
     let http_port = free_port();
     let pgwire_port = free_port();
     let native_port = free_port();
+    // Unique too: the sync bind is boot-fatal, so concurrent server
+    // processes must not share the default sync port.
+    let sync_port = free_port();
 
     let child = std::process::Command::new(bin)
         .env("NODEDB_DATA_DIR", dir.path())
@@ -70,6 +73,7 @@ fn offender_task_aborted_at_500ms_budget() {
         .env("NODEDB_PORT_HTTP", http_port.to_string())
         .env("NODEDB_PORT_PGWIRE", pgwire_port.to_string())
         .env("NODEDB_PORT_NATIVE", native_port.to_string())
+        .env("NODEDB_PORT_SYNC", sync_port.to_string())
         // Inject a slow drain task that will be detected as an offender.
         .env("NODEDB_TEST_SLOW_DRAIN_TASK", "1")
         // Use warn level so the shutdown offender ERROR log is captured.

--- a/nodedb/tests/shutdown_budget.rs
+++ b/nodedb/tests/shutdown_budget.rs
@@ -66,6 +66,9 @@ fn real_nodedb_binary_exits_within_1_second_of_sigterm() {
     let http_port = free_port();
     let pgwire_port = free_port();
     let native_port = free_port();
+    // Unique too: the sync bind is boot-fatal, so concurrent server
+    // processes must not share the default sync port.
+    let sync_port = free_port();
 
     let mut child = std::process::Command::new(bin)
         .env("NODEDB_DATA_DIR", dir.path())
@@ -73,6 +76,7 @@ fn real_nodedb_binary_exits_within_1_second_of_sigterm() {
         .env("NODEDB_PORT_HTTP", http_port.to_string())
         .env("NODEDB_PORT_PGWIRE", pgwire_port.to_string())
         .env("NODEDB_PORT_NATIVE", native_port.to_string())
+        .env("NODEDB_PORT_SYNC", sync_port.to_string())
         .env("RUST_LOG", "error")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/nodedb/tests/shutdown_idempotent.rs
+++ b/nodedb/tests/shutdown_idempotent.rs
@@ -58,6 +58,9 @@ fn double_sigterm_is_idempotent_no_panic() {
     let http_port = free_port();
     let pgwire_port = free_port();
     let native_port = free_port();
+    // Unique too: the sync bind is boot-fatal, so concurrent server
+    // processes must not share the default sync port.
+    let sync_port = free_port();
 
     let mut child = std::process::Command::new(bin)
         .env("NODEDB_DATA_DIR", dir.path())
@@ -65,6 +68,7 @@ fn double_sigterm_is_idempotent_no_panic() {
         .env("NODEDB_PORT_HTTP", http_port.to_string())
         .env("NODEDB_PORT_PGWIRE", pgwire_port.to_string())
         .env("NODEDB_PORT_NATIVE", native_port.to_string())
+        .env("NODEDB_PORT_SYNC", sync_port.to_string())
         .env("RUST_LOG", "error")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/nodedb/tests/shutdown_in_flight.rs
+++ b/nodedb/tests/shutdown_in_flight.rs
@@ -60,6 +60,9 @@ async fn sigterm_during_in_flight_query_does_not_hang() {
     let http_port = free_port();
     let pgwire_port = free_port();
     let native_port = free_port();
+    // Unique too: the sync bind is boot-fatal, so concurrent server
+    // processes must not share the default sync port.
+    let sync_port = free_port();
 
     let mut child = std::process::Command::new(bin)
         .env("NODEDB_DATA_DIR", dir.path())
@@ -67,6 +70,7 @@ async fn sigterm_during_in_flight_query_does_not_hang() {
         .env("NODEDB_PORT_HTTP", http_port.to_string())
         .env("NODEDB_PORT_PGWIRE", pgwire_port.to_string())
         .env("NODEDB_PORT_NATIVE", native_port.to_string())
+        .env("NODEDB_PORT_SYNC", sync_port.to_string())
         .env("RUST_LOG", "error")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())


### PR DESCRIPTION
Fixes #209.

## What

Makes the sync WebSocket listener address configurable through server config, consistent with every other listener, and makes a sync bind failure boot-fatal instead of a silent non-fatal WARN.

- `[server.ports] sync = 9090` — new always-on `u16` port key on `PortsConfig` (serde default 9090), mirroring `native`/`pgwire`/`http` exactly. Composed with the shared `server.host` via a new `ServerConfig::sync_addr()` accessor, same shape as its siblings.
- `NODEDB_PORT_SYNC` env override via the existing `apply_port_env` helper (env > TOML > default, malformed values warn-and-ignore — same convention as the other port vars).
- `spawn_protocol_listeners` now returns `anyhow::Result<()>`; a sync bind failure propagates to `main()` and aborts boot with context, matching the fatal behavior of the pgwire/native/ilp/resp binds. Rationale: a sync Origin that cannot accept sync is misconfigured rather than degraded (per the issue discussion), and the motivating incident was an instance running two days sync-less on one WARN line.
- Docs: `getting-started.md` and `protocols.md` port tables/examples updated with `sync` / `NODEDB_PORT_SYNC`.

## Deliberate behavior change

The listener previously force-bound `0.0.0.0:9090` regardless of `server.host`. It now binds `{server.host}:9090` like every other listener — so with the default `host = "127.0.0.1"` the sync listener is no longer silently exposed on all interfaces. Deployments that relied on the implicit `0.0.0.0` bind while setting a narrower `host` will need `host` (or their firewall posture) revisited — calling this out explicitly since it tightens exposure.

Not in scope (per the issue): sync opt-out/disable (sync stays always-on; that is a larger design question), readiness-endpoint surfacing (fatal-at-boot chosen instead), moving the bind earlier in boot order.

## Tests

- `defaults_match_documented_values` + `default_config_valid` extended (`sync == 9090`).
- New `env_sync_port_overrides` (valid + malformed, modeled on `env_memory_limit_overrides`).
- New `start_sync_listener_returns_err_on_occupied_port` — reserves an ephemeral port with a real listener, asserts `start_sync_listener` returns `Err` on the occupied address (first direct test of the bind-failure surface).
- Full `nodedb` lib suite: 4793 passed. `cargo clippy -p nodedb --lib --bins` clean. `cargo fmt` applied.
