### PR TITLE
fix(sql): reject procedural division/modulo by zero, reusing #216 error plumbing

### DIFF
--- a/nodedb/src/control/planner/procedural/executor/eval.rs
+++ b/nodedb/src/control/planner/procedural/executor/eval.rs
@@ -12,6 +12,31 @@
 use crate::control::state::SharedState;
 use crate::types::TenantId;
 
+/// Signal from constant-expression evaluation that a `/` or `%` reached a
+/// zero divisor (nodedb issue #227).
+///
+/// Kept local to this module — the procedural executor's constant folder is
+/// a separate, sqlparser-based tree-walk evaluator with no dependency on
+/// `nodedb_query` (whose own `EvalError::DivisionByZero`, from the
+/// DataFusion-backed row-expression evaluator fixed under issue #216,
+/// covers a different code path entirely). Every other historically
+/// `None`-folding case (unknown identifiers, unsupported operators,
+/// overflow, non-finite float results) is unaffected and keeps folding to
+/// `Ok(None)` — see `try_eval_constant`, `evaluate_to_value`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+enum ConstEvalError {
+    #[error("division by zero")]
+    DivisionByZero,
+}
+
+impl From<ConstEvalError> for crate::Error {
+    fn from(e: ConstEvalError) -> Self {
+        match e {
+            ConstEvalError::DivisionByZero => Self::DivisionByZero,
+        }
+    }
+}
+
 /// Evaluate a SQL boolean condition.
 ///
 /// Fast path for constant TRUE/FALSE/1/0/NULL. Falls back to constant
@@ -25,7 +50,7 @@ pub async fn evaluate_condition(
         return Ok(result);
     }
 
