### PR TITLE
fix(cluster): enforce cluster-epoch fence at the decode chokepoint

### DIFF
--- a/nodedb-cluster/src/cluster_epoch.rs
+++ b/nodedb-cluster/src/cluster_epoch.rs
@@ -42,7 +42,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::catalog::ClusterCatalog;
-use crate::error::Result;
+use crate::error::{ClusterError, Result};
+use crate::rpc_codec::discriminants::{RPC_JOIN_REQ, RPC_JOIN_RESP, RPC_PING, RPC_PONG};
 
 /// Process-global cluster epoch high-water mark.
 ///
@@ -73,6 +74,48 @@ pub fn observe_peer_cluster_epoch(peer_epoch: u64) -> u64 {
     prev.max(peer_epoch)
 }
 
+/// RPC types exempt from the cluster-epoch fence.
+///
+/// * Join handshake (`RPC_JOIN_REQ` / `RPC_JOIN_RESP`): a joining or rejoining
+///   node legitimately carries a zero or stale epoch — the join response is the
+///   mechanism by which it learns (observes) the cluster's current epoch.
+/// * Ping/pong (`RPC_PING` / `RPC_PONG`): the pre-join bootstrap probe
+///   (`bootstrap/probe.rs`) pings the elected bootstrapper before joining, and
+///   ping is the side-effect-free liveness channel a fenced peer needs in order
+///   to be discovered and told to rejoin.
+///
+/// Everything else (raft consensus, topology, execute, shuffle, calvin,
+/// surrogate, data/metadata propose, vshard envelopes) is fenced.
+pub(crate) const EPOCH_EXEMPT_RPC_TYPES: &[u8] =
+    &[RPC_JOIN_REQ, RPC_JOIN_RESP, RPC_PING, RPC_PONG];
+
+/// Enforce the cluster-epoch fence on one inbound frame.
+///
+/// Rejects `peer_epoch < local` unless the RPC type is exempt. Called from
+/// the decode path ([`crate::rpc_codec::header::parse_frame`]) for every
+/// inbound rpc_codec frame, in both directions (server-side requests and
+/// client-side responses).
+///
+/// `peer_epoch == 0` is *not* special-cased: against a local epoch of 0
+/// (genesis / pre-init startup) it passes; against a local epoch > 0 it is
+/// rejected exactly like any other stale stamp. The epoch check runs on
+/// MAC-authenticated header bytes (the envelope MAC is verified before
+/// decode in `transport/server.rs` and `transport/client/send.rs`), so a
+/// spoofed stamp cannot trigger spurious rejections.
+pub fn validate_peer_cluster_epoch(rpc_type: u8, peer_epoch: u64) -> Result<()> {
+    if EPOCH_EXEMPT_RPC_TYPES.contains(&rpc_type) {
+        return Ok(());
+    }
+    let local_epoch = LOCAL_CLUSTER_EPOCH.load(Ordering::Acquire);
+    if peer_epoch < local_epoch {
+        return Err(ClusterError::StalePeerEpoch {
+            peer_epoch,
+            local_epoch,
+        });
+    }
+    Ok(())
+}
+
 /// Increment the local epoch by 1 and persist the new value to the
 /// cluster catalog. Called by the metadata-group leader on a leadership
 /// transition.
@@ -96,17 +139,22 @@ pub fn init_local_cluster_epoch_from_catalog(catalog: &Arc<ClusterCatalog>) -> R
     Ok(prev.max(persisted))
 }
 
+/// Serialises every test that mutates the shared `LOCAL_CLUSTER_EPOCH`
+/// global — including the header decode-path tests in `rpc_codec::header`,
+/// which set the epoch from outside this module. `pub(crate)` so both test
+/// suites take the SAME lock (two locks would not exclude each other).
+#[cfg(test)]
+pub(crate) static EPOCH_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// All tests in this module mutate the same global atomic, so they
-    /// must be serialised. The lock is taken at the top of each test.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn reset() -> std::sync::MutexGuard<'static, ()> {
-        let g = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // The shared crate-wide epoch test lock also serialises against
+        // the decode-path tests in `rpc_codec::header`, which set the
+        // global from outside this module.
+        let g = EPOCH_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         LOCAL_CLUSTER_EPOCH.store(0, Ordering::Release);
         g
     }
