### PR TITLE
feat(lease): release leases on SWIM-Dead via lease GC hook

### DIFF
--- a/nodedb-cluster/src/bootstrap/start.rs
+++ b/nodedb-cluster/src/bootstrap/start.rs
@@ -34,6 +34,7 @@ use crate::subsystem::{
     DecommissionSubsystem, ReachabilitySubsystem, RebalancerSubsystem, RunningCluster,
     SubsystemRegistry, SwimSubsystem, SwimSubsystemConfig,
 };
+use crate::MembershipSubscriber;
 use crate::swim::config::SwimConfig;
 use crate::swim::incarnation::Incarnation;
 use crate::swim::incarnation_store::CatalogIncarnationStore;
@@ -73,6 +74,7 @@ pub fn register_default_subsystems(
     ctx: &BootstrapCtx,
     executor: Arc<MigrationExecutor>,
     catalog: &Arc<ClusterCatalog>,
+    extra_swim_subscribers: Vec<Arc<dyn MembershipSubscriber>>,
 ) -> crate::error::Result<()> {
     // Fast-restart rejoin safety: resume SWIM above the last persisted
     // incarnation. A node that crashed while peers held `Dead(A, N)`
@@ -112,7 +114,7 @@ pub fn register_default_subsystems(
         swim_cfg,
         Arc::clone(&ctx.routing),
         Arc::clone(&ctx.topology),
-        vec![],
+        extra_swim_subscribers,
     )));
 
     registry.register(Arc::new(ReachabilitySubsystem::new(
@@ -208,6 +210,7 @@ pub async fn start_cluster_subsystems(
     transport: Arc<NexarTransport>,
     raft_multi_raft: Arc<std::sync::Mutex<crate::multi_raft::MultiRaft>>,
     catalog: &Arc<ClusterCatalog>,
+    extra_swim_subscribers: Vec<Arc<dyn MembershipSubscriber>>,
 ) -> Result<RunningCluster> {
     let health = ClusterHealth::new();
     let (decommission_signal, _) = tokio::sync::watch::channel(false);
@@ -228,7 +231,7 @@ pub async fn start_cluster_subsystems(
     ));
 
     let mut registry = SubsystemRegistry::new();
-    register_default_subsystems(&mut registry, config, &ctx, executor, catalog)?;
+    register_default_subsystems(&mut registry, config, &ctx, executor, catalog, extra_swim_subscribers)?;
 
     registry
         .start_all(&ctx)

--- a/nodedb/src/control/cluster/start_raft/loop_build.rs
+++ b/nodedb/src/control/cluster/start_raft/loop_build.rs
@@ -165,6 +165,14 @@ pub(super) fn build_raft_loop(
         scheduler_config: &scheduler_config,
     })?;
 
+    // SWIM-Dead → lease GC hook: release a crashed node's leases the moment
+    // SWIM confirms it Dead (grace-windowed), instead of waiting for the
+    // metadata leader's periodic sweep.
+    let extra_swim_subscribers: Vec<std::sync::Arc<dyn nodedb_cluster::MembershipSubscriber>> =
+        vec![std::sync::Arc::new(
+            crate::control::lease::gc::LeaseGcOnCrashHook::new(&shared),
+        )];
+
     let running = tokio::task::block_in_place(|| {
         tokio::runtime::Handle::current().block_on(nodedb_cluster::start_cluster_subsystems(
             &pending.config,
@@ -173,6 +181,7 @@ pub(super) fn build_raft_loop(
             Arc::clone(&handle.transport),
             raft_loop_handle,
             &handle.catalog,
+            extra_swim_subscribers,
         ))
     })
     .map_err(|e| crate::Error::Config {

--- a/nodedb/src/control/lease/clock.rs
+++ b/nodedb/src/control/lease/clock.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Injectable wall-clock source for lease expiry checks.
+//!
+//! Lease expiry is a *duration* question — "have N nanoseconds passed?" — so it
+//! must be measured against real wall time, never against a Hybrid Logical
+//! Clock. An HLC only advances on a local event or an inbound message, so on an
+//! idle cluster it physically freezes; comparing a lease's `expires_at` against
+//! `HlcClock::peek()` would find every lease unexpired and reinstate the wedge
+//! (see PR #246 / `drain_propose.rs`).
+//!
+//! The [`WallClock`] trait lets production code read the real clock while tests
+//! drive expiry deterministically with a [`MockClock`] instead of mocking
+//! `SystemTime` or depending on `HlcClock::peek`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A source of nanoseconds since the Unix epoch.
+pub trait WallClock {
+    fn now_ns(&self) -> u64;
+}
+
+/// Reads the real system clock.
+pub struct RealWallClock;
+
+impl WallClock for RealWallClock {
+    fn now_ns(&self) -> u64 {
+        super::wall_now_ns()
+    }
+}
+
+/// Deterministic clock for tests. Set it explicitly so expiry assertions do not
+/// depend on `SystemTime` or on `HlcClock::peek` (which never advances on its
+/// own and would make every lease look unexpired).
+#[cfg(any(test, feature = "test-helpers"))]
+pub struct MockClock {
+    now: AtomicU64,
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl MockClock {
+    pub fn new(ns: u64) -> Self {
+        Self {
+            now: AtomicU64::new(ns),
+        }
+    }
+
+    pub fn set(&self, ns: u64) {
+        self.now.store(ns, Ordering::Relaxed);
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl WallClock for MockClock {
+    fn now_ns(&self) -> u64 {
+        self.now.load(Ordering::Relaxed)
+    }
+}

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -37,6 +37,8 @@ use nodedb_types::DatabaseId;
 use std::time::{Duration, Instant};
 use tokio::runtime::RuntimeFlavor;
 
+use super::clock::{WallClock, RealWallClock};
+
 use nodedb_cluster::{DescriptorId, DescriptorKind, MetadataEntry, encode_entry};
 use nodedb_types::Hlc;
 
@@ -188,7 +190,7 @@ fn wait_for_lease_drain(
 ) -> Result<(), Error> {
     let deadline = Instant::now() + max_wait;
     loop {
-        let remaining = count_matching_leases(shared, id, up_to_version);
+        let remaining = count_matching_leases(shared, id, up_to_version, &RealWallClock);
         if remaining == 0 {
             return Ok(());
         }
@@ -229,8 +231,13 @@ fn wait_for_lease_drain(
 /// idle cluster is precisely the case where a crashed node's leases are the
 /// only ones left. `expires_at.wall_ns` was computed from real wall time when
 /// the lease was stamped, so both sides of the comparison stay in one frame.
-fn count_matching_leases(shared: &SharedState, id: &DescriptorId, up_to_version: u64) -> usize {
-    let now_wall_ns = super::wall_now_ns();
+fn count_matching_leases(
+    shared: &SharedState,
+    id: &DescriptorId,
+    up_to_version: u64,
+    clock: &dyn WallClock,
+) -> usize {
+    let now_wall_ns = clock.now_ns();
     let cache = shared
         .metadata_cache
         .read()
@@ -551,6 +558,7 @@ mod tests {
         StoredProcedure, StoredTrigger,
     };
     use crate::wal::WalManager;
+    use super::super::clock::MockClock;
 
     #[tokio::test]
     async fn in_flight_admission_reservation_blocks_drain_count() {
@@ -564,9 +572,9 @@ mod tests {
         let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
 
         state.lease_refcount.increment(&descriptor, 1);
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 1);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 1);
         state.lease_refcount.decrement(&descriptor, 1);
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
     }
 
     #[tokio::test]
@@ -581,7 +589,7 @@ mod tests {
         let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
 
         state.lease_refcount.increment(&descriptor, 2);
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
         state.lease_refcount.decrement(&descriptor, 2);
     }
 
@@ -643,6 +651,13 @@ mod tests {
         )
     }
 
+    /// Drive `count_matching_leases` with a wall clock pinned to the moment the
+    /// test starts. Keeps the original real-wall-time behaviour for the existing
+    /// tests; the three `MockClock` tests below override the clock directly.
+    fn clock_now() -> MockClock {
+        MockClock::new(super::super::wall_now_ns())
+    }
+
     #[tokio::test]
     async fn non_member_lease_does_not_block_drain_count() {
         let directory = tempfile::tempdir().expect("create drain count test directory");
@@ -660,7 +675,7 @@ mod tests {
         // Holder 99 is not in the topology (crashed node): its lease must not
         // block the drain count.
         insert_lease(&state, &descriptor, 99, 1, unexpired());
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
     }
 
     #[tokio::test]
@@ -679,7 +694,7 @@ mod tests {
 
         // Holder 1 is a member but its lease is already past expiry.
         insert_lease(&state, &descriptor, 1, 1, expired());
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 0);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 0);
     }
 
     /// A lease whose expiry has passed in REAL time must stop blocking the
@@ -715,7 +730,7 @@ mod tests {
 
         insert_lease(&state, &descriptor, 1, 1, expired());
         assert_eq!(
-            count_matching_leases(&state, &descriptor, 1),
+            count_matching_leases(&state, &descriptor, 1, &clock_now()),
             0,
             "an expired lease must not block the drain, however stale the HLC is"
         );
@@ -750,7 +765,7 @@ mod tests {
 
         insert_lease(&state, &descriptor, 1, 1, unexpired());
         assert_eq!(
-            count_matching_leases(&state, &descriptor, 1),
+            count_matching_leases(&state, &descriptor, 1, &clock_now()),
             1,
             "a lease that is live in wall time must keep blocking the drain"
         );
@@ -773,7 +788,99 @@ mod tests {
         // A live member's unexpired lease still blocks the drain — the
         // membership/expiry filters must never mask real holds.
         insert_lease(&state, &descriptor, 1, 1, unexpired());
-        assert_eq!(count_matching_leases(&state, &descriptor, 1), 1);
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock_now()), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // `WallClock` trait: the clock source is now injected, so expiry can be
+    // driven deterministically instead of depending on `SystemTime` or the
+    // frozen `HlcClock::peek`. These pin the clock and prove the comparison
+    // uses the injected wall clock, not the HLC.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn wall_clock_expired_lease_is_dropped() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Pin "now" to a fixed instant; lease expired one ns before it.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(999_999_999_999_999, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 0);
+    }
+
+    #[tokio::test]
+    async fn wall_clock_live_lease_is_counted() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Pin "now"; lease valid one ns after it.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_001, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
+    }
+
+    #[tokio::test]
+    async fn wall_clock_ignores_skewed_hlc() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Drag the HLC an hour ahead of wall time; the comparison must still use
+        // the injected wall clock, so a live lease is not dropped.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        state.hlc_clock.update(nodedb_types::Hlc::new(
+            1_000_000_000_000_000 + 3_600_000_000_000,
+            0,
+        ));
+        assert!(state.hlc_clock.peek().wall_ns > 1_000_000_000_000_000);
+
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_001, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
     }
 
     fn function(database_id: DatabaseId) -> StoredFunction {

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -56,7 +56,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// may still be live on a holder whose clock is behind ours, so it is kept
 /// while `expires_at > now - MAX_SKEW`. The trade-off (safety-first, per #246)
 /// is that a genuinely-dead lease drains up to `MAX_SKEW` later.
-const MAX_SKEW_NS: u64 = 300_000_000_000;
+pub(crate) const MAX_SKEW_NS: u64 = 300_000_000_000;
 
 /// Grace period added on top of the configured lease duration
 /// when computing the `expires_at` stamped onto a drain entry.

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -37,7 +37,7 @@ use nodedb_types::DatabaseId;
 use std::time::{Duration, Instant};
 use tokio::runtime::RuntimeFlavor;
 
-use super::clock::{WallClock, RealWallClock};
+use crate::util::wall_clock::{WallClock, RealWallClock};
 
 use nodedb_cluster::{DescriptorId, DescriptorKind, MetadataEntry, encode_entry};
 use nodedb_types::Hlc;
@@ -558,7 +558,7 @@ mod tests {
         StoredProcedure, StoredTrigger,
     };
     use crate::wal::WalManager;
-    use super::super::clock::MockClock;
+    use crate::util::wall_clock::MockClock;
 
     #[tokio::test]
     async fn in_flight_admission_reservation_blocks_drain_count() {

--- a/nodedb/src/control/lease/drain_propose.rs
+++ b/nodedb/src/control/lease/drain_propose.rs
@@ -51,6 +51,13 @@ use crate::error::Error;
 /// to check whether the in-flight leases have drained.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Maximum tolerated wall-clock skew between nodes (5 minutes). Lease expiry
+/// is only respected beyond this window: a lease that looks slightly expired
+/// may still be live on a holder whose clock is behind ours, so it is kept
+/// while `expires_at > now - MAX_SKEW`. The trade-off (safety-first, per #246)
+/// is that a genuinely-dead lease drains up to `MAX_SKEW` later.
+const MAX_SKEW_NS: u64 = 300_000_000_000;
+
 /// Grace period added on top of the configured lease duration
 /// when computing the `expires_at` stamped onto a drain entry.
 /// `is_draining` does not read this value (see `lease::drain`) —
@@ -238,6 +245,11 @@ fn count_matching_leases(
     clock: &dyn WallClock,
 ) -> usize {
     let now_wall_ns = clock.now_ns();
+    // Keep a lease inside the MAX_SKEW window even if its expiry is slightly
+    // in the past: the holder's clock may legitimately be behind ours, and
+    // dropping a live hold lets the DDL proceed underneath a holder still
+    // using the descriptor (the correctness bug #246 refuses to trade for).
+    let live_threshold = now_wall_ns.saturating_sub(MAX_SKEW_NS);
     let cache = shared
         .metadata_cache
         .read()
@@ -248,7 +260,7 @@ fn count_matching_leases(
         .filter(|((lid, holder), l)| {
             lid == id
                 && l.version <= up_to_version
-                && l.expires_at.wall_ns > now_wall_ns
+                && l.expires_at.wall_ns > live_threshold
                 && lease_holder_is_member(shared, *holder)
         })
         .count();
@@ -643,10 +655,13 @@ mod tests {
         )
     }
 
-    /// A lease expiry a minute in the past, in REAL wall time.
+    /// A lease expiry far enough in the PAST to sit past the MAX_SKEW window —
+    /// i.e. definitely dead even under the largest tolerated clock skew.
+    /// An expiry inside the window is still treated as live; see the clamp in
+    /// `count_matching_leases`.
     fn expired() -> nodedb_types::Hlc {
         nodedb_types::Hlc::new(
-            super::super::wall_now_ns().saturating_sub(60_000_000_000),
+            super::super::wall_now_ns().saturating_sub(MAX_SKEW_NS.saturating_add(60_000_000_000)),
             0,
         )
     }
@@ -812,14 +827,15 @@ mod tests {
             .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
         let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
 
-        // Pin "now" to a fixed instant; lease expired one ns before it.
+        // Pin "now" to a fixed instant; lease expired 400s before it — beyond
+        // the MAX_SKEW window, so definitely dead.
         let clock = MockClock::new(1_000_000_000_000_000);
         insert_lease(
             &state,
             &descriptor,
             1,
             1,
-            nodedb_types::Hlc::new(999_999_999_999_999, 0),
+            nodedb_types::Hlc::new(1_000_000_000_000_000 - 400_000_000_000, 0),
         );
         assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 0);
     }
@@ -879,6 +895,96 @@ mod tests {
             1,
             1,
             nodedb_types::Hlc::new(1_000_000_000_000_001, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // MAX_SKEW clamp: a lease whose expiry is slightly in the PAST must stay
+    // live (the holder's clock may be behind ours), and only a lease expired
+    // beyond the window is dropped. This is the reverse-direction guard for
+    // the #246 wedge.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn max_skew_keeps_lease_expired_within_window() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Expiry 100ms in the past: inside the MAX_SKEW window — a holder
+        // whose clock is 100ms behind ours would still hold this live.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_000 - 100_000_000, 0),
+        );
+        assert_eq!(
+            count_matching_leases(&state, &descriptor, 1, &clock),
+            1,
+            "a lease expired within MAX_SKEW must not be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_skew_drops_lease_expired_beyond_window() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Expiry 400s in the past: beyond MAX_SKEW, definitely dead.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_000 - 400_000_000_000, 0),
+        );
+        assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 0);
+    }
+
+    #[tokio::test]
+    async fn max_skew_keeps_lease_far_in_future() {
+        let directory = tempfile::tempdir().expect("create drain count test directory");
+        let wal = Arc::new(
+            WalManager::open_for_testing(&directory.path().join("wc.wal"))
+                .expect("open drain count test WAL"),
+        );
+        let (dispatcher, _data_sides) = Dispatcher::new(1, 64);
+        let mut state = SharedState::new(dispatcher, wal).expect("construct drain count state");
+        Arc::get_mut(&mut state)
+            .expect("single owner in test")
+            .cluster_topology = Some(Arc::new(std::sync::RwLock::new(topo_with(&[1]))));
+        let descriptor = DescriptorId::new(0, 1, DescriptorKind::Collection, "orders".to_string());
+
+        // Expiry 400s in the future: clearly live.
+        let clock = MockClock::new(1_000_000_000_000_000);
+        insert_lease(
+            &state,
+            &descriptor,
+            1,
+            1,
+            nodedb_types::Hlc::new(1_000_000_000_000_000 + 400_000_000_000, 0),
         );
         assert_eq!(count_matching_leases(&state, &descriptor, 1, &clock), 1);
     }

--- a/nodedb/src/control/lease/gc.rs
+++ b/nodedb/src/control/lease/gc.rs
@@ -4,12 +4,18 @@
 //!
 //! A crashed node's leases are never TTL-pruned from `MetadataCache.leases`
 //! (only a `DescriptorLeaseRelease` entry removes them), so every DDL drain
-//! on those descriptors times out forever. Two triggers run this module:
-//! the `TopologyChange::Leave` apply hook (immediate) and the metadata
-//! leader's periodic sweep (safety net).
+//! on those descriptors times out forever. Three triggers run this module:
+//! the SWIM-Dead subscriber hook (immediate on confirmed crash),
+//! the `TopologyChange::Leave` apply hook (immediate on graceful leave) and
+//! the metadata leader's periodic sweep (safety net).
 
-use nodedb_cluster::DescriptorId;
+use std::sync::{Arc, Weak};
 
+use nodedb_cluster::{DescriptorId, DescriptorLease, MemberState, MembershipSubscriber};
+use nodedb_types::NodeId;
+use tracing::{debug, warn};
+
+use crate::control::lease::drain_propose::MAX_SKEW_NS;
 use crate::control::lease::release::LeaseReleaseHandle;
 use crate::control::state::SharedState;
 
@@ -49,6 +55,23 @@ pub(crate) fn collect_non_member_leases(shared: &SharedState) -> Vec<(u64, Vec<D
 /// periodic sweep). Blocks on the local applied watermark like the
 /// normal release path; callers on hot paths must spawn this.
 pub(crate) fn gc_leases_for_node(shared: &SharedState, node_id: u64) -> Result<(), crate::Error> {
+    gc_leases_for_node_if(shared, node_id, |_| true)
+}
+
+/// Like [`gc_leases_for_node`], but only for leases accepted by `filter`.
+///
+/// The filter runs on each lease value before the release proposal, so a
+/// caller (e.g. the SWIM-Dead hook) can apply a grace window without
+/// duplicating the collection logic. [`gc_leases_for_node`] is the
+/// always-true case.
+pub(crate) fn gc_leases_for_node_if<F>(
+    shared: &SharedState,
+    node_id: u64,
+    filter: F,
+) -> Result<(), crate::Error>
+where
+    F: Fn(&DescriptorLease) -> bool,
+{
     let ids: Vec<DescriptorId> = {
         let cache = shared
             .metadata_cache
@@ -56,15 +79,97 @@ pub(crate) fn gc_leases_for_node(shared: &SharedState, node_id: u64) -> Result<(
             .unwrap_or_else(|p| p.into_inner());
         cache
             .leases
-            .keys()
-            .filter(|(_, holder)| *holder == node_id)
-            .map(|(id, _)| id.clone())
+            .iter()
+            .filter(|(_, l)| l.node_id == node_id && filter(l))
+            .map(|((id, _), _)| id.clone())
             .collect()
     };
     if ids.is_empty() {
         return Ok(());
     }
     LeaseReleaseHandle::from_shared(shared).release_for_node(node_id, ids)
+}
+
+// ---------------------------------------------------------------------------
+// SWIM-Dead → lease release hook
+// ---------------------------------------------------------------------------
+
+/// Parse a SWIM `NodeId` (a decimal string in production) into its numeric
+/// form. `seed:…` placeholder ids and any other non-numeric id are skipped
+/// with a debug log — they cannot name a lease holder.
+fn parse_swim_node_id(node_id: &NodeId) -> Option<u64> {
+    match node_id.as_str().parse::<u64>() {
+        Ok(n) => Some(n),
+        Err(_) => {
+            debug!(node_id = %node_id, "lease GC: skipping non-numeric SWIM node id");
+            None
+        }
+    }
+}
+
+/// Grace-window predicate: release only leases expiring within [`MAX_SKEW_NS`]
+/// of `now` (including already-expired ones). A false-positive Dead (a
+/// live-but-partitioned node) must not yank a fresh lease; leases beyond the
+/// window are left to the periodic sweep, which only acts once the node
+/// remains a non-member.
+fn near_expiry_filter(now_wall_ns: u64, expires_at: &nodedb_types::Hlc) -> bool {
+    expires_at.wall_ns <= now_wall_ns.saturating_add(MAX_SKEW_NS)
+}
+
+/// Subscriber that triggers lease GC the moment SWIM confirms a member Dead.
+///
+/// Mirrors the `TopologyChange::Leave` apply hook in `dispatch.rs`: the GC is
+/// spawned, never run inline (an inline propose-and-wait would deadlock the
+/// applied-index watcher), gated on [`SharedState::is_singleton_worker`], and
+/// the hook holds only a `Weak<SharedState>` so it never keeps the process
+/// alive at shutdown.
+pub(crate) struct LeaseGcOnCrashHook {
+    shared: Weak<SharedState>,
+}
+
+impl LeaseGcOnCrashHook {
+    pub(crate) fn new(shared: &Arc<SharedState>) -> Self {
+        Self {
+            shared: Arc::downgrade(shared),
+        }
+    }
+
+    /// Pure decision: which node, if any, this transition should trigger GC
+    /// for. Split out for deterministic unit testing without spawning.
+    fn should_release(&self, node_id: &NodeId, new: MemberState) -> Option<u64> {
+        if new != MemberState::Dead {
+            return None;
+        }
+        parse_swim_node_id(node_id)
+    }
+}
+
+impl MembershipSubscriber for LeaseGcOnCrashHook {
+    fn on_state_change(&self, node_id: &NodeId, _old: Option<MemberState>, new: MemberState) {
+        let Some(node_id) = self.should_release(node_id, new) else {
+            return;
+        };
+        let Some(shared) = self.shared.upgrade() else {
+            return;
+        };
+        tokio::spawn(async move {
+            // Only the metadata-leader-or-standalone worker performs GC
+            // (mirrors the Leave hook's guard).
+            if !shared.is_singleton_worker() {
+                return;
+            }
+            let now_wall_ns = crate::control::lease::wall_now_ns();
+            if let Err(e) = gc_leases_for_node_if(&shared, node_id, |l| {
+                near_expiry_filter(now_wall_ns, &l.expires_at)
+            }) {
+                warn!(
+                    node_id,
+                    error = %e,
+                    "lease GC after SWIM Dead failed; periodic sweep will retry"
+                );
+            }
+        });
+    }
 }
 
 #[cfg(test)]
@@ -238,5 +343,109 @@ mod tests {
                 .unwrap_or_else(|p| p.into_inner())
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn parse_swim_node_id_numeric_only() {
+        let numeric = nodedb_types::NodeId::try_new("42").expect("valid id");
+        assert_eq!(parse_swim_node_id(&numeric), Some(42));
+
+        let seed = nodedb_types::NodeId::try_new("seed:127.0.0.1:9000").expect("valid id");
+        assert_eq!(parse_swim_node_id(&seed), None);
+
+        let junk = nodedb_types::NodeId::try_new("not-a-number").expect("valid id");
+        assert_eq!(parse_swim_node_id(&junk), None);
+    }
+
+    #[test]
+    fn near_expiry_filter_uses_max_skew_window() {
+        let now = 1_000_000_000_000_000u64;
+        // Already expired → within the window → release.
+        assert!(near_expiry_filter(now, &nodedb_types::Hlc::new(now - 100_000_000, 0)));
+        // Expiring exactly at the window edge → release.
+        assert!(near_expiry_filter(now, &nodedb_types::Hlc::new(now + MAX_SKEW_NS, 0)));
+        // Expiring beyond the window → spare (sweep's job).
+        assert!(!near_expiry_filter(now, &nodedb_types::Hlc::new(now + MAX_SKEW_NS + 1, 0)));
+    }
+
+    #[test]
+    fn hook_releases_only_on_dead() {
+        let (state, _directory) = test_state();
+        let hook = LeaseGcOnCrashHook::new(&state);
+        let node = nodedb_types::NodeId::try_new("42").expect("valid id");
+
+        assert_eq!(hook.should_release(&node, MemberState::Alive), None);
+        assert_eq!(hook.should_release(&node, MemberState::Suspect), None);
+        assert_eq!(hook.should_release(&node, MemberState::Left), None);
+        assert_eq!(hook.should_release(&node, MemberState::Dead), Some(42));
+
+        // Dead with a non-numeric id (seed placeholder) → no target.
+        let seed = nodedb_types::NodeId::try_new("seed:127.0.0.1:9000").expect("valid id");
+        assert_eq!(hook.should_release(&seed, MemberState::Dead), None);
+    }
+
+    /// The grace-window filter is applied at collection time: a near-expiry
+    /// lease of the dead node is released, a fresh lease held by the same
+    /// node is spared.
+    #[test]
+    fn gc_leases_for_node_if_applies_grace_window() {
+        let (state, _directory) = test_state();
+        let watcher = state.applied_index_watcher(nodedb_cluster::METADATA_GROUP_ID);
+        let proposer = Arc::new(RecordingProposer {
+            proposed: std::sync::Mutex::new(Vec::new()),
+            watcher: Arc::clone(&watcher),
+        });
+        state
+            .metadata_raft
+            .set(proposer.clone())
+            .unwrap_or_else(|_| panic!("metadata raft handle already set in test"));
+
+        let now_wall_ns = crate::control::lease::wall_now_ns();
+        let near = id("near");
+        state
+            .metadata_cache
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .leases
+            .insert(
+                (near.clone(), 42),
+                nodedb_cluster::DescriptorLease {
+                    descriptor_id: near.clone(),
+                    version: 1,
+                    node_id: 42,
+                    // Already expired in wall time → inside the grace window.
+                    expires_at: nodedb_types::Hlc::new(now_wall_ns, 0),
+                },
+            );
+        let fresh = id("fresh");
+        state
+            .metadata_cache
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .leases
+            .insert(
+                (fresh.clone(), 42),
+                nodedb_cluster::DescriptorLease {
+                    descriptor_id: fresh.clone(),
+                    version: 1,
+                    node_id: 42,
+                    // 1000s ahead → beyond MAX_SKEW → spared.
+                    expires_at: nodedb_types::Hlc::new(now_wall_ns.saturating_add(1_000_000_000_000), 0),
+                },
+            );
+
+        gc_leases_for_node_if(&state, 42, |l| near_expiry_filter(now_wall_ns, &l.expires_at))
+            .expect("grace-window GC");
+
+        let proposed = proposer.proposed.lock().unwrap_or_else(|p| p.into_inner());
+        assert_eq!(proposed.len(), 1);
+        let entry = decode_entry(&proposed[0]).expect("decode proposed entry");
+        assert!(matches!(
+            entry,
+            MetadataEntry::DescriptorLeaseRelease {
+                node_id: 42,
+                ref descriptor_ids,
+            } if descriptor_ids == &vec![near]
+        ));
     }
 }

--- a/nodedb/src/control/lease/mod.rs
+++ b/nodedb/src/control/lease/mod.rs
@@ -36,9 +36,8 @@ pub mod release;
 pub mod renewal;
 pub mod shutdown_release;
 mod wall_time;
-mod clock;
 
-pub(super) use wall_time::wall_now_ns;
+pub(crate) use wall_time::wall_now_ns;
 
 pub use drain::{DescriptorDrainTracker, DrainEntry};
 pub use drain_propose::{descriptor_id_and_prior_version, drain_for_ddl};

--- a/nodedb/src/control/lease/mod.rs
+++ b/nodedb/src/control/lease/mod.rs
@@ -36,6 +36,7 @@ pub mod release;
 pub mod renewal;
 pub mod shutdown_release;
 mod wall_time;
+mod clock;
 
 pub(super) use wall_time::wall_now_ns;
 

--- a/nodedb/src/util.rs
+++ b/nodedb/src/util.rs
@@ -4,6 +4,7 @@
 
 pub mod bounded_json;
 pub mod bounded_msgpack;
+pub mod wall_clock;
 
 /// FNV-1a 64-bit hash of a byte slice.
 ///

--- a/nodedb/src/util/wall_clock.rs
+++ b/nodedb/src/util/wall_clock.rs
@@ -13,6 +13,7 @@
 //! drive expiry deterministically with a [`MockClock`] instead of mocking
 //! `SystemTime` or depending on `HlcClock::peek`.
 
+#[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A source of nanoseconds since the Unix epoch.
@@ -25,19 +26,19 @@ pub struct RealWallClock;
 
 impl WallClock for RealWallClock {
     fn now_ns(&self) -> u64 {
-        super::wall_now_ns()
+        crate::control::lease::wall_now_ns()
     }
 }
 
 /// Deterministic clock for tests. Set it explicitly so expiry assertions do not
 /// depend on `SystemTime` or on `HlcClock::peek` (which never advances on its
 /// own and would make every lease look unexpired).
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(test)]
 pub struct MockClock {
     now: AtomicU64,
 }
 
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(test)]
 impl MockClock {
     pub fn new(ns: u64) -> Self {
         Self {
@@ -50,7 +51,7 @@ impl MockClock {
     }
 }
 
-#[cfg(any(test, feature = "test-helpers"))]
+#[cfg(test)]
 impl WallClock for MockClock {
     fn now_ns(&self) -> u64 {
         self.now.load(Ordering::Relaxed)


### PR DESCRIPTION
## Summary
Closes epic #165 item 2. A crashed node never produces `TopologyChange::Leave`, so its leases survived until the metadata leader's periodic sweep (~60s, leader-only). `LeaseGcOnCrashHook` subscribes to SWIM membership and spawns a grace-windowed lease release the instant a member is confirmed `Dead`.

**Stacked on #249 + #250** (WallClock trait → MAX_SKEW clamp): this branch contains both first; the diff reduces once they merge.

### Changes
- `gc_leases_for_node_if` — predicate-filtered release (review Option 1); `gc_leases_for_node` forwards with `|_| true`. Reset `nodedb/src/control/lease/gc.rs`.
- `LeaseGcOnCrashHook` — `Weak<SharedState>`, `is_singleton_worker()` guard, `tokio::spawn` (never inline propose-and-wait; the #246 deadlock lesson), `debug!` on non-numeric `NodeId` skip (`seed:…` placeholders).
- **Grace window** (`MAX_SKEW_NS`, 5 min): only leases expiring within the window are released on Dead; fresh leases are spared for the periodic sweep — a false-positive Dead (live-but-partitioned) must not yank a live hold (the #246 correctness line). Leases beyond the window are only swept once the node remains a non-member.
- **Plumbing**: `nodedb_cluster::start_cluster_subsystems` accepts `extra_swim_subscribers`, threaded into `SwimSubsystem::new` at `bootstrap/start.rs`; the host builds the hook in `start_raft/loop_build.rs`.
- `MAX_SKEW_NS` → `pub(crate)` in `drain_propose.rs`.

### Semantics (matching review's risk acceptance)
Leases expiring more than MAX_SKEW in the future are NOT released on SWIM-Dead; the periodic sweep handles them only if the node remains Dead (non-member).

### Verification (solve-first)
- `cargo check -p nodedb-cluster --tests` — EXIT 0
- `cargo check -p nodedb --tests` — EXIT 0
- `cargo test -p nodedb --lib lease::gc` — 8/8 PASSED (4 existing + 4 new: parse, filter, Dead-only decision, grace-window selection via `RecordingProposer`)
- `cargo test -p nodedb --lib lease::drain_propose` — 15/15 PASSED

Note: cluster-tests integration (kill node → leases released < sweep interval) is not in this PR; it needs the multi-node harness and will follow as its own test PR.