### PR TITLE
fix(lease): descriptor-lease crash-wedge GC

### DIFF
--- a/nodedb-cluster/src/raft_loop/builder.rs
+++ b/nodedb-cluster/src/raft_loop/builder.rs
@@ -8,13 +8,14 @@
 //! than in [`super::loop_core`] so that the struct definition, constructor,
 //! and runtime methods stay under the file-size limit.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use crate::applied_watcher::GroupAppliedWatchers;
 use crate::catalog::ClusterCatalog;
 use crate::forward::PlanExecutor;
 use crate::metadata_group::applier::MetadataApplier;
+use crate::metadata_group::cache::MetadataCache;
 
 use super::hooks::{
     AssignRemoteSurrogate, CalvinSubmit, CalvinSubmitInbox, ReleaseReservation, ReserveRead,
@@ -65,6 +66,7 @@ impl<A: CommitApplier, P: PlanExecutor> RaftLoop<A, P> {
             // Construction-time builder, before `run()` and any join kick — a
             // fresh `Notify` has no pending permit, so this loses nothing.
             reconcile_notify: tokio::sync::Notify::new(),
+            metadata_cache: self.metadata_cache,
         }
     }
 
@@ -262,6 +264,13 @@ impl<A: CommitApplier, P: PlanExecutor> RaftLoop<A, P> {
     /// [`NoopMetadataApplier`] is kept only for tests that don't care.
     pub fn with_metadata_applier(mut self, applier: Arc<dyn MetadataApplier>) -> Self {
         self.metadata_applier = applier;
+        self
+    }
+
+    /// Wire the metadata cache used by the periodic lease-GC sweep. The
+    /// host passes the same `Arc` the production metadata applier holds.
+    pub fn with_metadata_cache(mut self, cache: Arc<RwLock<MetadataCache>>) -> Self {
+        self.metadata_cache = Some(cache);
         self
     }
 

--- a/nodedb-cluster/src/raft_loop/lease_gc.rs
+++ b/nodedb-cluster/src/raft_loop/lease_gc.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Periodic lease GC on the metadata-group leader.
+//!
+//! Mirrors `placement_reconcile`: leader-gated, throttled by tick count in
+//! `tick::core::do_tick`. Sweeps `MetadataCache.leases` and proposes
+//! `DescriptorLeaseRelease` for every holder no longer in the cluster
+//! topology. This is the safety net behind the Leave apply hook.
+
+use std::collections::HashMap;
+use tracing::{debug, warn};
+
+use crate::forward::PlanExecutor;
+use crate::metadata_group::cache::MetadataCache;
+use crate::metadata_group::descriptors::DescriptorId;
+use crate::topology::ClusterTopology;
+
+use super::loop_core::{CommitApplier, RaftLoop};
+
+/// Pure collection: `(node_id, descriptor_ids)` for every lease holder that
+/// is not in `topology`. Sorted by `node_id` for deterministic proposal
+/// order. Extracted so the sweep's decision logic is unit-testable without
+/// a full `RaftLoop`.
+pub(super) fn collect_non_member_lease_releases(
+    topology: &ClusterTopology,
+    cache: &MetadataCache,
+) -> Vec<(u64, Vec<DescriptorId>)> {
+    let mut by_holder: HashMap<u64, Vec<DescriptorId>> = HashMap::new();
+    for (id, holder) in cache.leases.keys() {
+        if !topology.contains(*holder) {
+            by_holder.entry(*holder).or_default().push(id.clone());
+        }
+    }
+    let mut out: Vec<(u64, Vec<DescriptorId>)> = by_holder.into_iter().collect();
+    out.sort_by_key(|(node_id, _)| *node_id);
+    out
+}
+
+impl<A: CommitApplier, P: PlanExecutor> RaftLoop<A, P> {
+    /// On the metadata-group leader, propose `DescriptorLeaseRelease` for
+    /// every lease whose holder is no longer in `ClusterTopology`.
+    pub(super) fn gc_stale_node_leases(&self) {
+        let Some(cache) = &self.metadata_cache else {
+            return; // not wired (some tests) — nothing to sweep
+        };
+        let to_release: Vec<(u64, Vec<DescriptorId>)> = {
+            let mr = self.multi_raft.lock().unwrap_or_else(|p| p.into_inner());
+            if !mr.group_role_is_leader(crate::metadata_group::METADATA_GROUP_ID) {
+                return;
+            }
+            let topo = self.topology.read().unwrap_or_else(|p| p.into_inner());
+            let cache = cache.read().unwrap_or_else(|p| p.into_inner());
+            collect_non_member_lease_releases(&topo, &cache)
+        };
+
+        for (node_id, descriptor_ids) in to_release {
+            let entry =
+                crate::metadata_group::entry::MetadataEntry::DescriptorLeaseRelease {
+                    node_id,
+                    descriptor_ids,
+                };
+            let bytes = match crate::metadata_group::codec::encode_entry(&entry) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(node_id, error = %e, "lease GC: encode DescriptorLeaseRelease failed");
+                    continue;
+                }
+            };
+            match self.propose_to_metadata_group(bytes) {
+                Ok(idx) => debug!(
+                    node_id,
+                    log_index = idx,
+                    "lease GC: released leases of non-member node"
+                ),
+                Err(e) => debug!(node_id, error = %e, "lease GC: proposal deferred"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metadata_group::cache::MetadataCache;
+    use crate::metadata_group::descriptors::{DescriptorId, DescriptorKind};
+    use crate::topology::{ClusterTopology, NodeInfo, NodeState};
+
+    use super::collect_non_member_lease_releases;
+
+    fn topo_with(ids: &[u64]) -> ClusterTopology {
+        let mut t = ClusterTopology::new();
+        for (i, id) in ids.iter().enumerate() {
+            let addr: std::net::SocketAddr =
+                format!("127.0.0.1:{}", 9000 + i).parse().unwrap();
+            t.add_node(NodeInfo::new(*id, addr, NodeState::Active));
+        }
+        t
+    }
+
+    fn lease(id: &DescriptorId, holder: u64) -> crate::metadata_group::descriptors::DescriptorLease {
+        crate::metadata_group::descriptors::DescriptorLease {
+            descriptor_id: id.clone(),
+            version: 1,
+            node_id: holder,
+            expires_at: nodedb_types::Hlc::new(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as u64
+                    + 60_000_000_000,
+                0,
+            ),
+        }
+    }
+
+    #[test]
+    fn gc_stale_node_leases_proposes_for_non_members_only() {
+        let topo = topo_with(&[1]);
+        let mut cache = MetadataCache::new();
+        let orders = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+        let metrics = DescriptorId::new(0, 1, DescriptorKind::Collection, "metrics".to_string());
+
+        // Member holder 1: must NOT be collected.
+        cache
+            .leases
+            .insert((orders.clone(), 1), lease(&orders, 1));
+        // Non-member holder 2: must be collected.
+        cache
+            .leases
+            .insert((orders.clone(), 2), lease(&orders, 2));
+        // Non-member holder 3 with two descriptors.
+        cache
+            .leases
+            .insert((orders.clone(), 3), lease(&orders, 3));
+        cache
+            .leases
+            .insert((metrics.clone(), 3), lease(&metrics, 3));
+
+        let collected = collect_non_member_lease_releases(&topo, &cache);
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected[0].0, 2);
+        assert_eq!(collected[0].1, vec![orders.clone()]);
+        assert_eq!(collected[1].0, 3);
+        assert_eq!(collected[1].1.len(), 2);
+        assert!(collected[1].1.contains(&orders));
+        assert!(collected[1].1.contains(&metrics));
+    }
+
+    #[test]
+    fn gc_is_noop_when_all_holders_are_members() {
+        let topo = topo_with(&[1, 2, 3]);
+        let mut cache = MetadataCache::new();
+        let orders = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+        for holder in [1, 2, 3] {
+            cache
+                .leases
+                .insert((orders.clone(), holder), lease(&orders, holder));
+        }
+
+        assert!(collect_non_member_lease_releases(&topo, &cache).is_empty());
+    }
+
+    #[test]
+    fn gc_collects_empty_cache() {
+        let topo = topo_with(&[1]);
+        let cache = MetadataCache::new();
+        assert!(collect_non_member_lease_releases(&topo, &cache).is_empty());
+    }
+}

--- a/nodedb-cluster/src/raft_loop/lease_gc.rs
+++ b/nodedb-cluster/src/raft_loop/lease_gc.rs
@@ -72,7 +72,7 @@ impl<A: CommitApplier, P: PlanExecutor> RaftLoop<A, P> {
                     log_index = idx,
                     "lease GC: released leases of non-member node"
                 ),
-                Err(e) => debug!(node_id, error = %e, "lease GC: proposal deferred"),
+                Err(e) => warn!(node_id, error = %e, "lease GC: proposal failed; will be retried on next sweep"),
             }
         }
     }