@@ -170,5 +218,65 @@ mod tests {
         let v = init_local_cluster_epoch_from_catalog(&catalog).unwrap();
         assert_eq!(v, 0);
         assert_eq!(current_local_cluster_epoch(), 0);
+    }
+
+    #[test]
+    fn validate_rejects_stale_non_exempt() {
+        let _g = reset();
+        use crate::rpc_codec::discriminants::RPC_APPEND_ENTRIES_REQ;
+        set_local_cluster_epoch(5);
+        assert!(matches!(
+            validate_peer_cluster_epoch(RPC_APPEND_ENTRIES_REQ, 3),
+            Err(ClusterError::StalePeerEpoch {
+                peer_epoch: 3,
+                local_epoch: 5,
+            })
+        ));
+        // Rejection must not touch the local mark.
+        assert_eq!(current_local_cluster_epoch(), 5);
+    }
+
+    #[test]
+    fn validate_accepts_equal_and_newer() {
+        let _g = reset();
+        use crate::rpc_codec::discriminants::RPC_EXECUTE_REQ;
+        set_local_cluster_epoch(5);
+        assert!(validate_peer_cluster_epoch(RPC_EXECUTE_REQ, 5).is_ok());
+        assert!(validate_peer_cluster_epoch(RPC_EXECUTE_REQ, 6).is_ok());
+        assert_eq!(current_local_cluster_epoch(), 5);
+    }
+
+    #[test]
+    fn validate_genesis_zero_zero_ok() {
+        let _g = reset();
+        use crate::rpc_codec::discriminants::RPC_APPEND_ENTRIES_REQ;
+        // Pre-init startup: local 0 must not reject a peer stamp of 0.
+        assert!(validate_peer_cluster_epoch(RPC_APPEND_ENTRIES_REQ, 0).is_ok());
+    }
+
+    #[test]
+    fn validate_exempts_join_and_ping() {
+        let _g = reset();
+        set_local_cluster_epoch(9);
+        assert!(validate_peer_cluster_epoch(RPC_JOIN_REQ, 0).is_ok());
+        assert!(validate_peer_cluster_epoch(RPC_JOIN_RESP, 0).is_ok());
+        assert!(validate_peer_cluster_epoch(RPC_PING, 0).is_ok());
+        assert!(validate_peer_cluster_epoch(RPC_PONG, 0).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_stale_for_other_mgmt_types() {
+        let _g = reset();
+        use crate::rpc_codec::discriminants::{RPC_REQUEST_VOTE_RESP, RPC_TOPOLOGY_ACK};
+        set_local_cluster_epoch(5);
+        assert!(matches!(
+            validate_peer_cluster_epoch(RPC_TOPOLOGY_ACK, 4),
+            Err(ClusterError::StalePeerEpoch { .. })
+        ));
+        // Elections are fenced too.
+        assert!(matches!(
+            validate_peer_cluster_epoch(RPC_REQUEST_VOTE_RESP, 4),
+            Err(ClusterError::StalePeerEpoch { .. })
+        ));
     }
 }

--- a/nodedb-cluster/src/error.rs
+++ b/nodedb-cluster/src/error.rs
@@ -115,6 +115,19 @@ pub enum ClusterError {
         supported_max: u8,
     },
 
+    /// A peer sent a frame stamped with a cluster epoch strictly older than
+    /// the local high-water mark. The peer missed a topology transition and is
+    /// fenced out: its frames are dropped at decode until it rejoins the
+    /// cluster (join handshake and ping/pong frames are exempt).
+    #[error(
+        "stale cluster epoch: peer stamp {peer_epoch} < local {local_epoch} \
+         (peer missed a topology transition and must rejoin)"
+    )]
+    StalePeerEpoch {
+        peer_epoch: u64,
+        local_epoch: u64,
+    },
+
     #[error("circuit open for node {node_id}: peer has {failures} consecutive failures")]
     CircuitOpen { node_id: u64, failures: u32 },
 