-    match try_eval_constant(condition_sql) {
+    match try_eval_constant(condition_sql)? {
         Some(nodedb_types::Value::Bool(b)) => Ok(b),
         Some(nodedb_types::Value::Integer(i)) => Ok(i != 0),
         Some(nodedb_types::Value::Float(f)) => Ok(f != 0.0),
@@ -48,7 +73,7 @@ pub async fn evaluate_int(
         return Ok(v);
     }
 
-    match try_eval_constant(sql) {
+    match try_eval_constant(sql)? {
         Some(nodedb_types::Value::Integer(i)) => Ok(i),
         Some(nodedb_types::Value::Float(f)) => Ok(f as i64),
         _ => Err(crate::Error::PlanError {
@@ -87,7 +112,7 @@ pub async fn evaluate_to_value(
         return Ok(nodedb_types::Value::String(inner.replace("''", "'")));
     }
 
-    match try_eval_constant(trimmed) {
+    match try_eval_constant(trimmed)? {
         Some(val) => Ok(val),
         None => Ok(nodedb_types::Value::Null),
     }
@@ -97,7 +122,13 @@ pub async fn evaluate_to_value(
 ///
 /// Handles basic arithmetic (+, -, *, /), comparisons, boolean logic,
 /// and string concatenation on literal values.
-fn try_eval_constant(sql: &str) -> Option<nodedb_types::Value> {
+///
+/// Returns `Ok(None)` for anything this mini-evaluator doesn't handle
+/// (unparseable input, unknown identifiers, unsupported operators,
+/// overflow) — callers fold that to `Value::Null`, matching historical
+/// behavior. Returns `Err(ConstEvalError::DivisionByZero)` only when
+/// evaluation reaches a `/` or `%` with a zero divisor (nodedb issue #227).
+fn try_eval_constant(sql: &str) -> Result<Option<nodedb_types::Value>, ConstEvalError> {
     let trimmed = sql.trim();
     let expr_str = if trimmed.to_uppercase().starts_with("SELECT ") {
         trimmed[7..].trim()
@@ -108,8 +139,12 @@ fn try_eval_constant(sql: &str) -> Option<nodedb_types::Value> {
     let dialect = sqlparser::dialect::PostgreSqlDialect {};
     let select_sql = format!("SELECT {expr_str}");
     // reconstructed-sql: parser-only evaluates one constant-expression AST without dispatch
-    let stmts = sqlparser::parser::Parser::parse_sql(&dialect, &select_sql).ok()?;
-    let stmt = stmts.first()?;
+    let Ok(stmts) = sqlparser::parser::Parser::parse_sql(&dialect, &select_sql) else {
+        return Ok(None);
+    };
+    let Some(stmt) = stmts.first() else {
+        return Ok(None);
+    };
 
     if let sqlparser::ast::Statement::Query(query) = stmt
         && let sqlparser::ast::SetExpr::Select(select) = &*query.body
@@ -117,15 +152,15 @@ fn try_eval_constant(sql: &str) -> Option<nodedb_types::Value> {
     {
         return eval_expr(expr);
     }
-    None
+    Ok(None)
 }
 
 /// Recursively evaluate a sqlparser expression tree.
-fn eval_expr(expr: &sqlparser::ast::Expr) -> Option<nodedb_types::Value> {
+fn eval_expr(expr: &sqlparser::ast::Expr) -> Result<Option<nodedb_types::Value>, ConstEvalError> {
     use sqlparser::ast::{Expr, UnaryOperator, Value};
 
     match expr {
-        Expr::Value(v) => match &v.value {
+        Expr::Value(v) => Ok(match &v.value {
             Value::Number(n, _) => {
                 if let Ok(i) = n.parse::<i64>() {
                     Some(nodedb_types::Value::Integer(i))
@@ -139,29 +174,28 @@ fn eval_expr(expr: &sqlparser::ast::Expr) -> Option<nodedb_types::Value> {
             Value::Boolean(b) => Some(nodedb_types::Value::Bool(*b)),
             Value::Null => Some(nodedb_types::Value::Null),
             _ => None,
-        },
+        }),
         Expr::UnaryOp {
             op: UnaryOperator::Minus,
             expr: inner,
-        } => match eval_expr(inner)? {
-            nodedb_types::Value::Integer(i) => Some(nodedb_types::Value::Integer(-i)),
-            nodedb_types::Value::Float(f) => Some(nodedb_types::Value::Float(-f)),
+        } => Ok(match eval_expr(inner)? {
+            Some(nodedb_types::Value::Integer(i)) => Some(nodedb_types::Value::Integer(-i)),
+            Some(nodedb_types::Value::Float(f)) => Some(nodedb_types::Value::Float(-f)),
             _ => None,
-        },
+        }),
         Expr::UnaryOp {
             op: UnaryOperator::Not,
             expr: inner,
-        } => match eval_expr(inner)? {
-            nodedb_types::Value::Bool(b) => Some(nodedb_types::Value::Bool(!b)),
+        } => Ok(match eval_expr(inner)? {
+            Some(nodedb_types::Value::Bool(b)) => Some(nodedb_types::Value::Bool(!b)),
             _ => None,
+        }),
+        Expr::BinaryOp { left, op, right } => match (eval_expr(left)?, eval_expr(right)?) {
+            (Some(l), Some(r)) => eval_binary_op(&l, op, &r),
+            _ => Ok(None),
         },
-        Expr::BinaryOp { left, op, right } => {
-            let l = eval_expr(left)?;
-            let r = eval_expr(right)?;
-            eval_binary_op(&l, op, &r)
-        }
         Expr::Nested(inner) => eval_expr(inner),
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -169,44 +203,50 @@ fn eval_binary_op(
     l: &nodedb_types::Value,
     op: &sqlparser::ast::BinaryOperator,
     r: &nodedb_types::Value,
-) -> Option<nodedb_types::Value> {
+) -> Result<Option<nodedb_types::Value>, ConstEvalError> {
     use nodedb_types::Value;
     use sqlparser::ast::BinaryOperator::*;
 
     match (l, r) {
         (Value::Integer(a), Value::Integer(b)) => match op {
-            Plus => Some(Value::Integer(a.checked_add(*b)?)),
-            Minus => Some(Value::Integer(a.checked_sub(*b)?)),
-            Multiply => Some(Value::Integer(a.checked_mul(*b)?)),
-            Divide if *b != 0 => Some(Value::Integer(a.checked_div(*b)?)),
-            Modulo if *b != 0 => Some(Value::Integer(a.checked_rem(*b)?)),
-            Gt => Some(Value::Bool(a > b)),
-            GtEq => Some(Value::Bool(a >= b)),
-            Lt => Some(Value::Bool(a < b)),
-            LtEq => Some(Value::Bool(a <= b)),
-            Eq => Some(Value::Bool(a == b)),
-            NotEq => Some(Value::Bool(a != b)),
-            _ => None,
+            Plus => Ok(a.checked_add(*b).map(Value::Integer)),
+            Minus => Ok(a.checked_sub(*b).map(Value::Integer)),
+            Multiply => Ok(a.checked_mul(*b).map(Value::Integer)),
+            Divide if *b != 0 => Ok(a.checked_div(*b).map(Value::Integer)),
+            Divide => Err(ConstEvalError::DivisionByZero),
+            Modulo if *b != 0 => Ok(a.checked_rem(*b).map(Value::Integer)),
+            Modulo => Err(ConstEvalError::DivisionByZero),
+            Gt => Ok(Some(Value::Bool(a > b))),
+            GtEq => Ok(Some(Value::Bool(a >= b))),
+            Lt => Ok(Some(Value::Bool(a < b))),
+            LtEq => Ok(Some(Value::Bool(a <= b))),
+            Eq => Ok(Some(Value::Bool(a == b))),
+            NotEq => Ok(Some(Value::Bool(a != b))),
+            _ => Ok(None),
         },
         (Value::Float(a), Value::Float(b)) => match op {
-            Plus => Some(Value::Float(a + b)),
-            Minus => Some(Value::Float(a - b)),
-            Multiply => Some(Value::Float(a * b)),
-            Divide if *b != 0.0 && b.is_finite() && *b != -0.0 => {
+            Plus => Ok(Some(Value::Float(a + b))),
+            Minus => Ok(Some(Value::Float(a - b))),
+            Multiply => Ok(Some(Value::Float(a * b))),
+            // Non-finite divisor (NaN/Infinity) is unsupported input, not a
+            // zero-divisor — keeps folding to `None` as before.
+            Divide if !b.is_finite() => Ok(None),
+            Divide if *b == 0.0 => Err(ConstEvalError::DivisionByZero),
+            Divide => {
                 let result = a / b;
                 if result.is_finite() {
-                    Some(Value::Float(result))
+                    Ok(Some(Value::Float(result)))
                 } else {
-                    None
+                    Ok(None)
                 }
             }
-            Gt => Some(Value::Bool(a > b)),
-            GtEq => Some(Value::Bool(a >= b)),
-            Lt => Some(Value::Bool(a < b)),
-            LtEq => Some(Value::Bool(a <= b)),
-            Eq => Some(Value::Bool(a == b)),
-            NotEq => Some(Value::Bool(a != b)),
-            _ => None,
+            Gt => Ok(Some(Value::Bool(a > b))),
+            GtEq => Ok(Some(Value::Bool(a >= b))),
+            Lt => Ok(Some(Value::Bool(a < b))),
+            LtEq => Ok(Some(Value::Bool(a <= b))),
+            Eq => Ok(Some(Value::Bool(a == b))),
+            NotEq => Ok(Some(Value::Bool(a != b))),
+            _ => Ok(None),
         },
         (Value::Integer(a), Value::Float(b)) => {
             eval_binary_op(&Value::Float(*a as f64), op, &Value::Float(*b))
@@ -214,19 +254,66 @@ fn eval_binary_op(
         (Value::Float(a), Value::Integer(b)) => {
             eval_binary_op(&Value::Float(*a), op, &Value::Float(*b as f64))
         }
-        (Value::Bool(a), Value::Bool(b)) => match op {
+        (Value::Bool(a), Value::Bool(b)) => Ok(match op {
             And => Some(Value::Bool(*a && *b)),
             Or => Some(Value::Bool(*a || *b)),
             Eq => Some(Value::Bool(a == b)),
             NotEq => Some(Value::Bool(a != b)),
             _ => None,
-        },
-        (Value::String(a), Value::String(b)) => match op {
+        }),
+        (Value::String(a), Value::String(b)) => Ok(match op {
             StringConcat => Some(Value::String(format!("{a}{b}"))),
             Eq => Some(Value::Bool(a == b)),
             NotEq => Some(Value::Bool(a != b)),
             _ => None,
-        },
-        _ => None,
+        }),
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Division/modulo by zero (nodedb issue #227) ─────────────────────────
+
+    #[test]
+    fn integer_division_by_zero_signals_error() {
+        assert_eq!(
+            try_eval_constant("10 / 0"),
+            Err(ConstEvalError::DivisionByZero)
+        );
+    }
+
+    #[test]
+    fn integer_modulo_by_zero_signals_error() {
+        assert_eq!(
+            try_eval_constant("10 % 0"),
+            Err(ConstEvalError::DivisionByZero)
+        );
+    }
+
+    #[test]
+    fn float_division_by_zero_signals_error() {
+        assert_eq!(
+            try_eval_constant("10.0 / 0.0"),
+            Err(ConstEvalError::DivisionByZero)
+        );
+    }
+
+    /// Control: a non-zero divisor still computes normally.
+    #[test]
+    fn integer_division_by_nonzero_still_computes() {
+        assert_eq!(
+            try_eval_constant("10 / 2"),
+            Ok(Some(nodedb_types::Value::Integer(5)))
+        );
+    }
+
+    /// Control: an unrelated `None` case (unknown identifier) is unaffected
+    /// by the division-by-zero signal and still folds to `Ok(None)`.
+    #[test]
+    fn unknown_identifier_still_folds_to_none() {
+        assert_eq!(try_eval_constant("some_unbound_identifier"), Ok(None));
     }
 }

--- a/nodedb/src/control/planner/procedural/executor/eval.rs
+++ b/nodedb/src/control/planner/procedural/executor/eval.rs
@@ -13,16 +13,16 @@ use crate::control::state::SharedState;
 use crate::types::TenantId;
 
 /// Signal from constant-expression evaluation that a `/` or `%` reached a
-/// zero divisor (nodedb issue #227).
+/// zero divisor.
 ///
 /// Kept local to this module — the procedural executor's constant folder is
 /// a separate, sqlparser-based tree-walk evaluator with no dependency on
 /// `nodedb_query` (whose own `EvalError::DivisionByZero`, from the
-/// DataFusion-backed row-expression evaluator fixed under issue #216,
-/// covers a different code path entirely). Every other historically
-/// `None`-folding case (unknown identifiers, unsupported operators,
-/// overflow, non-finite float results) is unaffected and keeps folding to
-/// `Ok(None)` — see `try_eval_constant`, `evaluate_to_value`.
+/// DataFusion-backed row-expression evaluator, covers a different code path
+/// entirely). Every other historically `None`-folding case (unknown
+/// identifiers, unsupported operators, overflow, non-finite float results)
+/// is unaffected and keeps folding to `Ok(None)` — see `try_eval_constant`,
+/// `evaluate_to_value`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 enum ConstEvalError {
     #[error("division by zero")]
@@ -127,7 +127,7 @@ pub async fn evaluate_to_value(
 /// (unparseable input, unknown identifiers, unsupported operators,
 /// overflow) — callers fold that to `Value::Null`, matching historical
 /// behavior. Returns `Err(ConstEvalError::DivisionByZero)` only when
-/// evaluation reaches a `/` or `%` with a zero divisor (nodedb issue #227).
+/// evaluation reaches a `/` or `%` with a zero divisor.
 fn try_eval_constant(sql: &str) -> Result<Option<nodedb_types::Value>, ConstEvalError> {
     let trimmed = sql.trim();
     let expr_str = if trimmed.to_uppercase().starts_with("SELECT ") {
@@ -275,7 +275,7 @@ fn eval_binary_op(
 mod tests {
     use super::*;
 
-    // ── Division/modulo by zero (nodedb issue #227) ─────────────────────────
+    // ── Division/modulo by zero ─────────────────────────────────────────────
 
     #[test]
     fn integer_division_by_zero_signals_error() {

--- a/nodedb/src/error.rs
+++ b/nodedb/src/error.rs
@@ -201,7 +201,8 @@ pub enum Error {
     UndefinedFunction { name: String },
 
     /// Expression evaluation divided or took a modulus by zero. Propagated
-    /// from `nodedb_query::EvalError::DivisionByZero`; the pgwire layer
+    /// from the row-expression evaluator (`nodedb_query::EvalError::DivisionByZero`)
+    /// and the procedural executor's constant folder; the pgwire layer
     /// renders this as SQLSTATE `22012` (division_by_zero).
     #[error("division by zero")]
     DivisionByZero,

--- a/nodedb/tests/trigger_e2e.rs
+++ b/nodedb/tests/trigger_e2e.rs
@@ -97,6 +97,148 @@ async fn before_trigger_reject_does_not_persist_row() {
     server.exec("DROP TRIGGER guard").await.unwrap();
 }
 
+/// A BEFORE INSERT trigger that divides by zero in a NEW.* assignment must
+/// reject the insert with a "division by zero" error instead of silently
+/// writing NULL (nodedb issue #227), and the row must NOT be persisted —
+/// the same fail-closed contract as any other BEFORE trigger rejection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn before_trigger_division_by_zero_rejects_insert() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION ratios (id TEXT PRIMARY KEY, numerator INT, \
+             denominator INT, ratio INT) WITH (engine='document_strict')",
+        )
+        .await
+        .unwrap();
+
+    server
+        .exec(
+            "CREATE TRIGGER compute_ratio BEFORE INSERT ON ratios FOR EACH ROW \
+             BEGIN \
+               NEW.ratio := NEW.numerator / NEW.denominator; \
+             END",
+        )
+        .await
+        .unwrap();
+
+    // Insert with a zero denominator should fail with a division-by-zero error.
+    server
+        .expect_error(
+            "INSERT INTO ratios (id, numerator, denominator) VALUES ('r1', 10, 0)",
+            "division by zero",
+        )
+        .await;
+
+    // Row should NOT exist.
+    let rows = server
+        .query_text("SELECT id FROM ratios WHERE id = 'r1'")
+        .await
+        .unwrap();
+    assert!(
+        rows.is_empty(),
+        "row rejected by division-by-zero trigger should not be persisted"
+    );
+
+    server.exec("DROP TRIGGER compute_ratio").await.unwrap();
+}
+
+/// Happy-path control for `before_trigger_division_by_zero_rejects_insert`:
+/// a non-zero denominator computes normally and the row persists with the
+/// computed value.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn before_trigger_nonzero_division_persists_computed_value() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION ratios2 (id TEXT PRIMARY KEY, numerator INT, \
+             denominator INT, ratio INT) WITH (engine='document_strict')",
+        )
+        .await
+        .unwrap();
+
+    server
+        .exec(
+            "CREATE TRIGGER compute_ratio2 BEFORE INSERT ON ratios2 FOR EACH ROW \
+             BEGIN \
+               NEW.ratio := NEW.numerator / NEW.denominator; \
+             END",
+        )
+        .await
+        .unwrap();
+
+    server
+        .exec("INSERT INTO ratios2 (id, numerator, denominator) VALUES ('r2', 10, 2)")
+        .await
+        .unwrap();
+
+    let rows = server
+        .query_text("SELECT ratio FROM ratios2 WHERE id = 'r2'")
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec!["5".to_string()],
+        "expected computed ratio 10/2 = 5"
+    );
+
+    server.exec("DROP TRIGGER compute_ratio2").await.unwrap();
+}
+
+/// An `EXCEPTION WHEN DIVISION_BY_ZERO` handler inside the trigger body must
+/// catch the division-by-zero signal end-to-end: the insert succeeds and the
+/// handler's fallback assignment is applied, proving the previously-dormant
+/// `DIVISION_BY_ZERO` named condition (see `exception::exception_matches`)
+/// now actually fires.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn before_trigger_exception_handler_catches_division_by_zero() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION ratios_safe (id TEXT PRIMARY KEY, numerator INT, \
+             denominator INT, ratio INT) WITH (engine='document_strict')",
+        )
+        .await
+        .unwrap();
+
+    server
+        .exec(
+            "CREATE TRIGGER compute_ratio_safe BEFORE INSERT ON ratios_safe FOR EACH ROW \
+             BEGIN \
+               NEW.ratio := NEW.numerator / NEW.denominator; \
+             EXCEPTION WHEN DIVISION_BY_ZERO THEN \
+               NEW.ratio := 0; \
+             END",
+        )
+        .await
+        .unwrap();
+
+    // Insert with a zero denominator: the EXCEPTION handler catches the
+    // division-by-zero error and the insert succeeds with ratio = 0.
+    server
+        .exec("INSERT INTO ratios_safe (id, numerator, denominator) VALUES ('s1', 10, 0)")
+        .await
+        .unwrap();
+
+    let rows = server
+        .query_text("SELECT ratio FROM ratios_safe WHERE id = 's1'")
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec!["0".to_string()],
+        "EXCEPTION handler should have set ratio to 0"
+    );
+
+    server
+        .exec("DROP TRIGGER compute_ratio_safe")
+        .await
+        .unwrap();
+}
+
 /// AFTER ASYNC trigger failure does NOT affect the parent write.
 /// The write should succeed; trigger error is handled by retry/DLQ.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/nodedb/tests/trigger_e2e.rs
+++ b/nodedb/tests/trigger_e2e.rs
@@ -99,8 +99,8 @@ async fn before_trigger_reject_does_not_persist_row() {
 
 /// A BEFORE INSERT trigger that divides by zero in a NEW.* assignment must
 /// reject the insert with a "division by zero" error instead of silently
-/// writing NULL (nodedb issue #227), and the row must NOT be persisted —
-/// the same fail-closed contract as any other BEFORE trigger rejection.
+/// writing NULL, and the row must NOT be persisted — the same fail-closed
+/// contract as any other BEFORE trigger rejection.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn before_trigger_division_by_zero_rejects_insert() {
     let server = TestServer::start().await;


### PR DESCRIPTION
Fixes #227.

## What

Trigger-body assignments stop silently writing NULL on division by zero: `NEW.ratio := NEW.numerator / NEW.denominator;` with a zero denominator now aborts the triggering statement with a division-by-zero error instead of committing a wrong row. Same class as #216, but in a **different evaluator** — the procedural executor's own constant folder, which every trigger body / `CALL` / scheduled job / alert body runs through. #216 fixed the `nodedb_query` row-expression path; this fixes the procedural path, which on `main` today still folds a zero divisor to `NULL`.

Root cause was one coercion: `evaluate_to_value` mapped every failed constant-fold (`None`) to `Ok(Value::Null)` — including the zero-divisor arms that deliberately declined to divide. The fix threads a typed `ConstEvalError::DivisionByZero` through `try_eval_constant` / `eval_expr` / `eval_binary_op` so the zero-divisor cases become `crate::Error::DivisionByZero`, while every other fold-to-NULL shape (unknown identifiers, unsupported operators, overflow, non-finite float divisors) keeps today's behavior — scope-disciplined to `/` and `%` by zero only.

**Bonus that fell out for free:** the `EXCEPTION WHEN DIVISION_BY_ZERO` handler machinery — present and unit-tested since introduction, but matching an error nothing ever raised — now works end-to-end. A trigger body with `EXCEPTION WHEN DIVISION_BY_ZERO THEN NEW.ratio := 0; END` catches a real division by zero and rescues the insert (covered by a new e2e test).

## Scope / notes for review

- **Reuses #216's error plumbing.** This PR was originally opened against a base predating #216 and carried its own copy of the `nodedb-types` plumbing (SQLSTATE `22012`, `ErrorCode` 1204, msgpack tag 68, the `Error::DivisionByZero` variant). #216 has since merged that same plumbing to `main`, so the PR has been **rebased onto current `main` and the redundant 11-file plumbing dropped** — it now reuses the existing `Error::DivisionByZero` variant. The diff is the fix and its tests only.
- **Known pre-existing gap, not addressed here:** the trigger-firing wrapper flattens every inner trigger error (including `RAISE EXCEPTION`) to `BadRequest` / SQLSTATE 42601, so an *uncaught* division by zero in a trigger surfaces to the client as 42601 with "division by zero" in the message rather than 22012. Fixing that wrapper's error fidelity is a separate, broader change.
- Behavior change: any trigger/procedure relying on silent NULL-on-zero-divisor now hard-fails. No existing test pinned the old behavior.
- All live procedural consumers (BEFORE/AFTER/INSTEAD-OF triggers, `CALL`, scheduled jobs, alert bodies) share the fixed choke point; IF/WHILE conditions already hard-failed and now carry the precise error.

## Tests

New unit module for the procedural evaluator (int/float/modulo zero-divisor, non-zero control, unrelated-`None`-still-folds control) and three e2e trigger tests: the issue's exact repro (errors + row not persisted), the happy path (ratio computed and persisted), and the exception-handler rescue.

- nodedb-types error round-trip: 91 passed
- procedural eval unit tests: 5 passed
- trigger_e2e: 21 passed
- fmt clean; touched files clippy-clean