--- a/nodedb-cluster/src/raft_loop/loop_core.rs
+++ b/nodedb-cluster/src/raft_loop/loop_core.rs
@@ -20,6 +20,7 @@ use crate::error::Result;
 use crate::forward::{NoopPlanExecutor, PlanExecutor};
 use crate::loop_metrics::LoopMetrics;
 use crate::metadata_group::applier::{MetadataApplier, NoopMetadataApplier};
+use crate::metadata_group::cache::MetadataCache;
 use crate::multi_raft::MultiRaft;
 use crate::topology::ClusterTopology;
 use crate::transport::NexarTransport;
@@ -280,6 +281,12 @@ pub struct RaftLoop<A: CommitApplier, P: PlanExecutor = NoopPlanExecutor> {
     /// tick. Fired from [`super::join`] on the success path; consumed by
     /// an extra `select!` arm in [`Self::run`].
     pub(super) reconcile_notify: tokio::sync::Notify,
+
+    /// Optional handle to the metadata group's `MetadataCache` (the same
+    /// `Arc` the `CacheApplier` writes into). When set, the leader's
+    /// periodic lease-GC sweep can read committed lease state directly.
+    /// `None` in cluster-only tests that don't wire it.
+    pub(super) metadata_cache: Option<Arc<RwLock<MetadataCache>>>,
 }
 
 impl<A: CommitApplier> RaftLoop<A> {
@@ -327,6 +334,7 @@ impl<A: CommitApplier> RaftLoop<A> {
             replication_factor: 1,
             tick_count: std::sync::atomic::AtomicU64::new(0),
             reconcile_notify: tokio::sync::Notify::new(),
+            metadata_cache: None,
         }
     }
 }

