### PR TITLE
fix(lease): clamp lease expiry against MAX_SKEW clock skew

### DIFF
--- a/nodedb/src/control/lease/clock.rs
+++ b/nodedb/src/control/lease/clock.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Injectable wall-clock source for lease expiry checks.
+//!
+//! Lease expiry is a *duration* question — "have N nanoseconds passed?" — so it
+//! must be measured against real wall time, never against a Hybrid Logical
+//! Clock. An HLC only advances on a local event or an inbound message, so on an
+//! idle cluster it physically freezes; comparing a lease's `expires_at` against
+//! `HlcClock::peek()` would find every lease unexpired and reinstate the wedge
+//! (see PR #246 / `drain_propose.rs`).
+//!
+//! The [`WallClock`] trait lets production code read the real clock while tests
+//! drive expiry deterministically with a [`MockClock`] instead of mocking
+//! `SystemTime` or depending on `HlcClock::peek`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A source of nanoseconds since the Unix epoch.
+pub trait WallClock {
+    fn now_ns(&self) -> u64;
+}
+
+/// Reads the real system clock.
+pub struct RealWallClock;
+
+impl WallClock for RealWallClock {
+    fn now_ns(&self) -> u64 {
+        super::wall_now_ns()
+    }
+}
+
+/// Deterministic clock for tests. Set it explicitly so expiry assertions do not
+/// depend on `SystemTime` or on `HlcClock::peek` (which never advances on its
+/// own and would make every lease look unexpired).
+#[cfg(any(test, feature = "test-helpers"))]
+pub struct MockClock {
+    now: AtomicU64,
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl MockClock {
+    pub fn new(ns: u64) -> Self {
+        Self {
+            now: AtomicU64::new(ns),
+        }
+    }
+
+    pub fn set(&self, ns: u64) {
+        self.now.store(ns, Ordering::Relaxed);
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl WallClock for MockClock {
+    fn now_ns(&self) -> u64 {
+        self.now.load(Ordering::Relaxed)
+    }
+}

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -37,6 +37,8 @@ use nodedb_types::DatabaseId;
 use std::time::{Duration, Instant};
 use tokio::runtime::RuntimeFlavor;
 
+use super::clock::{WallClock, RealWallClock};
+
 use nodedb_cluster::{DescriptorId, DescriptorKind, MetadataEntry, encode_entry};
 use nodedb_types::Hlc;
 
@@ -188,7 +190,7 @@ fn wait_for_lease_drain(
 ) -> Result<(), Error> {
     let deadline = Instant::now() + max_wait;
     loop {
-        let remaining = count_matching_leases(shared, id, up_to_version);
+        let remaining = count_matching_leases(shared, id, up_to_version, &RealWallClock);
         if remaining == 0 {
             return Ok(());
         }
@@ -229,8 +231,13 @@ fn wait_for_lease_drain(
 /// idle cluster is precisely the case where a crashed node's leases are the
 /// only ones left. `expires_at.wall_ns` was computed from real wall time when
 /// the lease was stamped, so both sides of the comparison stay in one frame.
-fn count_matching_leases(shared: &SharedState, id: &DescriptorId, up_to_version: u64) -> usize {
-    let now_wall_ns = super::wall_now_ns();
+fn count_matching_leases(
+    shared: &SharedState,
+    id: &DescriptorId,
+    up_to_version: u64,
+    clock: &dyn WallClock,
+) -> usize {
+    let now_wall_ns = clock.now_ns();
     let cache = shared
         .metadata_cache
         .read()
@@ -551,6 +558,7 @@ mod tests {
         StoredProcedure, StoredTrigger,
     };
     use crate::wal::WalManager;
+    use super::super::clock::MockClock;
 
     #[tokio::test]
     async fn in_flight_admission_reservation_blocks_drain_count() {
@@ -564,9 +572,9 @@ mod tests {
         let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
 
         state.lease_refcount.increment(&descriptor, 1);
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 1);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 1);
         state.lease_refcount.decrement(&descriptor, 1);
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
     }
 
     #[tokio::test]
@@ -581,7 +589,7 @@ mod tests {
         let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
 
         state.lease_refcount.increment(&descriptor, 2);
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
         state.lease_refcount.decrement(&descriptor, 2);
     }
 
@@ -643,6 +651,13 @@ mod tests {
         )
     }
 
+    /// Drive `count_matching_leases` with a wall clock pinned to the moment the
+    /// test starts. Keeps the original real-wall-time behaviour for the existing
+    /// tests; the three `MockClock` tests below override the clock directly.
+    fn clock_now() -> MockClock {
+        MockClock::new(super::super::wall_now_ns())
+    }
+
     #[tokio::test]
     async fn non_member_lease_does_not_block_drain_count() {
         let directory = tempfile::tempdir().expect("create drain count test directory");
@@ -660,7 +675,7 @@ mod tests {
         // Holder 99 is not in the topology (crashed node): its lease must not
         // block the drain count.
         insert_lease(&state, &descriptor, 99, 1, unexpired());
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
     }
 
     #[tokio::test]
@@ -679,7 +694,7 @@ mod tests {
 
         // Holder 1 is a member but its lease is already past expiry.
         insert_lease(&state, &descriptor, 1, 1, expired());
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
     }
 
     /// A lease whose expiry has passed in REAL time must stop blocking the
@@ -715,7 +730,7 @@ mod tests {
 
         insert_lease(&state, &descriptor, 1, 1, expired());
         assert_eq!(
-            count_matching_leases(&state, &descriptor, 1),
+            count_matching_leases(&state, &descriptor, 1, &clock_now()),
             0,
             "an expired lease must not block the drain, however stale the HLC is"
         );
@@ -750,7 +765,7 @@ mod tests {
 
         insert_lease(&state, &descriptor, 1, 1, unexpired());
         assert_eq!(
-            count_matching_leases(&state, &descriptor, 1),
+            count_matching_leases(&state, &descriptor, 1, &clock_now()),
             1,
             "a lease that is live in wall time must keep blocking the drain"
         );
@@ -773,7 +788,99 @@ mod tests {
         // A live member's unexpired lease still blocks the drain — the
         // membership/expiry filters must never mask real holds.
         insert_lease(&state, &descriptor, 1, 1, unexpired());
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 1);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // `WallClock` trait: the clock source is now injected, so expiry can be
+    // driven deterministically instead of depending on `SystemTime` or the
+    // frozen `HlcClock::peek`. These pin the clock and prove the comparison
+    // uses the injected wall clock, not the HLC.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn wall_clock_expired_lease_is_dropped() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Pin "now" to a fixed instant; lease expired one ns before it.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(999_999_999_999_999, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 0);
+    }
+
+    #[tokio::test]
+    async fn wall_clock_live_lease_is_counted() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Pin "now"; lease valid one ns after it.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_001, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
+    }
+
+    #[tokio::test]
+    async fn wall_clock_ignores_skewed_hlc() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Drag the HLC an hour ahead of wall time; the comparison must still use
+        // the injected wall clock, so a live lease is not dropped.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        state.hlc_clock.update(nodedb_types::Hlc::new(
+            1_000_000_000_000_000 + 3_600_000_000_000,
+            0,
+        ));
+        assert!(state.hlc_clock.peek().wall_ns > 1_000_000_000_000_000);
+
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_001, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
     }
 
     fn function(database_id: DatabaseId) -> StoredFunction {

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -37,7 +37,7 @@ use nodedb_types::DatabaseId;
 use std::time::{Duration, Instant};
 use tokio::runtime::RuntimeFlavor;
 
-use super::clock::{WallClock, RealWallClock};
+use crate::util::wall_clock::{WallClock, RealWallClock};
 
 use nodedb_cluster::{DescriptorId, DescriptorKind, MetadataEntry, encode_entry};
 use nodedb_types::Hlc;
@@ -558,7 +558,7 @@ mod tests {
         StoredProcedure, StoredTrigger,
     };
     use crate::wal::WalManager;
-    use super::super::clock::MockClock;
+    use crate::util::wall_clock::MockClock;
 
     #[tokio::test]
     async fn in_flight_admission_reservation_blocks_drain_count() {

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -51,6 +51,13 @@ use crate::error::Error;
 /// to check whether the in-flight leases have drained.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Maximum tolerated wall-clock skew between nodes (5 minutes). Lease expiry
+/// is only respected beyond this window: a lease that looks slightly expired
+/// may still be live on a holder whose clock is behind ours, so it is kept
+/// while `expires_at > now - MAX_SKEW`. The trade-off (safety-first, per #246)
+/// is that a genuinely-dead lease drains up to `MAX_SKEW` later.
+const MAX_SKEW_NS: u64 = 300_000_000_000;
+
 /// Grace period added on top of the configured lease duration
 /// when computing the `expires_at` stamped onto a drain entry.
 /// `is_draining` does not read this value (see `lease::drain`) —
@@ -238,6 +245,11 @@ fn count_matching_leases(
     clock: &dyn WallClock,
 ) -> usize {
     let now_wall_ns = clock.now_ns();
+    // Keep a lease inside the MAX_SKEW window even if its expiry is slightly
+    // in the past: the holder's clock may legitimately be behind ours, and
+    // dropping a live hold lets the DDL proceed underneath a holder still
+    // using the descriptor (the correctness bug #246 refuses to trade for).
+    let live_threshold = now_wall_ns.saturating_sub(MAX_SKEW_NS);
     let cache = shared
         .metadata_cache
         .read()
@@ -248,7 +260,7 @@ fn count_matching_leases(
         .filter(|((lid, holder), l)| {
             lid == id
                 && l.version <= up_to_version
-                && l.expires_at.wall_ns > now_wall_ns
+                && l.expires_at.wall_ns > live_threshold
                 && lease_holder_is_member(shared, *holder)
         })
         .count();
@@ -643,10 +655,13 @@ mod tests {
         )
     }
 
-    /// A lease expiry a minute in the past, in REAL wall time.
+    /// A lease expiry far enough in the PAST to sit past the MAX_SKEW window —
+    /// i.e. definitely dead even under the largest tolerated clock skew.
+    /// An expiry inside the window is still treated as live; see the clamp in
+    /// `count_matching_leases`.
     fn expired() -> nodedb_types::Hlc {
         nodedb_types::Hlc::new(
-            super::super::wall_now_ns().saturating_sub(60_000_000_000),
+            super::super::wall_now_ns().saturating_sub(MAX_SKEW_NS.saturating_add(60_000_000_000)),
             0,
         )
     }
@@ -812,14 +827,15 @@ mod tests {
             .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
         let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
 
-        // Pin "now" to a fixed instant; lease expired one ns before it.
+        // Pin "now" to a fixed instant; lease expired 400s before it — beyond
+        // the MAX_SKEW window, so definitely dead.
         let clock = MockClock::new(1_000_000_000_000_000);
         insert_lease(
             &state,
             &descriptor,
             1,
             1,
-            nodedb_types::Hlc::new(999_999_999_999_999, 0),
+            nodedb_types::Hlc::new(1_000_000_000_000_000 - 400_000_000_000, 0),
         );
         assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 0);
     }
@@ -879,6 +895,96 @@ mod tests {
             1,
             1,
             nodedb_types::Hlc::new(1_000_000_000_000_001, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // MAX_SKEW clamp: a lease whose expiry is slightly in the PAST must stay
+    // live (the holder's clock may be behind ours), and only a lease expired
+    // beyond the window is dropped. This is the reverse-direction guard for
+    // the #246 wedge.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn max_skew_keeps_lease_expired_within_window() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Expiry 100ms in the past: inside the MAX_SKEW window — a holder
+        // whose clock is 100ms behind ours would still hold this live.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_000 - 100_000_000, 0),
+        );
+        assert_eq!(
+            count_matching_leases(&state, &descriptor, 1, &clock),
+            1,
+            "a lease expired within MAX_SKEW must not be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_skew_drops_lease_expired_beyond_window() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Expiry 400s in the past: beyond MAX_SKEW, definitely dead.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_000 - 400_000_000_000, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 0);
+    }
+
+    #[tokio::test]
+    async fn max_skew_keeps_lease_far_in_future() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Expiry 400s in the future: clearly live.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_000 + 400_000_000_000, 0),
         );
         assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
     }

--- a/nodedb/src/control/lease/mod.rs
+++ b/nodedb/src/control/lease/mod.rs
@@ -36,9 +36,8 @@ pub mod release;
 pub mod renewal;
 pub mod shutdown_release;
 mod wall_time;
-mod clock;
 
-pub(super) use wall_time::wall_now_ns;
+pub(crate) use wall_time::wall_now_ns;
 
 pub use drain::{DescriptorDrainTracker, DrainEntry};
 pub use drain_propose::{descriptor_id_and_prior_version, drain_for_ddl};

--- a/nodedb/src/control/lease/mod.rs
+++ b/nodedb/src/control/lease/mod.rs
@@ -36,6 +36,7 @@ pub mod release;
 pub mod renewal;
 pub mod shutdown_release;
 mod wall_time;
+mod clock;
 
 pub(super) use wall_time::wall_now_ns;
 

--- a/nodedb/src/util.rs
+++ b/nodedb/src/util.rs
@@ -4,6 +4,7 @@
 
 pub mod bounded_json;
 pub mod bounded_msgpack;
+pub mod wall_clock;
 
 /// FNV-1a 64-bit hash of a byte slice.
 ///

--- a/nodedb/src/util/wall_clock.rs
+++ b/nodedb/src/util/wall_clock.rs
@@ -13,6 +13,7 @@
 //! drive expiry deterministically with a [`MockClock`] instead of mocking
 //! `SystemTime` or depending on `HlcClock::peek`.
 
+#[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A source of nanoseconds since the Unix epoch.
@@ -25,19 +26,19 @@ pub struct RealWallClock;
 
 impl WallClock for RealWallClock {
     fn now_ns(&self) -> u64 {
-        super::wall_now_ns()
+        crate::control::lease::wall_now_ns()
     }
 }
 
 /// Deterministic clock for tests. Set it explicitly so expiry assertions do not
 /// depend on `SystemTime` or on `HlcClock::peek` (which never advances on its
 /// own and would make every lease look unexpired).
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(test)]
 pub struct MockClock {
     now: AtomicU64,
 }
 
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(test)]
 impl MockClock {
     pub fn new(ns: u64) -> Self {
         Self {
@@ -50,7 +51,7 @@ impl MockClock {
     }
 }
 
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(test)]
 impl WallClock for MockClock {
     fn now_ns(&self) -> u64 {
         self.now.load(Ordering::Relaxed)


### PR DESCRIPTION
## Summary
Reverse-direction guard for the #246 wedge. The hotfix (`7168ecc55`) judges expiry against the local wall clock, but a lease stamped by a holder whose clock is **behind** ours then looks already-expired → false expiry → DDL proceeds under a live holder (the correctness bug #246 refuses to trade for).

`count_matching_leases` now keeps any lease whose expiry is inside a **5-minute MAX_SKEW window** (`expires_at > now - MAX_SKEW`) and drops only leases expired beyond it.

**Stacked on #249** (WallClock trait): this branch contains the trait first; once #249 merges, this PR's diff reduces to the clamp + tests only.

## Changes
- `MAX_SKEW_NS = 300_000_000_000` (5 min) in `drain_propose.rs`
- `live_threshold = now.saturating_sub(MAX_SKEW_NS)` in the drain filter
- `expired()` test fixture moved beyond the skew window (60s-past leases are now *live* by design)
- 3 new `MockClock` tests: within-window kept, beyond-window dropped, far-future kept

## Trade-off (safety-first, per #246)
A genuinely-dead lease drains up to `MAX_SKEW` later. Never dropping a live hold is the priority.

## Verification (solve-first)
- `cargo check -p nodedb --lib --tests` — PASSED (exit 0)
- `cargo test -p nodedb --lib lease::drain_propose::tests` — 15/15 PASSED