### PR TITLE
fix(swim): fast-restart rejoin — persist incarnation, echo refutations, ping liveness

### DIFF
--- a/nodedb-cluster/src/bootstrap/start.rs
+++ b/nodedb-cluster/src/bootstrap/start.rs
@@ -78,8 +78,10 @@ pub fn register_default_subsystems(
     // incarnation. A node that crashed while peers held `Dead(A, N)`
     // restarts at `N + 1`, so its very first `Alive` announcement
     // dominates every lingering rumour — no probabilistic refutation
-    // round-trip required.
-    let persisted_inc = catalog.load_swim_incarnation().unwrap_or(None);
+    // round-trip required. A read error (or corrupted metadata) FAILS
+    // bootstrap rather than silently restarting at incarnation 0, which
+    // would reintroduce the stick the persisted key exists to prevent.
+    let persisted_inc = catalog.load_swim_incarnation()?;
     let initial_incarnation = match persisted_inc {
         Some(v) => Incarnation::new(v).bump(),
         None => Incarnation::ZERO,

--- a/nodedb-cluster/src/bootstrap/start.rs
+++ b/nodedb-cluster/src/bootstrap/start.rs
@@ -34,6 +34,9 @@ use crate::subsystem::{
     DecommissionSubsystem, ReachabilitySubsystem, RebalancerSubsystem, RunningCluster,
     SubsystemRegistry, SwimSubsystem, SwimSubsystemConfig,
 };
+use crate::swim::config::SwimConfig;
+use crate::swim::incarnation::Incarnation;
+use crate::swim::incarnation_store::CatalogIncarnationStore;
 use crate::transport::NexarTransport;
 
 use super::bootstrap_fn::bootstrap;
@@ -69,9 +72,24 @@ pub fn register_default_subsystems(
     config: &ClusterConfig,
     ctx: &BootstrapCtx,
     executor: Arc<MigrationExecutor>,
+    catalog: &Arc<ClusterCatalog>,
 ) -> crate::error::Result<()> {
+    // Fast-restart rejoin safety: resume SWIM above the last persisted
+    // incarnation. A node that crashed while peers held `Dead(A, N)`
+    // restarts at `N + 1`, so its very first `Alive` announcement
+    // dominates every lingering rumour — no probabilistic refutation
+    // round-trip required.
+    let persisted_inc = catalog.load_swim_incarnation().unwrap_or(None);
+    let initial_incarnation = match persisted_inc {
+        Some(v) => Incarnation::new(v).bump(),
+        None => Incarnation::ZERO,
+    };
+
     let swim_cfg = SwimSubsystemConfig {
-        swim: crate::swim::config::SwimConfig::default(),
+        swim: SwimConfig {
+            initial_incarnation,
+            ..SwimConfig::default()
+        },
         local_id: NodeId::try_new(config.node_id.to_string()).map_err(|e| {
             crate::error::ClusterError::Config {
                 detail: format!("node_id is not a valid ID: {e}"),
@@ -85,6 +103,7 @@ pub fn register_default_subsystems(
             a
         }),
         seeds: config.seed_nodes.clone(),
+        incarnation_store: Some(Arc::new(CatalogIncarnationStore::new(Arc::clone(catalog)))),
     };
 
     registry.register(Arc::new(SwimSubsystem::new(
@@ -186,6 +205,7 @@ pub async fn start_cluster_subsystems(
     routing: Arc<std::sync::RwLock<crate::routing::RoutingTable>>,
     transport: Arc<NexarTransport>,
     raft_multi_raft: Arc<std::sync::Mutex<crate::multi_raft::MultiRaft>>,
+    catalog: &Arc<ClusterCatalog>,
 ) -> Result<RunningCluster> {
     let health = ClusterHealth::new();
     let (decommission_signal, _) = tokio::sync::watch::channel(false);
@@ -206,7 +226,7 @@ pub async fn start_cluster_subsystems(
     ));
 
     let mut registry = SubsystemRegistry::new();
-    register_default_subsystems(&mut registry, config, &ctx, executor)?;
+    register_default_subsystems(&mut registry, config, &ctx, executor, catalog)?;
 
     registry
         .start_all(&ctx)

--- a/nodedb-cluster/src/catalog/core.rs
+++ b/nodedb-cluster/src/catalog/core.rs
@@ -175,7 +175,15 @@ impl ClusterCatalog {
                     arr.copy_from_slice(bytes);
                     Ok(Some(u64::from_le_bytes(arr)))
                 } else {
-                    Ok(None)
+                    // Corrupted metadata: an unexpected length is NOT "no
+                    // value". Surface it so operators detect catalog
+                    // corruption early instead of silently restarting at
+                    // incarnation 0 (which would reintroduce the rejoin
+                    // stick the key exists to prevent).
+                    Err(catalog_err(format!(
+                        "metadata key {KEY_SWIM_INCARNATION} has unexpected length {} (expected 8)",
+                        bytes.len()
+                    )))
                 }
             }
             None => Ok(None),

--- a/nodedb-cluster/src/catalog/core.rs
+++ b/nodedb-cluster/src/catalog/core.rs
@@ -17,8 +17,8 @@ use crate::error::Result;
 use super::migration::migrate_if_needed;
 use super::schema::{
     CATALOG_FORMAT_VERSION, GHOST_TABLE, KEY_CA_CERT, KEY_CLUSTER_EPOCH, KEY_CLUSTER_ID,
-    KEY_FORMAT_VERSION, METADATA_TABLE, MIGRATION_STATE_TABLE, ROUTING_TABLE, TOPOLOGY_TABLE,
-    catalog_err,
+    KEY_FORMAT_VERSION, KEY_SWIM_INCARNATION, METADATA_TABLE, MIGRATION_STATE_TABLE, ROUTING_TABLE,
+    TOPOLOGY_TABLE, catalog_err,
 };
 
 /// Persistent cluster catalog backed by redb.
@@ -132,6 +132,42 @@ impl ClusterCatalog {
         let txn = self.db.begin_read().map_err(catalog_err)?;
         let table = txn.open_table(METADATA_TABLE).map_err(catalog_err)?;
         match table.get(KEY_CLUSTER_EPOCH).map_err(catalog_err)? {
+            Some(guard) => {
+                let bytes = guard.value();
+                if bytes.len() == 8 {
+                    let mut arr = [0u8; 8];
+                    arr.copy_from_slice(bytes);
+                    Ok(Some(u64::from_le_bytes(arr)))
+                } else {
+                    Ok(None)
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Persist the local SWIM incarnation (u64 LE). Written on every
+    /// self-refutation bump so a fast restart can resume at the stored
+    /// value instead of 0. See `crate::swim::incarnation_store`.
+    pub fn save_swim_incarnation(&self, incarnation: u64) -> Result<()> {
+        let bytes = incarnation.to_le_bytes();
+        let txn = self.db.begin_write().map_err(catalog_err)?;
+        {
+            let mut table = txn.open_table(METADATA_TABLE).map_err(catalog_err)?;
+            table
+                .insert(KEY_SWIM_INCARNATION, bytes.as_slice())
+                .map_err(catalog_err)?;
+        }
+        txn.commit().map_err(catalog_err)?;
+        Ok(())
+    }
+
+    /// Load the persisted SWIM incarnation. Returns `None` on a catalog
+    /// that has never written one (callers treat that as `ZERO`).
+    pub fn load_swim_incarnation(&self) -> Result<Option<u64>> {
+        let txn = self.db.begin_read().map_err(catalog_err)?;
+        let table = txn.open_table(METADATA_TABLE).map_err(catalog_err)?;
+        match table.get(KEY_SWIM_INCARNATION).map_err(catalog_err)? {
             Some(guard) => {
                 let bytes = guard.value();
                 if bytes.len() == 8 {

--- a/nodedb-cluster/src/catalog/schema.rs
+++ b/nodedb-cluster/src/catalog/schema.rs
@@ -39,6 +39,11 @@ pub(super) const KEY_CLUSTER_ID: &str = "cluster_id";
 /// Cluster epoch (u64 LE) — monotonic, leader-bumped, stamped on every
 /// Raft RPC. Persisted so the local high-water mark survives restart.
 pub(super) const KEY_CLUSTER_EPOCH: &str = "cluster_epoch";
+/// SWIM incarnation (u64 LE) — the local node's last advertised
+/// incarnation, persisted so a fast restart can rejoin at `stored + 1`
+/// and dominate any lingering `Dead(stored)` rumour. See
+/// `crate::swim::incarnation_store`.
+pub(super) const KEY_SWIM_INCARNATION: &str = "swim_incarnation";
 pub(super) const KEY_CA_CERT: &str = "ca_cert";
 /// Metadata key holding the catalog format version (u32 LE).
 /// Stored under this key in the metadata table by `ClusterCatalog::open`.

--- a/nodedb-cluster/src/subsystem/impls/swim_subsystem.rs
+++ b/nodedb-cluster/src/subsystem/impls/swim_subsystem.rs
@@ -30,6 +30,7 @@ use crate::routing_liveness::{NodeIdResolver, RoutingLivenessHook};
 use crate::swim::bootstrap::{SwimHandle, spawn_with_subscribers};
 use crate::swim::config::SwimConfig;
 use crate::swim::detector::UdpTransport;
+use crate::swim::incarnation_store::IncarnationStore;
 use crate::swim::subscriber::MembershipSubscriber;
 use crate::topology::ClusterTopology;
 
@@ -49,6 +50,9 @@ pub struct SwimSubsystemConfig {
     pub swim_addr: SocketAddr,
     /// Initial seed peers for the membership list.
     pub seeds: Vec<SocketAddr>,
+    /// Persists self-refutation incarnation bumps across restarts.
+    /// Production passes a catalog-backed store.
+    pub incarnation_store: Option<Arc<dyn IncarnationStore>>,
 }
 
 /// Owns the SWIM failure detector lifetime.
@@ -132,6 +136,7 @@ impl ClusterSubsystem for SwimSubsystem {
             self.cfg.seeds.clone(),
             Arc::new(transport),
             subscribers,
+            self.cfg.incarnation_store.clone(),
         )
         .await
         .map_err(|e| BootstrapError::SubsystemStart {
@@ -209,6 +214,7 @@ mod tests {
             local_id: NodeId::try_new("1").expect("test fixture"),
             swim_addr: "127.0.0.1:0".parse().unwrap(),
             seeds: vec![],
+            incarnation_store: None,
         };
         let routing = Arc::new(RwLock::new(RoutingTable::uniform(1, &[1], 1)));
         let topology = Arc::new(RwLock::new(ClusterTopology::new()));
@@ -233,6 +239,7 @@ mod tests {
             local_id: NodeId::try_new("1").expect("test fixture"),
             swim_addr: "127.0.0.1:0".parse().unwrap(),
             seeds: vec![],
+            incarnation_store: None,
         };
         let routing = Arc::new(RwLock::new(RoutingTable::uniform(1, &[1], 1)));
         let topology = Arc::new(RwLock::new(ClusterTopology::new()));

--- a/nodedb-cluster/src/swim/bootstrap.rs
+++ b/nodedb-cluster/src/swim/bootstrap.rs
@@ -28,6 +28,7 @@ use super::detector::{FailureDetector, ProbeScheduler, Transport};
 use super::dissemination::DisseminationQueue;
 use super::error::SwimError;
 use super::incarnation::Incarnation;
+use super::incarnation_store::IncarnationStore;
 use super::member::MemberState;
 use super::member::record::MemberUpdate;
 use super::membership::MembershipList;
@@ -92,12 +93,24 @@ pub async fn spawn(
     seeds: Vec<SocketAddr>,
     transport: Arc<dyn Transport>,
 ) -> Result<SwimHandle, SwimError> {
-    spawn_with_subscribers(cfg, local_id, local_addr, seeds, transport, Vec::new()).await
+    spawn_with_subscribers(
+        cfg,
+        local_id,
+        local_addr,
+        seeds,
+        transport,
+        Vec::new(),
+        None,
+    )
+    .await
 }
 
 /// Same as [`spawn`] but installs the given [`MembershipSubscriber`]s
 /// on the detector before its run loop starts, so every state
 /// transition is observed from the very first probe round.
+///
+/// `incarnation_store` persists self-refutation bumps across restarts.
+/// Production passes a catalog-backed store; tests pass `None`.
 pub async fn spawn_with_subscribers(
     cfg: SwimConfig,
     local_id: NodeId,
@@ -105,6 +118,7 @@ pub async fn spawn_with_subscribers(
     seeds: Vec<SocketAddr>,
     transport: Arc<dyn Transport>,
     subscribers: Vec<Arc<dyn MembershipSubscriber>>,
+    incarnation_store: Option<Arc<dyn IncarnationStore>>,
 ) -> Result<SwimHandle, SwimError> {
     cfg.validate()?;
 
@@ -130,13 +144,17 @@ pub async fn spawn_with_subscribers(
     }
 
     let initial_inc = cfg.initial_incarnation;
-    let detector = Arc::new(FailureDetector::with_subscribers(
+    let mut detector = FailureDetector::with_subscribers(
         cfg,
         Arc::clone(&membership),
         transport,
         ProbeScheduler::new(),
         subscribers,
-    ));
+    );
+    if let Some(store) = incarnation_store {
+        detector.set_incarnation_store(store);
+    }
+    let detector = Arc::new(detector);
 
     // Prime the dissemination queue with our own Alive record so the
     // first outgoing probes advertise our canonical NodeId + addr to

--- a/nodedb-cluster/src/swim/detector/runner.rs
+++ b/nodedb-cluster/src/swim/detector/runner.rs
@@ -10,6 +10,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use tokio::sync::{Mutex, watch};
 use tokio::time::{Instant, interval};
@@ -18,6 +19,7 @@ use crate::swim::config::SwimConfig;
 use crate::swim::dissemination::{DisseminationQueue, apply_and_disseminate};
 use crate::swim::error::SwimError;
 use crate::swim::incarnation::Incarnation;
+use crate::swim::incarnation_store::IncarnationStore;
 use crate::swim::member::MemberState;
 use crate::swim::member::record::MemberUpdate;
 use crate::swim::membership::{MembershipList, MergeOutcome};
@@ -28,6 +30,11 @@ use super::probe_round::{InflightProbes, ProbeOutcome, ProbeRound};
 use super::scheduler::ProbeScheduler;
 use super::suspicion::SuspicionTimer;
 use super::transport::Transport;
+
+/// Minimum interval between self-alive advertisements on the ping-ack
+/// path. A heavily-pinged node would otherwise flood its dissemination
+/// queue with copies of its own record, starving real gossip.
+const SELF_ADVERTISE_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Top-level failure detector handle.
 ///
@@ -45,6 +52,14 @@ pub struct FailureDetector {
     probe_counter: AtomicU64,
     local_incarnation: Mutex<Incarnation>,
     subscribers: Vec<Arc<dyn MembershipSubscriber>>,
+    /// Persistence backend for the local incarnation. `None` in bare
+    /// tests; production installs a catalog-backed store so a restart
+    /// can resume above its last advertised value.
+    incarnation_store: Option<Arc<dyn IncarnationStore>>,
+    /// When we last enqueued our own `Alive` record on the ping-ack
+    /// path; rate-limits self-advertisement (see
+    /// [`SELF_ADVERTISE_INTERVAL`]).
+    last_self_advertise: Mutex<Option<Instant>>,
 }
 
 impl FailureDetector {
@@ -80,7 +95,16 @@ impl FailureDetector {
             probe_counter: AtomicU64::new(0),
             local_incarnation: Mutex::new(initial_inc),
             subscribers,
+            incarnation_store: None,
+            last_self_advertise: Mutex::new(None),
         }
+    }
+
+    /// Install the persistence backend for the local incarnation.
+    /// Production wires a catalog-backed store so self-refutation bumps
+    /// survive a restart; bare tests leave it `None`.
+    pub fn set_incarnation_store(&mut self, store: Arc<dyn IncarnationStore>) {
+        self.incarnation_store = Some(store);
     }
 
     /// Apply an update via [`apply_and_disseminate`] while notifying
@@ -115,16 +139,58 @@ impl FailureDetector {
     /// Applies each update to the membership list via
     /// [`apply_and_disseminate`] and, on a self-refutation, bumps the
     /// local incarnation so subsequent probes advertise the new value.
-    async fn ingest_piggyback(&self, piggyback: &[MemberUpdate]) {
+    ///
+    /// Returns the refutations to echo deterministically back to the
+    /// sender: whenever we `Refute` an update (the sender gossiped a
+    /// stale view), we include our stored record in the reply piggyback.
+    /// Without this, the refutation only reaches the sender
+    /// probabilistically via the regular gossip fanout.
+    async fn ingest_piggyback(&self, piggyback: &[MemberUpdate]) -> Vec<MemberUpdate> {
+        let mut refutations = Vec::new();
         for update in piggyback {
             let outcome = self.apply_and_notify(update);
-            if let MergeOutcome::SelfRefute { new_incarnation } = outcome {
-                let mut guard = self.local_incarnation.lock().await;
-                if new_incarnation > *guard {
-                    *guard = new_incarnation;
+            match outcome {
+                MergeOutcome::SelfRefute { new_incarnation } => {
+                    let mut guard = self.local_incarnation.lock().await;
+                    if new_incarnation > *guard {
+                        *guard = new_incarnation;
+                        // Persist the bump so a fast restart resumes above
+                        // the rumoured incarnation. Fire-and-forget: the
+                        // write is rare (self-refutation only) and must
+                        // not stall the probe loop.
+                        if let Some(store) = &self.incarnation_store {
+                            let store = Arc::clone(store);
+                            let v = new_incarnation.get();
+                            tokio::spawn(async move {
+                                if let Err(e) = store.save(v) {
+                                    tracing::warn!(
+                                        incarnation = v,
+                                        error = %e,
+                                        "failed to persist swim incarnation"
+                                    );
+                                }
+                            });
+                        }
+                    }
                 }
+                MergeOutcome::Refute => {
+                    // Echo our stored (newer) view back to the sender.
+                    if let Some(stored) = self.membership.get(&update.node_id) {
+                        refutations.push(MemberUpdate::from(&stored));
+                    }
+                }
+                MergeOutcome::Insert | MergeOutcome::Apply => {
+                    // A fresh Alive clears any pending suspicion timer for
+                    // that node — the timer would otherwise promote it to
+                    // Dead at expiry even though we just saw it live.
+                    if update.state == MemberState::Alive {
+                        self.suspicion.lock().await.cancel(&update.node_id);
+                    }
+                }
+                MergeOutcome::Ignore | MergeOutcome::TerminalLeft => {}
             }
         }
+        refutations
     }
 
     /// Exposed for tests that need to route a synthetic message into the
@@ -230,10 +296,12 @@ impl FailureDetector {
     async fn on_incoming(&self, from_addr: SocketAddr, msg: SwimMessage) {
         // Every datagram carries piggyback; ingest before dispatching so
         // a self-refutation bump is reflected in the outgoing Ack below.
-        self.ingest_piggyback(msg.piggyback()).await;
+        // Refutations (our stored view of records the sender got wrong)
+        // ride back deterministically on the reply.
+        let refutations = self.ingest_piggyback(msg.piggyback()).await;
         match msg {
-            SwimMessage::Ping(ping) => self.handle_ping(from_addr, ping).await,
-            SwimMessage::PingReq(req) => self.handle_ping_req(from_addr, req).await,
+            SwimMessage::Ping(ping) => self.handle_ping(from_addr, ping, refutations).await,
+            SwimMessage::PingReq(req) => self.handle_ping_req(from_addr, req, refutations).await,
             SwimMessage::Ack(ack) => {
                 self.inflight
                     .resolve(ack.probe_id, SwimMessage::Ack(ack))
@@ -247,22 +315,86 @@ impl FailureDetector {
         }
     }
 
-    async fn handle_ping(&self, from_addr: SocketAddr, ping: Ping) {
+    async fn handle_ping(
+        &self,
+        from_addr: SocketAddr,
+        ping: Ping,
+        mut refutations: Vec<MemberUpdate>,
+    ) {
+        // A ping IS liveness evidence (SWIM paper §3): apply the sender's
+        // claim before acking so an up-but-Dead node gets credit for
+        // probing. Stale claims fall out naturally via the merge rules.
+        let sender_claim = MemberUpdate {
+            node_id: ping.from.clone(),
+            addr: from_addr.to_string(),
+            state: MemberState::Alive,
+            incarnation: ping.incarnation,
+        };
+        let outcome = self.apply_and_notify(&sender_claim);
+        if matches!(outcome, MergeOutcome::Insert | MergeOutcome::Apply) {
+            self.suspicion.lock().await.cancel(&ping.from);
+        }
+        if matches!(outcome, MergeOutcome::Refute)
+            && let Some(stored) = self.membership.get(&ping.from)
+        {
+            refutations.push(MemberUpdate::from(&stored));
+        }
+
+        // Rate-limited self-advertisement: a heavily-pinged node should
+        // not flood the queue with copies of its own record.
+        let advertise = {
+            let mut last = self.last_self_advertise.lock().await;
+            let now = Instant::now();
+            match *last {
+                Some(prev) if now.duration_since(prev) < SELF_ADVERTISE_INTERVAL => false,
+                _ => {
+                    *last = Some(now);
+                    true
+                }
+            }
+        };
+        if advertise {
+            let local_inc = *self.local_incarnation.lock().await;
+            if let Some(me) = self.membership.get(self.membership.local_node_id()) {
+                self.dissemination.enqueue(MemberUpdate {
+                    node_id: me.node_id.clone(),
+                    addr: me.addr.to_string(),
+                    state: MemberState::Alive,
+                    incarnation: local_inc,
+                });
+            }
+        }
+
         let local_inc = *self.local_incarnation.lock().await;
         let fanout =
             DisseminationQueue::fanout_threshold(self.membership.len(), self.cfg.fanout_lambda);
+        let mut piggyback = self
+            .dissemination
+            .take_for_message(self.cfg.max_piggyback, fanout);
+
+        // Echo refutations back to the sender (deduped, bounded).
+        for r in refutations {
+            if !piggyback.iter().any(|p| p.node_id == r.node_id) {
+                piggyback.push(r);
+            }
+        }
+        piggyback.truncate(self.cfg.max_piggyback);
+
         let ack = SwimMessage::Ack(Ack {
             probe_id: ping.probe_id,
             from: self.membership.local_node_id().clone(),
             incarnation: local_inc,
-            piggyback: self
-                .dissemination
-                .take_for_message(self.cfg.max_piggyback, fanout),
+            piggyback,
         });
         let _ = self.transport.send(from_addr, ack).await;
     }
 
-    async fn handle_ping_req(&self, requester_addr: SocketAddr, req: PingReq) {
+    async fn handle_ping_req(
+        &self,
+        requester_addr: SocketAddr,
+        req: PingReq,
+        refutations: Vec<MemberUpdate>,
+    ) {
         let Ok(target_sock) = req.target_addr.parse::<SocketAddr>() else {
             return;
         };
@@ -288,6 +420,15 @@ impl FailureDetector {
         let original_probe_id = req.probe_id;
 
         tokio::spawn(async move {
+            // Merge echoed refutations into the forwarded ping piggyback.
+            let mut fwd_piggyback = dissemination.take_for_message(max_piggyback, fanout);
+            for r in refutations {
+                if !fwd_piggyback.iter().any(|p| p.node_id == r.node_id) {
+                    fwd_piggyback.push(r);
+                }
+            }
+            fwd_piggyback.truncate(max_piggyback);
+
             let send_res = transport
                 .send(
                     target_sock,
@@ -295,7 +436,7 @@ impl FailureDetector {
                         probe_id: forward_id,
                         from: local_node.clone(),
                         incarnation: local_inc,
-                        piggyback: dissemination.take_for_message(max_piggyback, fanout),
+                        piggyback: fwd_piggyback,
                     }),
                 )
                 .await;
@@ -336,6 +477,7 @@ impl FailureDetector {
 mod tests {
     use super::*;
     use crate::swim::detector::transport::TransportFabric;
+    use crate::swim::incarnation_store::{IncarnationStore, MemIncarnationStore};
     use crate::swim::member::MemberState;
     use crate::swim::wire::ProbeId;
     use nodedb_types::NodeId;
@@ -634,5 +776,276 @@ mod tests {
 
         let _ = sd_a.send(true);
         let _ = tokio::time::timeout(Duration::from_millis(100), h_a).await;
+    }
+
+    /// F4 (restart side): a non-Alive rumour about the local node always
+    /// triggers a self-refutation bump (merge rule), and a node restarted
+    /// at `persisted + 1` therefore refutes a lingering `Dead(A, persisted)`
+    /// to `persisted + 2` — strictly above the rumour, so its next Alive
+    /// announcement dominates.
+    #[test]
+    fn persisted_incarnation_dominates_lingering_dead() {
+        let list = Arc::new(MembershipList::new_local(
+            NodeId::try_new("a").expect("test fixture"),
+            addr(7100),
+            // Simulated restart: persisted 5, resume at 6.
+            Incarnation::new(5).bump(),
+        ));
+        let stale = MemberUpdate {
+            node_id: NodeId::try_new("a").expect("test fixture"),
+            addr: addr(7100).to_string(),
+            state: MemberState::Dead,
+            incarnation: Incarnation::new(5),
+        };
+        let outcome = list.apply(&stale);
+        match outcome {
+            MergeOutcome::SelfRefute { new_incarnation } => {
+                assert!(
+                    new_incarnation > Incarnation::new(5),
+                    "restart at 6 must refute Dead(5) above it, got {new_incarnation:?}"
+                );
+            }
+            other => panic!("expected SelfRefute, got {other:?}"),
+        }
+        let me = list
+            .get(&NodeId::try_new("a").expect("test fixture"))
+            .expect("self");
+        assert!(
+            me.incarnation > Incarnation::new(5),
+            "restart at 6 must end up strictly above Dead(5), got {:?}",
+            me.incarnation
+        );
+        assert_eq!(me.state, MemberState::Alive);
+    }
+
+    /// F1: a stale update about a peer yields the STORED view as an echo,
+    /// so the sender learns the newer truth deterministically on the reply
+    /// path instead of relying on probabilistic gossip.
+    #[tokio::test]
+    async fn stale_update_echoes_refutation() {
+        let fab = TransportFabric::new();
+        let (det_a, sd_a, h_a) = spawn_node(&fab, "a", 7110, &[]).await;
+
+        // A holds Alive(c, 9).
+        det_a.apply_and_notify(&MemberUpdate {
+            node_id: NodeId::try_new("c").expect("test fixture"),
+            addr: addr(7112).to_string(),
+            state: MemberState::Alive,
+            incarnation: Incarnation::new(9),
+        });
+
+        // B gossips a stale Dead(c, 3) → ingest must echo Alive(c, 9).
+        let refutations = det_a
+            .ingest_piggyback(&[MemberUpdate {
+                node_id: NodeId::try_new("c").expect("test fixture"),
+                addr: addr(7112).to_string(),
+                state: MemberState::Dead,
+                incarnation: Incarnation::new(3),
+            }])
+            .await;
+
+        assert_eq!(refutations.len(), 1);
+        assert_eq!(refutations[0].node_id.as_str(), "c");
+        assert_eq!(refutations[0].state, MemberState::Alive);
+        assert_eq!(refutations[0].incarnation, Incarnation::new(9));
+
+        let _ = sd_a.send(true);
+        let _ = tokio::time::timeout(Duration::from_millis(100), h_a).await;
+    }
+
+    /// F2: a ping IS liveness evidence — the sender's Alive claim is
+    /// applied, so an up-but-Dead node gets credit for probing.
+    #[tokio::test(start_paused = true)]
+    async fn ping_applies_sender_liveness() {
+        let fab = TransportFabric::new();
+        let (det_a, sd_a, h_a) = spawn_node(&fab, "a", 7120, &[]).await;
+
+        // A believes B is Dead(5).
+        det_a.apply_and_notify(&MemberUpdate {
+            node_id: NodeId::try_new("b").expect("test fixture"),
+            addr: addr(7121).to_string(),
+            state: MemberState::Dead,
+            incarnation: Incarnation::new(5),
+        });
+
+        // B pings with incarnation 6 → A must apply Alive(B, 6).
+        det_a
+            .on_incoming(
+                addr(7121),
+                SwimMessage::Ping(Ping {
+                    probe_id: ProbeId::new(9),
+                    from: NodeId::try_new("b").expect("test fixture"),
+                    incarnation: Incarnation::new(6),
+                    piggyback: vec![],
+                }),
+            )
+            .await;
+
+        let b = det_a
+            .membership
+            .get(&NodeId::try_new("b").expect("test fixture"))
+            .expect("b in list");
+        assert_eq!(b.state, MemberState::Alive, "ping must count as liveness");
+        assert_eq!(b.incarnation, Incarnation::new(6));
+
+        let _ = sd_a.send(true);
+        let _ = tokio::time::timeout(Duration::from_millis(100), h_a).await;
+    }
+
+    /// F3: applying a fresh Alive clears the pending suspicion timer, so
+    /// a stale expiry cannot promote the node to Dead afterwards.
+    #[tokio::test(start_paused = true)]
+    async fn alive_apply_cancels_suspicion_timer() {
+        let fab = TransportFabric::new();
+        let (det_a, sd_a, h_a) = spawn_node(&fab, "a", 7130, &[]).await;
+
+        // Arm a suspicion timer for c.
+        det_a.suspicion.lock().await.arm(
+            NodeId::try_new("c").expect("test fixture"),
+            Instant::now(),
+            &cfg(),
+            3,
+        );
+        assert_eq!(det_a.suspicion.lock().await.len(), 1);
+
+        // Alive(c) arrives via piggyback → timer must be cancelled.
+        det_a
+            .ingest_piggyback(&[MemberUpdate {
+                node_id: NodeId::try_new("c").expect("test fixture"),
+                addr: addr(7132).to_string(),
+                state: MemberState::Alive,
+                incarnation: Incarnation::new(2),
+            }])
+            .await;
+
+        assert_eq!(
+            det_a.suspicion.lock().await.len(),
+            0,
+            "Alive apply must cancel the suspicion timer"
+        );
+
+        let _ = sd_a.send(true);
+        let _ = tokio::time::timeout(Duration::from_millis(100), h_a).await;
+    }
+
+    /// F4 (bump side): a self-refutation bump is persisted through the
+    /// store so the next restart resumes above the rumoured incarnation.
+    #[tokio::test]
+    async fn self_refute_persists_incarnation() {
+        let fab = TransportFabric::new();
+        let (_det_a, sd_a, h_a) = spawn_node(&fab, "a", 7140, &[]).await;
+        let store = Arc::new(MemIncarnationStore::new());
+        // spawn_node builds the detector already; install the store via
+        // the public setter equivalent — rebuild through the same path
+        // the bootstrap uses.
+        drop((sd_a, h_a));
+
+        let transport: Arc<dyn Transport> = Arc::new(fab.bind(addr(7141)).await);
+        let list = Arc::new(MembershipList::new_local(
+            NodeId::try_new("a").expect("test fixture"),
+            addr(7141),
+            Incarnation::ZERO,
+        ));
+        let mut detector =
+            FailureDetector::new(cfg(), list, transport, ProbeScheduler::with_seed(1));
+        detector.set_incarnation_store(Arc::clone(&store) as Arc<dyn IncarnationStore>);
+        let det = Arc::new(detector);
+        let (tx, rx) = watch::channel(false);
+        let handle = tokio::spawn({
+            let d = Arc::clone(&det);
+            async move { d.run(rx).await }
+        });
+
+        // Rumour: Suspect(a, 7) → SelfRefute → bump to 8 + persist.
+        det.ingest_piggyback(&[MemberUpdate {
+            node_id: NodeId::try_new("a").expect("test fixture"),
+            addr: addr(7141).to_string(),
+            state: MemberState::Suspect,
+            incarnation: Incarnation::new(7),
+        }])
+        .await;
+
+        let bumped = *det.local_incarnation.lock().await;
+        assert!(bumped > Incarnation::new(7));
+
+        // The persist runs on a spawned task — give it a moment.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            store.load().unwrap(),
+            Some(bumped.get()),
+            "bump must be persisted through the store"
+        );
+
+        let _ = tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_millis(100), handle).await;
+    }
+
+    /// F1 + F4 combined: the full deterministic recovery loop, driven
+    /// manually at the ingest layer (the transport/run-loop interleaving
+    /// is exercised by the fabric tests; this pins the protocol logic).
+    /// A holds Dead(B, 5); B restarts at incarnation 0. B's stale Alive(0)
+    /// reaches A → A echoes its stored Dead(B, 5) (F1) → B self-refutes to
+    /// 6 (F4 bump) → B's next Alive(6) dominates and A converges.
+    #[tokio::test]
+    async fn fast_restart_rejoins_via_refutation_echo() {
+        let fab = TransportFabric::new();
+        let (det_a, sd_a, h_a) = spawn_node(&fab, "a", 7150, &[]).await;
+        let (det_b, sd_b, h_b) = spawn_node(&fab, "b", 7151, &[]).await;
+
+        // A believes B is Dead at incarnation 5 (lingering rumour).
+        det_a.apply_and_notify(&MemberUpdate {
+            node_id: NodeId::try_new("b").expect("test fixture"),
+            addr: addr(7151).to_string(),
+            state: MemberState::Dead,
+            incarnation: Incarnation::new(5),
+        });
+
+        // Step 1: B's restart announcement Alive(b, 0) reaches A via
+        // piggyback → A must echo its stored Dead(b, 5) back (F1).
+        let echoed = det_a
+            .ingest_piggyback(&[MemberUpdate {
+                node_id: NodeId::try_new("b").expect("test fixture"),
+                addr: addr(7151).to_string(),
+                state: MemberState::Alive,
+                incarnation: Incarnation::ZERO,
+            }])
+            .await;
+        assert_eq!(echoed.len(), 1, "A must echo exactly one refutation");
+        assert_eq!(echoed[0].state, MemberState::Dead);
+        assert_eq!(echoed[0].incarnation, Incarnation::new(5));
+
+        // Step 2: the echo reaches B → SelfRefute bump past 5 (F4).
+        det_b.ingest_piggyback(&echoed).await;
+        let bumped = *det_b.local_incarnation.lock().await;
+        assert!(
+            bumped > Incarnation::new(5),
+            "B must self-refute above Dead(5), got {bumped:?}"
+        );
+
+        // Step 3: B's next announcement Alive(b, bumped) dominates → A
+        // converges to Alive.
+        det_a
+            .ingest_piggyback(&[MemberUpdate {
+                node_id: NodeId::try_new("b").expect("test fixture"),
+                addr: addr(7151).to_string(),
+                state: MemberState::Alive,
+                incarnation: bumped,
+            }])
+            .await;
+        let b_view = det_a
+            .membership
+            .get(&NodeId::try_new("b").expect("test fixture"))
+            .expect("b in list");
+        assert_eq!(
+            b_view.state,
+            MemberState::Alive,
+            "A must converge to Alive after the refutation echo"
+        );
+        assert!(b_view.incarnation > Incarnation::new(5));
+
+        let _ = sd_a.send(true);
+        let _ = sd_b.send(true);
+        let _ = tokio::time::timeout(Duration::from_millis(200), h_a).await;
+        let _ = tokio::time::timeout(Duration::from_millis(200), h_b).await;
     }
 }

--- a/nodedb-cluster/src/swim/incarnation_store.rs
+++ b/nodedb-cluster/src/swim/incarnation_store.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Persistence backend for the local SWIM incarnation.
+//!
+//! The incarnation is the node's monotonic self-epoch. Persisting it
+//! closes the fast-restart rejoin gap: a node that crashes while the
+//! cluster holds `Dead(A, N)` can restart at `N + 1` and dominate every
+//! lingering rumour with its very first announcement — no probabilistic
+//! refutation round-trip required.
+//!
+//! Backends:
+//! - [`CatalogIncarnationStore`] — production; writes into the redb
+//!   catalog metadata table (same pattern as the cluster epoch).
+//! - [`MemIncarnationStore`] — tests only.
+
+use std::sync::Arc;
+
+use crate::error::Result;
+
+/// Persistence for the local SWIM incarnation.
+pub trait IncarnationStore: Send + Sync {
+    /// Durably record the current incarnation (called on every
+    /// self-refutation bump).
+    fn save(&self, incarnation: u64) -> Result<()>;
+    /// Read the last persisted incarnation; `None` if never written.
+    fn load(&self) -> Result<Option<u64>>;
+}
+
+/// Catalog-backed store (production path).
+pub struct CatalogIncarnationStore {
+    catalog: Arc<crate::catalog::ClusterCatalog>,
+}
+
+impl CatalogIncarnationStore {
+    pub fn new(catalog: Arc<crate::catalog::ClusterCatalog>) -> Self {
+        Self { catalog }
+    }
+}
+
+impl IncarnationStore for CatalogIncarnationStore {
+    fn save(&self, incarnation: u64) -> Result<()> {
+        self.catalog.save_swim_incarnation(incarnation)
+    }
+
+    fn load(&self) -> Result<Option<u64>> {
+        self.catalog.load_swim_incarnation()
+    }
+}
+
+/// In-memory store for deterministic tests.
+#[cfg(test)]
+pub struct MemIncarnationStore {
+    value: std::sync::Mutex<Option<u64>>,
+}
+
+#[cfg(test)]
+impl MemIncarnationStore {
+    pub fn new() -> Self {
+        Self {
+            value: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for MemIncarnationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+impl IncarnationStore for MemIncarnationStore {
+    fn save(&self, incarnation: u64) -> Result<()> {
+        *self.value.lock().unwrap_or_else(|p| p.into_inner()) = Some(incarnation);
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Option<u64>> {
+        Ok(*self.value.lock().unwrap_or_else(|p| p.into_inner()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mem_store_roundtrips() {
+        let store = MemIncarnationStore::new();
+        assert_eq!(store.load().unwrap(), None);
+        store.save(7).unwrap();
+        assert_eq!(store.load().unwrap(), Some(7));
+        store.save(9).unwrap();
+        assert_eq!(store.load().unwrap(), Some(9));
+    }
+}

--- a/nodedb-cluster/src/swim/mod.rs
+++ b/nodedb-cluster/src/swim/mod.rs
@@ -25,6 +25,7 @@ pub mod detector;
 pub mod dissemination;
 pub mod error;
 pub mod incarnation;
+pub mod incarnation_store;
 pub mod member;
 pub mod membership;
 pub mod subscriber;

--- a/nodedb/src/control/cluster/start_raft/loop_build.rs
+++ b/nodedb/src/control/cluster/start_raft/loop_build.rs
@@ -171,6 +171,7 @@ pub(super) fn build_raft_loop(
             Arc::clone(&handle.routing),
             Arc::clone(&handle.transport),
             raft_loop_handle,
+            &handle.catalog,
         ))
     })
     .map_err(|e| crate::Error::Config {


### PR DESCRIPTION
Closes the SWIM fast-restart rejoin stick (epic #165, Medium #9): a node that crashes while peers hold Dead(A, N) restarts at incarnation 0, announces Alive(0) exactly once, and can diverge forever when the probabilistic refutation round-trip fails.

- F4 (primary): persist local incarnation in the catalog (KEY_SWIM_INCARNATION); bootstrap resumes at persisted+1 so the first announcement dominates any lingering Dead rumour; every self-refutation bump persisted fire-and-forget.
- F1: refutations echoed deterministically on Ack + forwarded PingReq piggyback.
- F2: a ping IS liveness evidence — sender Alive claim applied before ack; self-advertise rate-limited to 500ms.
- F3: fresh Alive apply cancels the pending suspicion timer (kills the re-kill race).

6 regression tests incl. deterministic recovery loop (A holds Dead(B,5) → echo → self-refute → converge Alive). Verification: swim 129/129, cluster lib 1023, clippy -D warnings 0, maya-gate L1 clean.

Closes #165 item: Medium — SWIM fast-restart rejoin.