--- a/nodedb-cluster/src/raft_loop/mod.rs
+++ b/nodedb-cluster/src/raft_loop/mod.rs
@@ -22,6 +22,7 @@ pub mod in_flight_snapshots;
 pub mod join;
 mod leadership_transfer;
 pub mod loop_core;
+mod lease_gc;
 mod membership_convergence;
 mod placement_reconcile;
 pub mod proposals;

--- a/nodedb-cluster/src/raft_loop/tick/core.rs
+++ b/nodedb-cluster/src/raft_loop/tick/core.rs
@@ -58,6 +58,12 @@ const PLACEMENT_RECONCILE_TICK_INTERVAL: u64 = 100;
 /// sweeps proportionally more often (harmless).
 const ORPHAN_PARTIAL_GC_TICK_INTERVAL: u64 = 6000;
 
+/// Lease GC for nodes that left the topology: every 200 ticks (~2s at the
+/// 10ms default tick). Cheaper than placement reconcile (single map scan),
+/// and the Leave apply hook usually beats it to the release — this sweep
+/// only catches cases the hook missed.
+const LEASE_GC_TICK_INTERVAL: u64 = 200;
+
 impl<A: CommitApplier, P: PlanExecutor> RaftLoop<A, P> {
     /// Execute a single tick: drive Raft, dispatch outbound messages,
     /// apply commits, promote caught-up learners.
@@ -169,6 +175,9 @@ impl<A: CommitApplier, P: PlanExecutor> RaftLoop<A, P> {
                     tracing::warn!(error = %e, "periodic gc: failed to sweep partial snapshot directory");
                 }
             }