--- a/nodedb-cluster/src/lib.rs
+++ b/nodedb-cluster/src/lib.rs
@@ -87,7 +87,7 @@ pub use catalog::ClusterCatalog;
 pub use circuit_breaker::BreakerSnapshot;
 pub use cluster_epoch::{
     bump_local_cluster_epoch, current_local_cluster_epoch, init_local_cluster_epoch_from_catalog,
-    observe_peer_cluster_epoch, set_local_cluster_epoch,
+    observe_peer_cluster_epoch, set_local_cluster_epoch, validate_peer_cluster_epoch,
 };
 pub use cluster_info::{
     ClusterInfoSnapshot, ClusterObserver, GroupSnapshot, GroupStatusProvider, PeerSnapshot,

--- a/nodedb-cluster/src/rpc_codec/header.rs
+++ b/nodedb-cluster/src/rpc_codec/header.rs
@@ -14,7 +14,9 @@
 //! Every frame is emitted with `RPC_FRAME_VERSION` in the version byte.
 //! Frames with any other version byte are rejected immediately.
 
-use crate::cluster_epoch::{current_local_cluster_epoch, observe_peer_cluster_epoch};
+use crate::cluster_epoch::{
+    current_local_cluster_epoch, observe_peer_cluster_epoch, validate_peer_cluster_epoch,
+};
 use crate::error::{ClusterError, Result};
 
 /// Header size in bytes: version(1) + rpc_type(1) + payload_len(4) + crc32c(4) + cluster_epoch(8).
@@ -82,6 +84,11 @@ pub fn parse_frame(data: &[u8]) -> Result<(u8, &[u8])> {
     let peer_epoch = u64::from_le_bytes([
         data[10], data[11], data[12], data[13], data[14], data[15], data[16], data[17],
     ]);
+
+    // Enforce the cluster-epoch fence. Join handshake + ping/pong frames are
+    // exempt (see cluster_epoch::EPOCH_EXEMPT_RPC_TYPES); everything else from
+    // a peer on a strictly older epoch is dropped here, before any dispatch.
+    validate_peer_cluster_epoch(rpc_type, peer_epoch)?;
 
     if payload_len > MAX_RPC_PAYLOAD_SIZE {
         return Err(ClusterError::Codec {
@@ -152,12 +159,12 @@ mod tests {
     }
 
     /// Build a correct current-version frame (18-byte header).
-    fn make_frame(payload: &[u8], epoch: u64) -> Vec<u8> {
+    fn make_frame(rpc_type: u8, payload: &[u8], epoch: u64) -> Vec<u8> {
         let mut out = Vec::with_capacity(HEADER_SIZE + payload.len());
         let payload_len = payload.len() as u32;
         let crc = crc32c::crc32c(payload);
         out.push(RPC_FRAME_VERSION);
-        out.push(0xAB);
+        out.push(rpc_type);
         out.extend_from_slice(&payload_len.to_le_bytes());
         out.extend_from_slice(&crc.to_le_bytes());
         out.extend_from_slice(&epoch.to_le_bytes());
@@ -167,8 +174,14 @@ mod tests {
 
     #[test]
     fn parse_frame_accepts_current_version() {
+        use crate::cluster_epoch::set_local_cluster_epoch;
+        let _g = crate::cluster_epoch::EPOCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // Local epoch 0: any stamp (including 0) passes the fence.
+        set_local_cluster_epoch(0);
         let payload = b"world";
-        let frame = make_frame(payload, 0);
+        let frame = make_frame(0xAB, payload, 0);
         let (_t, body) = parse_frame(&frame).expect("current version must be accepted");
         assert_eq!(body, payload);
     }
@@ -222,6 +235,9 @@ mod tests {
     #[test]
     fn v3_frame_round_trips_with_epoch() {
         use crate::cluster_epoch::set_local_cluster_epoch;
+        let _g = crate::cluster_epoch::EPOCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         set_local_cluster_epoch(0);
         set_local_cluster_epoch(7);
         let payload = b"epoch-bound";
@@ -237,9 +253,62 @@ mod tests {
 
     #[test]
     fn frame_size_current_version() {
-        let frame = make_frame(b"abcde", 1);
+        let frame = make_frame(0xAB, b"abcde", 1);
         let mut hdr = [0u8; HEADER_SIZE];
         hdr.copy_from_slice(&frame[..HEADER_SIZE]);
         assert_eq!(frame_size(&hdr).unwrap(), HEADER_SIZE + 5);
+    }
+
+    #[test]
+    fn parse_frame_rejects_stale_epoch() {
+        use crate::cluster_epoch::set_local_cluster_epoch;
+        // Serialise against the cluster_epoch tests on the shared global.
+        let _g = crate::cluster_epoch::EPOCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_local_cluster_epoch(7);
+        let frame = make_frame(0xAB, b"stale", 5);
+        let err = parse_frame(&frame).expect_err("stale epoch must be rejected");
+        assert!(matches!(
+            err,
+            ClusterError::StalePeerEpoch {
+                peer_epoch: 5,
+                local_epoch: 7,
+            }
+        ));
+        // Rejection happens before observe, so the local mark is untouched.
+        assert_eq!(crate::cluster_epoch::current_local_cluster_epoch(), 7);
+        set_local_cluster_epoch(0);
+    }
+
+    #[test]
+    fn parse_frame_accepts_newer_epoch_and_observes() {
+        use crate::cluster_epoch::set_local_cluster_epoch;
+        let _g = crate::cluster_epoch::EPOCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_local_cluster_epoch(3);
+        let frame = make_frame(0xAB, b"newer", 9);
+        let (rpc_type, body) = parse_frame(&frame).expect("newer epoch must be accepted");
+        assert_eq!(rpc_type, 0xAB);
+        assert_eq!(body, b"newer");
+        assert_eq!(crate::cluster_epoch::current_local_cluster_epoch(), 9);
+        set_local_cluster_epoch(0);
+    }
+
+    #[test]
+    fn parse_frame_join_and_ping_exempt() {
+        use crate::cluster_epoch::set_local_cluster_epoch;
+        use crate::rpc_codec::discriminants::{RPC_JOIN_REQ, RPC_PING};
+        let _g = crate::cluster_epoch::EPOCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_local_cluster_epoch(9);
+        let join = make_frame(RPC_JOIN_REQ, b"join", 0);
+        parse_frame(&join).expect("join req must be exempt from the epoch fence");
+        let ping = make_frame(RPC_PING, b"ping", 0);
+        parse_frame(&ping).expect("ping must be exempt from the epoch fence");
+        assert_eq!(crate::cluster_epoch::current_local_cluster_epoch(), 9);
+        set_local_cluster_epoch(0);
     }
 }

--- a/nodedb-cluster/src/transport/server.rs
+++ b/nodedb-cluster/src/transport/server.rs
@@ -273,7 +273,24 @@ async fn handle_stream<H: RaftRpcHandler, S: PeerIdentityStore + ?Sized>(
 
         // 3. Decode before the identity decision so an unknown, CA-verified
         // peer can be restricted to exactly one enrollment operation.
-        let request = rpc_codec::decode(inner_frame)?;
+        let request = match rpc_codec::decode(inner_frame) {
+            Ok(r) => r,
+            Err(ClusterError::StalePeerEpoch { peer_epoch, local_epoch }) => {
+                // A fenced peer's frame is dropped, NOT a transport failure:
+                // ending this stream task without an encoded response lets
+                // the sender's raft retry path converge (its next inbound
+                // frame re-observes our epoch via fetch_max). The connection
+                // stays open for join/ping exempt traffic.
+                warn!(
+                    node_id = fields.from_node_id,
+                    peer_epoch,
+                    local_epoch,
+                    "dropped frame from peer on a stale cluster epoch (fenced until rejoin)"
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
         validate_join_sender(&request, fields.from_node_id)?;
 
         // 3b. Bind the MAC-authenticated node id to the mTLS leaf identity.


### PR DESCRIPTION
Makes the cluster-epoch fence real (epic #165 High #6). cluster_epoch was stamp-only: docs claimed stale-epoch peers are rejected but no rejection existed.

- ClusterError::StalePeerEpoch { peer_epoch, local_epoch } for operator-visible diagnostics.
- validate_peer_cluster_epoch(rpc_type, peer_epoch): rejects peer_epoch < local unless exempt (EPOCH_EXEMPT_RPC_TYPES = JOIN_REQ/JOIN_RESP/PING/PONG — join is how a fenced peer re-adopts the epoch; ping/pong is the pre-join liveness channel).
- Single enforcement point in parse_frame (the only decode path, both directions) before payload/CRC work; no dispatch/transport changes.
- EPOCH_TEST_LOCK serialises every test mutating the shared epoch global (fixed a latent parallel race in two pre-existing header tests).

9 new tests; cluster_epoch 11/11 + header 9/9 stable across 5 runs, full lib 1016/1016 serial, clippy 0, maya-gate clean 4/4.

Part of #165.