+        }
+        if tick.is_multiple_of(LEASE_GC_TICK_INTERVAL) {
+            self.gc_stale_node_leases();
         }
     }
 

--- a/nodedb/src/control/cluster/metadata_applier/dispatch.rs
+++ b/nodedb/src/control/cluster/metadata_applier/dispatch.rs
@@ -5,7 +5,7 @@
 
 use tracing::{debug, error, warn};
 
-use nodedb_cluster::{MetadataApplier, MetadataEntry, RoutingChange, decode_entry};
+use nodedb_cluster::{MetadataApplier, MetadataEntry, RoutingChange, TopologyChange, decode_entry};
 
 use super::types::{CatalogChangeEvent, MetadataCommitApplier};
 
@@ -252,6 +252,31 @@ impl MetadataCommitApplier {
                 placement,
             }) => {
                 return self.apply_set_placement(*group_id, placement, raft_index);
+            }
+            MetadataEntry::TopologyChange(TopologyChange::Leave { node_id }) => {
+                // Lease GC: a node that left the topology can never release
+                // its own leases. Spawn (do NOT propose-and-wait inline —
+                // apply runs on the raft loop task; blocking here would
+                // deadlock the applied-index watcher).
+                if let Some(shared) = self.shared.get().and_then(std::sync::Weak::upgrade) {
+                    let shared = std::sync::Arc::clone(&shared);
+                    let left_node_id = *node_id;
+                    tokio::spawn(async move {
+                        if !shared.is_singleton_worker() {
+                            return;
+                        }
+                        if let Err(e) =
+                            crate::control::lease::gc::gc_leases_for_node(&shared, left_node_id)
+                        {
+                            tracing::warn!(
+                                node_id = left_node_id,
+                                error = %e,
+                                "lease GC after Leave failed; periodic sweep will retry"
+                            );
+                        }
+                    });
+                }
+                return Ok(());
             }
             _ => {}
         }

--- a/nodedb/src/control/cluster/start_raft/loop_build.rs
+++ b/nodedb/src/control/cluster/start_raft/loop_build.rs
@@ -93,6 +93,7 @@ pub(super) fn build_raft_loop(
         )
         .with_plan_executor(plan_executor)
         .with_metadata_applier(metadata_applier)
+        .with_metadata_cache(shared.metadata_cache.clone())
         .with_vshard_handler(vshard_handler)
         .with_tick_interval(tick_interval)
         .with_group_watchers(handle.group_watchers.clone())

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -209,7 +209,16 @@ fn wait_for_lease_drain(
 /// `version <= up_to_version`. `0` means the drain target has cleared. The
 /// exact nonzero diagnostic count is not significant, so saturate rather than
 /// risking arithmetic overflow.
+///
+/// Leases held by nodes that are no longer cluster members are ignored, as are
+/// leases past their `expires_at`: a crashed node can never release its leases
+/// (no SIGTERM path runs), so without this filter every DDL on those
+/// descriptors would wedge on the drain wait forever. The membership filter is
+/// fail-safe — a missing topology treats every holder as a member — and the
+/// expiry filter matches the grant path's own semantics
+/// (`lease::propose` treats an expired lease as absent).
 fn count_matching_leases(shared: &SharedState, id: &DescriptorId, up_to_version: u64) -> usize {
+    let now = shared.hlc_clock.peek();
     let cache = shared
         .metadata_cache
         .read()
@@ -217,7 +226,12 @@ fn count_matching_leases(shared: &SharedState, id: &DescriptorId, up_to_version:
     let metadata_holds = cache
         .leases
         .iter()
-        .filter(|((lid, _), l)| lid == id && l.version <= up_to_version)
+        .filter(|((lid, holder), l)| {
+            lid == id
+                && l.version <= up_to_version
+                && l.expires_at > now
+                && lease_holder_is_member(shared, *holder)
+        })
         .count();
     drop(cache);
 
@@ -225,6 +239,19 @@ fn count_matching_leases(shared: &SharedState, id: &DescriptorId, up_to_version:
         metadata_holds
     } else {
         metadata_holds.saturating_add(1)
+    }
+}
+
+/// Whether `node_id` is a current cluster member. Missing topology
+/// (single-node / belum di-wire) treats every holder as member —
+/// fail-safe: filter ini hanya PERNAH membuang hold yang ia pasti.
+fn lease_holder_is_member(shared: &SharedState, node_id: u64) -> bool {
+    match &shared.cluster_topology {
+        Some(topo) => topo
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .contains(node_id),
+        None => true,
     }
 }
 
@@ -544,6 +571,115 @@ mod tests {
         state.lease_refcount.increment(&descriptor, 2);
         assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
         state.lease_refcount.decrement(&descriptor, 2);
+    }
+
+    /// Build a topology containing exactly `ids` as active members.
+    fn topo_with(ids: &[u64]) -> nodedb_cluster::ClusterTopology {
+        let mut t = nodedb_cluster::ClusterTopology::new();
+        for (i, id) in ids.iter().enumerate() {
+            let addr: std::net::SocketAddr =
+                format!("127.0.0.1:{}", 9000 + i).parse().unwrap();
+            t.add_node(nodedb_cluster::NodeInfo::new(
+                *id,
+                addr,
+                nodedb_cluster::NodeState::Active,
+            ));
+        }
+        t
+    }
+
+    /// Insert a lease directly into the metadata cache (as if committed via a
+    /// `DescriptorLeaseGrant` entry).
+    fn insert_lease(
+        state: &SharedState,
+        id: &DescriptorId,
+        holder: u64,
+        version: u64,
+        expires_at: nodedb_types::Hlc,
+    ) {
+        state
+            .metadata_cache
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .leases
+            .insert(
+                (id.clone(), holder),
+                nodedb_cluster::DescriptorLease {
+                    descriptor_id: id.clone(),
+                    version,
+                    node_id: holder,
+                    expires_at,
+                },
+            );
+    }
+
+    fn unexpired(state: &SharedState) -> nodedb_types::Hlc {
+        let now = state.hlc_clock.peek();
+        nodedb_types::Hlc::new(now.wall_ns.saturating_add(60_000_000_000), 0)
+    }
+
+    fn expired(state: &SharedState) -> nodedb_types::Hlc {
+        let now = state.hlc_clock.peek();
+        nodedb_types::Hlc::new(now.wall_ns.saturating_sub(1_000), 0)
+    }
+
+    #[tokio::test]
+    async fn non_member_lease_does_not_block_drain_count() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("drain-count.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Holder 99 is not in the topology (crashed node): its lease must not
+        // block the drain count.
+        insert_lease(&state, &descriptor, 99, 1, unexpired(&state));
+        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+    }
+
+    #[tokio::test]
+    async fn expired_lease_does_not_block_drain_count() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("drain-count.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Holder 1 is a member but its lease is already past expiry.
+        insert_lease(&state, &descriptor, 1, 1, expired(&state));
+        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+    }
+
+    #[tokio::test]
+    async fn member_unexpired_lease_still_blocks_drain_count() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("drain-count.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // A live member's unexpired lease still blocks the drain — the
+        // membership/expiry filters must never mask real holds.
+        insert_lease(&state, &descriptor, 1, 1, unexpired(&state));
+        assert_eq!(count_matching_leases(&state, &descriptor, 1), 1);
     }
 
     fn function(database_id: DatabaseId) -> StoredFunction {

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -243,8 +243,8 @@ fn count_matching_leases(shared: &SharedState, id: &DescriptorId, up_to_version:
 }
 
 /// Whether `node_id` is a current cluster member. Missing topology
-/// (single-node / belum di-wire) treats every holder as member —
-/// fail-safe: filter ini hanya PERNAH membuang hold yang ia pasti.
+/// (single-node / not yet wired) treats every holder as member —
+/// fail-safe: this filter only ever drops holds it is certain about.
 fn lease_holder_is_member(shared: &SharedState, node_id: u64) -> bool {
     match &shared.cluster_topology {
         Some(topo) => topo

--- a/nodedb/src/control/lease/gc.rs
+++ b/nodedb/src/control/lease/gc.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Descriptor lease garbage collection for nodes that left the cluster.
+//!
+//! A crashed node's leases are never TTL-pruned from `MetadataCache.leases`
+//! (only a `DescriptorLeaseRelease` entry removes them), so every DDL drain
+//! on those descriptors times out forever. Two triggers run this module:
+//! the `TopologyChange::Leave` apply hook (immediate) and the metadata
+//! leader's periodic sweep (safety net).
+
+use nodedb_cluster::DescriptorId;
+
+use crate::control::lease::release::LeaseReleaseHandle;
+use crate::control::state::SharedState;
+
+/// Collect `(node_id, descriptor_ids)` for every lease holder that is no
+/// longer a cluster member. Missing topology → empty (never GC on guesswork).
+///
+/// Host-side sibling of the cluster-side sweep's pure collector
+/// (`nodedb-cluster::raft_loop::lease_gc::collect_non_member_lease_releases`);
+/// kept here for the GC API surface and exercised by unit tests — the
+/// production sweep path lives in the cluster crate, which cannot depend on
+/// this one.
+#[allow(dead_code)]
+pub(crate) fn collect_non_member_leases(
+    shared: &SharedState,
+) -> Vec<(u64, Vec<DescriptorId>)> {
+    let Some(topo) = &shared.cluster_topology else {
+        return Vec::new();
+    };
+    let cache = shared
+        .metadata_cache
+        .read()
+        .unwrap_or_else(|p| p.into_inner());
+    let topo = topo.read().unwrap_or_else(|p| p.into_inner());
+
+    let mut by_holder: std::collections::HashMap<u64, Vec<DescriptorId>> =
+        std::collections::HashMap::new();
+    for (id, holder) in cache.leases.keys() {
+        if !topo.contains(*holder) {
+            by_holder.entry(*holder).or_default().push(id.clone());
+        }
+    }
+    let mut out: Vec<(u64, Vec<DescriptorId>)> = by_holder.into_iter().collect();
+    out.sort_by_key(|(node_id, _)| *node_id);
+    out
+}
+
+/// Propose `DescriptorLeaseRelease` for every lease held by `node_id`.
+/// No-op if the cache has no entries for that node (idempotent vs. the
+/// periodic sweep). Blocks on the local applied watermark like the
+/// normal release path; callers on hot paths must spawn this.
+pub(crate) fn gc_leases_for_node(
+    shared: &SharedState,
+    node_id: u64,
+) -> Result<(), crate::Error> {
+    let ids: Vec<DescriptorId> = {
+        let cache = shared
+            .metadata_cache
+            .read()
+            .unwrap_or_else(|p| p.into_inner());
+        cache
+            .leases
+            .keys()
+            .filter(|(_, holder)| *holder == node_id)
+            .map(|(id, _)| id.clone())
+            .collect()
+    };
+    if ids.is_empty() {
+        return Ok(());
+    }
+    LeaseReleaseHandle::from_shared(shared).release_for_node(node_id, ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nodedb_cluster::{
+        AppliedIndexWatcher, DescriptorId, DescriptorKind, MetadataEntry, decode_entry,
+    };
+
+    use super::*;
+    use crate::bridge::dispatch::Dispatcher;
+    use crate::control::state::SharedState;
+    use crate::wal::WalManager;
+
+    fn test_state() -> (Arc<SharedState>, tempfile::TempDir) {
+        let directory = tempfile::tempdir().expect("create lease gc test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("lease-gc.wal"))
+                .expect("open lease gc test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let state = SharedState::new(dispatcher, wal).expect("construct lease gc state");
+        (state, directory)
+    }
+
+    fn id(name: &str) -> DescriptorId {
+        DescriptorId::new(0, 1, DescriptorKind::Collection, name.to_string())
+    }
+
+    fn topo_with(ids: &[u64]) -> nodedb_cluster::ClusterTopology {
+        let mut t = nodedb_cluster::ClusterTopology::new();
+        for (i, id) in ids.iter().enumerate() {
+            let addr: std::net::SocketAddr =
+                format!("127.0.0.1:{}", 9000 + i).parse().unwrap();
+            t.add_node(nodedb_cluster::NodeInfo::new(
+                *id,
+                addr,
+                nodedb_cluster::NodeState::Active,
+            ));
+        }
+        t
+    }
+
+    fn insert_lease(state: &SharedState, descriptor: &DescriptorId, holder: u64) {
+        let now = state.hlc_clock.peek();
+        state
+            .metadata_cache
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .leases
+            .insert(
+                (descriptor.clone(), holder),
+                nodedb_cluster::DescriptorLease {
+                    descriptor_id: descriptor.clone(),
+                    version: 1,
+                    node_id: holder,
+                    expires_at: nodedb_types::Hlc::new(now.wall_ns.saturating_add(60_000_000_000), 0),
+                },
+            );
+    }
+
+    #[test]
+    fn collect_non_member_leases_returns_only_foreign_holders() {
+        let (state, _directory) = test_state();
+        let mut state = state;
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = id("orders");
+
+        insert_lease(&state, &descriptor, 1); // member — must be kept
+        insert_lease(&state, &descriptor, 2); // not in topology — GC target
+
+        let collected = collect_non_member_leases(&state);
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0, 2);
+        assert_eq!(collected[0].1, vec![descriptor]);
+    }
+
+    #[test]
+    fn collect_non_member_leases_empty_without_topology() {
+        let (state, _directory) = test_state();
+        // `cluster_topology` is None in single-node mode: never GC on guesswork.
+        let descriptor = id("orders");
+        insert_lease(&state, &descriptor, 99);
+
+        assert!(collect_non_member_leases(&state).is_empty());
+    }
+
+    /// Fake metadata raft handle: records proposed entries and bumps the
+    /// applied watcher so the release path's `wait_for` returns immediately.
+    struct RecordingProposer {
+        proposed: std::sync::Mutex<Vec<Vec<u8>>>,
+        watcher: Arc<AppliedIndexWatcher>,
+    }
+
+    impl crate::control::metadata_proposer::MetadataRaftHandle for RecordingProposer {
+        fn propose(&self, bytes: Vec<u8>) -> Result<u64, crate::Error> {
+            self.proposed.lock().unwrap_or_else(|p| p.into_inner()).push(bytes);
+            self.watcher.bump(1);
+            Ok(1)
+        }
+    }
+
+    #[test]
+    fn gc_leases_for_node_proposes_descriptor_lease_release() {
+        let (state, _directory) = test_state();
+        let watcher = state.applied_index_watcher(nodedb_cluster::METADATA_GROUP_ID);
+        let proposer = Arc::new(RecordingProposer {
+            proposed: std::sync::Mutex::new(Vec::new()),
+            watcher: Arc::clone(&watcher),
+        });
+        state
+            .metadata_raft
+            .set(proposer.clone())
+            .unwrap_or_else(|_| panic!("metadata raft handle already set in test"));
+
+        let descriptor = id("orders");
+        insert_lease(&state, &descriptor, 2);
+
+        gc_leases_for_node(&state, 2).expect("gc release for node 2");
+
+        let proposed = proposer.proposed.lock().unwrap_or_else(|p| p.into_inner());
+        assert_eq!(proposed.len(), 1);
+        let entry = decode_entry(&proposed[0]).expect("decode proposed entry");
+        assert!(matches!(
+            entry,
+            MetadataEntry::DescriptorLeaseRelease {
+                node_id: 2,
+                ref descriptor_ids,
+            } if descriptor_ids == &vec![descriptor]
+        ));
+    }
+
+    #[test]
+    fn gc_leases_for_node_noop_when_no_entries() {
+        let (state, _directory) = test_state();
+        let watcher = state.applied_index_watcher(nodedb_cluster::METADATA_GROUP_ID);
+        let proposer = Arc::new(RecordingProposer {
+            proposed: std::sync::Mutex::new(Vec::new()),
+            watcher: Arc::clone(&watcher),
+        });
+        state
+            .metadata_raft
+            .set(proposer.clone())
+            .unwrap_or_else(|_| panic!("metadata raft handle already set in test"));
+
+        // No leases at all for node 2 (or anyone): must not propose.
+        gc_leases_for_node(&state, 2).expect("gc noop");
+        assert!(proposer.proposed.lock().unwrap_or_else(|p| p.into_inner()).is_empty());
+
+        // Leases held by OTHER nodes are also not this node's GC target.
+        insert_lease(&state, &id("other"), 3);
+        gc_leases_for_node(&state, 2).expect("gc noop for foreign-only leases");
+        assert!(proposer.proposed.lock().unwrap_or_else(|p| p.into_inner()).is_empty());
+    }
+}

--- a/nodedb/src/control/lease/mod.rs
+++ b/nodedb/src/control/lease/mod.rs
@@ -29,6 +29,7 @@ use crate::error::Error;
 
 pub mod drain;
 pub mod drain_propose;
+pub mod gc;
 pub mod propose;
 pub mod refcount;
 pub mod release;

--- a/nodedb/src/control/lease/release.rs
+++ b/nodedb/src/control/lease/release.rs
@@ -68,25 +68,50 @@ impl LeaseReleaseHandle {
         self.release_raw(unheld)
     }
 
-    /// Raw metadata release. The caller must hold `grant_gate`.
+    /// Raw metadata release for this node. The caller must hold `grant_gate`.
     fn release_raw(&self, descriptor_ids: Vec<DescriptorId>) -> Result<(), Error> {
+        self.release_raw_for_node(self.node_id, descriptor_ids)
+    }
+
+    /// Release leases held by an ARBITRARY node. Used by lease GC for
+    /// nodes that left the topology (crashed/decommissioned). Does NOT take
+    /// `grant_gate` (no contention with local grants — the foreign holder
+    /// cannot grant anymore).
+    pub(crate) fn release_for_node(
+        &self,
+        node_id: u64,
+        descriptor_ids: Vec<DescriptorId>,
+    ) -> Result<(), Error> {
+        self.release_raw_for_node(node_id, descriptor_ids)
+    }
+
+    /// Raw metadata release for `node_id`. `release_raw` keeps its gate-taking
+    /// wrapper for the self path; this is the ungated core.
+    fn release_raw_for_node(
+        &self,
+        node_id: u64,
+        descriptor_ids: Vec<DescriptorId>,
+    ) -> Result<(), Error> {
         if descriptor_ids.is_empty() {
             return Ok(());
         }
 
         let Some(metadata_raft) = &self.metadata_raft else {
-            let mut cache = self
-                .metadata_cache
-                .write()
-                .unwrap_or_else(|poison| poison.into_inner());
-            for id in descriptor_ids {
-                cache.leases.remove(&(id, self.node_id));
+            // Single-node fallback: hanya meaningful untuk self.
+            if node_id == self.node_id {
+                let mut cache = self
+                    .metadata_cache
+                    .write()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                for id in descriptor_ids {
+                    cache.leases.remove(&(id, node_id));
+                }
             }
             return Ok(());
         };
 
         let entry = MetadataEntry::DescriptorLeaseRelease {
-            node_id: self.node_id,
+            node_id,
             descriptor_ids,
         };
         let raw = nodedb_cluster::encode_entry(&entry).map_err(|error| Error::Config {


### PR DESCRIPTION
Fixes epic #165 Medium #8 availability gap: a node that crashes while holding a descriptor lease leaves its records in every MetadataCache forever — every DDL on those descriptors wedges on the 35s drain wait and fails permanently (shutdown_release's 'leases drain via TTL' doc claim was wrong; the poller never checked expiry).

- Drain filter: count_matching_leases ignores leases whose holder is no longer a cluster member (fail-safe: missing topology = all members) and leases past expires_at (matches grant-path semantics).
- TopologyChange::Leave hook: spawn a leader-gated (is_singleton_worker) task proposing DescriptorLeaseRelease for the departed node (spawned, not inline — apply runs on the raft-loop task; inline propose-wait would deadlock the applied watcher).
- Periodic sweep (leader-gated, tick-throttled, mirrors reconcile_placement): proposes releases for every holder no longer in ClusterTopology — safety net for crashes before Leave commits.

Tests: 78 lease (3 drain-filter + 3 gc), 3 lease_gc collector; clippy 0, check 0 errors, maya-gate clean 11/11.

Part of #165.