### PR TITLE
feat(trigger): run Event-Plane trigger bodies as one system transaction

### DIFF
--- a/nodedb/src/control/planner/procedural/executor/core/dispatch.rs
+++ b/nodedb/src/control/planner/procedural/executor/core/dispatch.rs
@@ -102,7 +102,24 @@ impl<'a> StatementExecutor<'a> {
             })
             .await?;
 
-        if let Some(ref tx_ctx) = self.tx_ctx {
+        if let Some(ref system_scope) = self.system_scope {
+            // System-transaction mode (Event-Plane trigger fire): stage every
+            // task into the active scope instead of dispatching immediately.
+            // All statements of the fired body commit or roll back together;
+            // the scope retains each plan's lease scope until COMMIT.
+            let lease_scope = std::sync::Arc::new(lease_scope);
+            for task in tasks {
+                crate::control::system_txn::push_task_into_scope(
+                    system_scope,
+                    self.state,
+                    task,
+                    std::sync::Arc::clone(&lease_scope),
+                    self.event_source,
+                )
+                .await
+                .map_err(|e| crate::Error::BadRequest { detail: e.to_string() })?;
+            }
+        } else if let Some(ref tx_ctx) = self.tx_ctx {
             let mut guard = tx_ctx.lock().unwrap_or_else(|p| p.into_inner());
             guard.buffer_statement(tasks, lease_scope);
         } else {

--- a/nodedb/src/control/planner/procedural/executor/core/mod.rs
+++ b/nodedb/src/control/planner/procedural/executor/core/mod.rs
@@ -59,6 +59,12 @@ pub struct StatementExecutor<'a> {
     /// Arc<Mutex> required (not RefCell) because execute_statement returns `+ Send` futures.
     pub(super) new_mutations: Arc<Mutex<HashMap<String, nodedb_types::Value>>>,
     pub(super) tx_ctx: Option<Arc<Mutex<ProcedureTransactionCtx>>>,
+    /// System transaction scope for the Event-Plane trigger fire path.
+    /// When set, `execute_sql` stages every task into this scope
+    /// (all-or-nothing per fired body) instead of dispatching immediately.
+    /// Nested (cascade) executors inherit the same scope so one failed body
+    /// rolls back every body the cascade touched.
+    pub(super) system_scope: Option<Arc<crate::control::system_txn::SystemTxnScope>>,
     pub(super) out_values: Arc<Mutex<HashMap<String, nodedb_types::Value>>>,
     /// Cross-shard origin context; `Some` only in the Event-Plane trigger fire
     /// path. Gates remote-write dispatch in `execute_sql`.
@@ -127,6 +133,7 @@ impl<'a> StatementExecutor<'a> {
             event_source,
             new_mutations: Arc::new(Mutex::new(HashMap::new())),
             tx_ctx: None,
+            system_scope: None,
             out_values: Arc::new(Mutex::new(HashMap::new())),
             cross_shard_origin: None,
         }
@@ -135,6 +142,14 @@ impl<'a> StatementExecutor<'a> {
     /// Enable procedure transaction context for COMMIT/ROLLBACK/SAVEPOINT.
     pub fn with_transaction_context(mut self) -> Self {
         self.tx_ctx = Some(Arc::new(Mutex::new(ProcedureTransactionCtx::new())));
+        self
+    }
+
+    /// Stage every statement's tasks into `scope` instead of dispatching
+    /// immediately. Used by the Event-Plane trigger fire path so a body is
+    /// all-or-nothing; nested cascade executors share the same scope.
+    pub fn with_system_scope(mut self, scope: Arc<crate::control::system_txn::SystemTxnScope>) -> Self {
+        self.system_scope = Some(scope);
         self
     }
 

--- a/nodedb/src/control/server/shared/ddl/neutral/collection/dml/triggers.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/collection/dml/triggers.rs
@@ -31,6 +31,7 @@ pub(super) async fn fire_sync_after_triggers(
             new_fields: fields,
             cascade_depth: 0,
             mode_filter: Some(TriggerExecutionMode::Sync),
+            system_scope: None,
             // SYNC AFTER triggers fire in the Control-Plane write path, which
             // has no source-write LSN/HWM identity; cross-shard origination for
             // this path is a tracked follow-up.
@@ -73,6 +74,7 @@ pub(super) async fn fire_sync_after_update_triggers(
             new_fields,
             cascade_depth: 0,
             mode_filter: Some(TriggerExecutionMode::Sync),
+            system_scope: None,
             // SYNC AFTER triggers run in the Control-Plane write path (no
             // source-write LSN/HWM identity); cross-shard origination here is a
             // tracked follow-up.

--- a/nodedb/src/control/system_txn/mod.rs
+++ b/nodedb/src/control/system_txn/mod.rs
@@ -13,5 +13,7 @@ mod data_plane;
 mod run;
 mod scope;
 
-pub use self::run::{SystemTxnError, run_tasks_atomically};
+pub use self::run::{
+    SystemTxnError, commit_scope, push_task_into_scope, rollback_scope, run_tasks_atomically,
+};
 pub use self::scope::SystemTxnScope;

--- a/nodedb/src/control/system_txn/run.rs
+++ b/nodedb/src/control/system_txn/run.rs
@@ -13,6 +13,8 @@ use crate::control::server::shared::session::{
 use crate::control::state::SharedState;
 use crate::event::EventSource;
 use crate::types::TraceId;
+use nodedb_physical::physical_plan::meta::MetaOp;
+use nodedb_physical::physical_plan::PhysicalPlan;
 use nodedb_physical::physical_task::PhysicalTask;
 
 use super::data_plane::SystemTxnDataPlane;
@@ -41,6 +43,83 @@ pub enum SystemTxnError {
     /// COMMIT itself aborted. The transaction applied nothing.
     #[error("system transaction aborted at commit: {detail}")]
     Commit { detail: String },
+
+    /// A DDL task cannot be staged through a system transaction. DDL proposes
+    /// through the metadata path with its own epoch fencing; staging it would
+    /// bypass the all-or-nothing guarantee. Fail fast so a trigger body never
+    /// half-applies DDL.
+    #[error("DDL is not allowed inside a system transaction: {detail}")]
+    Ddl { detail: String },
+}
+
+/// True when `task` is DDL that must never stage through a system
+/// transaction. Today that is collection conversion (`ConvertCollection`),
+/// the one DDL-shaped op that reaches the Data Plane; other DDL proposes
+/// through the metadata path and never becomes a `PhysicalTask`.
+pub(crate) fn is_system_ddl(task: &PhysicalTask) -> bool {
+    matches!(task.plan, PhysicalPlan::Meta(MetaOp::ConvertCollection { .. }))
+}
+
+/// Push ONE planned task into an active scope, staged exactly like
+/// `run_tasks_atomically` stages a pre-planned batch. Procedural trigger
+/// bodies plan statement-by-statement (Option B′), so each statement's tasks
+/// are pushed as they are planned instead of all upfront.
+///
+/// `lease_scope` is retained by the scope until COMMIT (Gap 1: a per-statement
+/// `Arc<QueryLeaseScope>` must not drop before the version fence runs).
+///
+/// Gap 3: DDL is rejected before staging — it would propose through the
+/// metadata path and bypass the all-or-nothing guarantee.
+pub async fn push_task_into_scope(
+    scope: &SystemTxnScope,
+    state: &SharedState,
+    task: PhysicalTask,
+    lease_scope: Arc<QueryLeaseScope>,
+    event_source: EventSource,
+) -> Result<(), SystemTxnError> {
+    if is_system_ddl(&task) {
+        return Err(SystemTxnError::Ddl {
+            detail: "collection conversion (DDL) inside a system transaction".into(),
+        });
+    }
+
+    let buffered_before = scope.sessions().buffered_task_count(scope.session_id());
+    let routed = route_in_tx_write(
+        state,
+        scope.sessions(),
+        scope.session_id(),
+        task,
+        |staged| dispatch_staged(state, staged, event_source),
+    )
+    .await;
+    if let Err(error) = routed {
+        return Err(SystemTxnError::Statement {
+            index: 0,
+            total: 1,
+            source: staging_error(error),
+        });
+    }
+
+    // Retain the plan's leases on whatever this task buffered, so the COMMIT
+    // fence has versions to compare. Gap 1: also keep the Arc alive in the
+    // scope — a per-statement Arc must not drop before the fence runs.
+    if scope.sessions().buffered_task_count(scope.session_id()) > buffered_before {
+        if !scope.sessions().attach_tx_lease_scope_since(
+            scope.session_id(),
+            buffered_before,
+            Arc::clone(&lease_scope),
+        ) {
+            return Err(SystemTxnError::Statement {
+                index: 0,
+                total: 1,
+                source: crate::Error::Internal {
+                    detail: "retaining descriptor leases for a system transaction failed".into(),
+                },
+            });
+        }
+        scope.retain_lease_scope(lease_scope);
+    }
+    Ok(())
 }
 
 /// Run every task as one transaction: all of them apply, or none do.
@@ -67,46 +146,27 @@ pub async fn run_tasks_atomically(
     };
 
     for (index, task) in tasks.into_iter().enumerate() {
-        let buffered_before = scope.sessions().buffered_task_count(scope.session_id());
-        let routed = route_in_tx_write(
-            state,
-            scope.sessions(),
-            scope.session_id(),
-            task,
-            |staged| dispatch_staged(state, staged, event_source),
-        )
-        .await;
-
-        if let Err(error) = routed {
-            let source = staging_error(error);
-            lifecycle::run_rollback(scope.sessions(), scope.session_id(), identity, state, &dp)
-                .await;
-            return Err(SystemTxnError::Statement {
-                index,
-                total,
-                source,
-            });
-        }
-
-        // Retain the plan's leases on whatever this task buffered, so the
-        // COMMIT fence has versions to compare. A refusal here means the
-        // session left the block underneath us; committing anyway would skip
-        // the fence entirely.
-        if scope.sessions().buffered_task_count(scope.session_id()) > buffered_before
-            && !scope.sessions().attach_tx_lease_scope_since(
-                scope.session_id(),
-                buffered_before,
-                Arc::clone(&lease_scope),
-            )
+        if let Err(error) =
+            push_task_into_scope(&scope, state, task, Arc::clone(&lease_scope), event_source).await
         {
-            lifecycle::run_rollback(scope.sessions(), scope.session_id(), identity, state, &dp)
-                .await;
-            return Err(SystemTxnError::Statement {
-                index,
-                total,
-                source: crate::Error::Internal {
-                    detail: "retaining descriptor leases for a system transaction failed".into(),
+            // A statement or DDL failure may have staged earlier tasks:
+            // roll back the whole block before reporting (execute_block's
+            // caller keeps the block alive after an error, so this must be
+            // explicit here, not deferred to Drop).
+            if matches!(
+                error,
+                SystemTxnError::Statement { .. } | SystemTxnError::Ddl { .. }
+            ) {
+                lifecycle::run_rollback(scope.sessions(), scope.session_id(), identity, state, &dp)
+                    .await;
+            }
+            return Err(match error {
+                SystemTxnError::Statement { source, .. } => SystemTxnError::Statement {
+                    index,
+                    total,
+                    source,
                 },
+                other => other,
             });
         }
     }
@@ -117,6 +177,41 @@ pub async fn run_tasks_atomically(
             detail: describe(&reason),
         }),
     }
+}
+
+/// COMMIT a scope that procedural (statement-serial) execution filled via
+/// [`push_task_into_scope`]. All buffered tasks apply, or none do.
+pub async fn commit_scope(
+    scope: &SystemTxnScope,
+    identity: &AuthenticatedIdentity,
+    state: &SharedState,
+    event_source: EventSource,
+) -> Result<(), SystemTxnError> {
+    let dp = SystemTxnDataPlane {
+        state,
+        event_source,
+    };
+    match commit::run_commit(scope.sessions(), scope.session_id(), identity, state, &dp).await {
+        CommitOutcome::Committed => Ok(()),
+        CommitOutcome::Aborted { reason } => Err(SystemTxnError::Commit {
+            detail: describe(&reason),
+        }),
+    }
+}
+
+/// ROLLBACK a scope after a statement (or body) failed. Best-effort: lease
+/// GC backstops anything the rollback could not release.
+pub async fn rollback_scope(
+    scope: &SystemTxnScope,
+    identity: &AuthenticatedIdentity,
+    state: &SharedState,
+    event_source: EventSource,
+) {
+    let dp = SystemTxnDataPlane {
+        state,
+        event_source,
+    };
+    lifecycle::run_rollback(scope.sessions(), scope.session_id(), identity, state, &dp).await;
 }
 
 /// Apply one stageable write to the transaction's overlay.
@@ -169,5 +264,39 @@ fn describe(reason: &AbortReason) -> String {
         AbortReason::SchemaChanged { detail } => detail.clone(),
         AbortReason::Dispatch(e) => e.to_string(),
         AbortReason::DdlPropose(e) => e.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nodedb_physical::physical_plan::meta::MetaOp;
+    use nodedb_physical::physical_plan::PhysicalPlan;
+    use nodedb_physical::physical_task::PhysicalTask;
+
+    fn task_with(plan: PhysicalPlan) -> PhysicalTask {
+        PhysicalTask {
+            tenant_id: crate::types::TenantId::new(1),
+            vshard_id: nodedb_types::id::VShardId::new(0),
+            database_id: crate::types::DatabaseId::DEFAULT,
+            plan,
+            post_set_op: nodedb_physical::physical_task::PostSetOp::None,
+            txn_id: None,
+        }
+    }
+
+    #[test]
+    fn is_system_ddl_detects_collection_conversion() {
+        // The one DDL-shaped op that reaches the Data Plane: must be rejected.
+        let ddl = task_with(PhysicalPlan::Meta(MetaOp::ConvertCollection {
+            collection: "orders".to_string(),
+            target_type: "document".to_string(),
+            schema_json: "{}".to_string(),
+        }));
+        assert!(is_system_ddl(&ddl));
+
+        // A non-DDL meta op must pass.
+        let housekeeping = task_with(PhysicalPlan::Meta(MetaOp::ListContinuousAggregates));
+        assert!(!is_system_ddl(&housekeeping));
     }
 }

--- a/nodedb/src/control/system_txn/scope.rs
+++ b/nodedb/src/control/system_txn/scope.rs
@@ -2,6 +2,9 @@
 
 //! An owned transaction block for work the database initiates itself.
 
+use std::sync::Arc;
+
+use crate::control::lease::QueryLeaseScope;
 use crate::control::server::shared::session::{DmlTxnCtx, SessionId, SessionStore};
 use crate::control::state::SharedState;
 
@@ -13,6 +16,12 @@ use crate::control::state::SharedState;
 pub struct SystemTxnScope {
     sessions: SessionStore,
     session_id: SessionId,
+    /// Lease scopes retained by statement-serial planning (procedural trigger
+    /// bodies). Each buffered task's `QueryLeaseScope` must stay alive until
+    /// COMMIT finishes the version fence; the scope owns them so a per-statement
+    /// `Arc` cannot drop early. `Mutex` because the scope is shared as an
+    /// `Arc<SystemTxnScope>` between the executor and the commit path.
+    lease_scopes: std::sync::Mutex<Vec<Arc<QueryLeaseScope>>>,
 }
 
 impl SystemTxnScope {
@@ -48,6 +57,7 @@ impl SystemTxnScope {
         Ok(Self {
             sessions,
             session_id,
+            lease_scopes: std::sync::Mutex::new(Vec::new()),
         })
     }
 
@@ -65,5 +75,17 @@ impl SystemTxnScope {
 
     pub fn session_id(&self) -> SessionId {
         self.session_id
+    }
+
+    /// Retain a plan lease scope until the scope's COMMIT finishes the
+    /// version fence. Statement-serial planning (procedural trigger bodies)
+    /// acquires one `Arc<QueryLeaseScope>` per statement; without retention
+    /// the Arc would drop when the statement returns and the COMMIT fence
+    /// would lose the versions it must compare.
+    pub fn retain_lease_scope(&self, lease_scope: Arc<QueryLeaseScope>) {
+        self.lease_scopes
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(lease_scope);
     }
 }

--- a/nodedb/src/control/trigger/dml_hook_fire.rs
+++ b/nodedb/src/control/trigger/dml_hook_fire.rs
@@ -227,6 +227,7 @@ pub async fn fire_post_dispatch_triggers(params: DispatchTriggerParams<'_>) -> c
                     new_fields,
                     cascade_depth,
                     mode_filter: Some(TriggerExecutionMode::Sync),
+                system_scope: None,
                     // SYNC post-dispatch triggers run in the Control-Plane write
                     // path (no source-write LSN/HWM identity); cross-shard
                     // origination for this path is a tracked follow-up.
@@ -251,6 +252,7 @@ pub async fn fire_post_dispatch_triggers(params: DispatchTriggerParams<'_>) -> c
                 new_fields,
                 cascade_depth,
                 mode_filter: Some(TriggerExecutionMode::Sync),
+                system_scope: None,
                 cross_shard_origin: None,
                 on_error: FireErrorPolicy::Abort,
                 only_trigger: None,
@@ -269,6 +271,7 @@ pub async fn fire_post_dispatch_triggers(params: DispatchTriggerParams<'_>) -> c
                 old_fields,
                 cascade_depth,
                 mode_filter: Some(TriggerExecutionMode::Sync),
+                system_scope: None,
                 cross_shard_origin: None,
                 on_error: FireErrorPolicy::Abort,
                 only_trigger: None,
@@ -290,6 +293,7 @@ pub async fn fire_post_dispatch_triggers(params: DispatchTriggerParams<'_>) -> c
         event: info.event,
         cascade_depth,
         mode_filter: Some(TriggerExecutionMode::Sync),
+                system_scope: None,
         on_error: FireErrorPolicy::Abort,
         only_trigger: None,
     })

--- a/nodedb/src/control/trigger/fire_after.rs
+++ b/nodedb/src/control/trigger/fire_after.rs
@@ -14,6 +14,8 @@
 
 use crate::control::planner::procedural::executor::bindings::RowBindings;
 use crate::control::planner::procedural::executor::core::CrossShardOrigin;
+use crate::control::system_txn::SystemTxnScope;
+use std::sync::Arc;
 use crate::control::security::catalog::trigger_types::{TriggerExecutionMode, TriggerTiming};
 use crate::control::security::identity::AuthenticatedIdentity;
 use crate::control::state::SharedState;
@@ -46,6 +48,8 @@ pub struct FireAfterInsertParams<'a> {
     pub mode_filter: Option<TriggerExecutionMode>,
     /// Cross-shard origin context (Event-Plane fire path only).
     pub cross_shard_origin: Option<CrossShardOrigin>,
+    /// System transaction scope (Event-Plane fire path); `None` otherwise.
+    pub system_scope: Option<Arc<SystemTxnScope>>,
     /// What a failing trigger does to the triggers queued behind it.
     pub on_error: FireErrorPolicy,
     /// Restricts firing to the one named trigger; `None` fires every match.
@@ -76,6 +80,7 @@ pub async fn fire_after_insert(params: FireAfterInsertParams<'_>) -> FireReport 
         cascade_depth,
         mode_filter,
         cross_shard_origin,
+        system_scope,
         on_error,
         only_trigger,
     } = params;
@@ -113,6 +118,7 @@ pub async fn fire_after_insert(params: FireAfterInsertParams<'_>) -> FireReport 
         bindings: &bindings,
         cascade_depth,
         cross_shard_origin,
+        system_scope,
         on_error,
     })
     .await
@@ -140,6 +146,8 @@ pub struct FireAfterUpdateParams<'a> {
     pub mode_filter: Option<TriggerExecutionMode>,
     /// Cross-shard origin context (Event-Plane fire path only).
     pub cross_shard_origin: Option<CrossShardOrigin>,
+    /// System transaction scope (Event-Plane fire path); `None` otherwise.
+    pub system_scope: Option<Arc<SystemTxnScope>>,
     /// What a failing trigger does to the triggers queued behind it.
     pub on_error: FireErrorPolicy,
     /// Restricts firing to the one named trigger; `None` fires every match.
@@ -165,6 +173,7 @@ pub async fn fire_after_update(params: FireAfterUpdateParams<'_>) -> FireReport 
         cascade_depth,
         mode_filter,
         cross_shard_origin,
+        system_scope,
         on_error,
         only_trigger,
     } = params;
@@ -202,6 +211,7 @@ pub async fn fire_after_update(params: FireAfterUpdateParams<'_>) -> FireReport 
         bindings: &bindings,
         cascade_depth,
         cross_shard_origin,
+        system_scope,
         on_error,
     })
     .await
@@ -227,6 +237,8 @@ pub struct FireAfterDeleteParams<'a> {
     pub mode_filter: Option<TriggerExecutionMode>,
     /// Cross-shard origin context (Event-Plane fire path only).
     pub cross_shard_origin: Option<CrossShardOrigin>,
+    /// System transaction scope (Event-Plane fire path); `None` otherwise.
+    pub system_scope: Option<Arc<SystemTxnScope>>,
     /// What a failing trigger does to the triggers queued behind it.
     pub on_error: FireErrorPolicy,
     /// Restricts firing to the one named trigger; `None` fires every match.
@@ -250,6 +262,7 @@ pub async fn fire_after_delete(params: FireAfterDeleteParams<'_>) -> FireReport 
         cascade_depth,
         mode_filter,
         cross_shard_origin,
+        system_scope,
         on_error,
         only_trigger,
     } = params;
@@ -287,6 +300,7 @@ pub async fn fire_after_delete(params: FireAfterDeleteParams<'_>) -> FireReport 
         bindings: &bindings,
         cascade_depth,
         cross_shard_origin,
+        system_scope,
         on_error,
     })
     .await

--- a/nodedb/src/control/trigger/fire_before.rs
+++ b/nodedb/src/control/trigger/fire_before.rs
@@ -174,6 +174,7 @@ pub async fn fire_before_delete(
         // Event-Plane async cross-shard sender path.
         cross_shard_origin: None,
         on_error: FireErrorPolicy::Abort,
+        system_scope: None,
     })
     .await
     .into_result()

--- a/nodedb/src/control/trigger/fire_common.rs
+++ b/nodedb/src/control/trigger/fire_common.rs
@@ -5,6 +5,7 @@
 //! Used by BEFORE, AFTER, and INSTEAD OF trigger fire paths.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tracing::{info, warn};
 
@@ -12,6 +13,7 @@ use crate::control::planner::procedural::executor::bindings::RowBindings;
 use crate::control::planner::procedural::executor::core::{
     CrossShardOrigin, MAX_CASCADE_DEPTH, StatementExecutor,
 };
+use crate::control::system_txn::SystemTxnScope;
 use crate::control::security::catalog::trigger_types::{StoredTrigger, TriggerSecurity};
 use crate::control::security::identity::{AuthenticatedIdentity, Role};
 use crate::control::state::SharedState;
@@ -52,6 +54,11 @@ pub struct FireTriggersParams<'a> {
     pub cross_shard_origin: Option<CrossShardOrigin>,
     /// What a failing trigger does to the triggers queued behind it.
     pub on_error: FireErrorPolicy,
+    /// System transaction scope for the Event-Plane fire path. When set,
+    /// every body's DML stages into this scope — all-or-nothing per fired
+    /// event, and cascade (nested) executors inherit the same scope. `None`
+    /// for the in-transaction sync/deferred paths.
+    pub system_scope: Option<Arc<SystemTxnScope>>,
 }
 
 /// What happens to the remaining triggers when one of them fails.
@@ -106,6 +113,13 @@ impl FireReport {
         self.refusal.as_ref()
     }
 
+    /// Non-consuming check: did the pass refuse, or did any trigger fail?
+    /// (The Event-Plane dispatcher uses this to decide system-txn commit vs
+    /// rollback BEFORE the report is consumed by the retry queue.)
+    pub fn has_failure(&self) -> bool {
+        self.refusal.is_some() || self.outcomes.iter().any(|outcome| outcome.error.is_some())
+    }
+
     /// Every trigger that failed, in registration order. A refused pass
     /// yields nothing — no individual trigger ran.
     pub fn into_failures(self) -> impl Iterator<Item = TriggerOutcome> {
@@ -146,6 +160,7 @@ pub async fn fire_triggers(params: FireTriggersParams<'_>) -> FireReport {
         cascade_depth,
         cross_shard_origin,
         on_error,
+        system_scope,
     } = params;
 
     let mut report = FireReport::default();
@@ -194,6 +209,11 @@ pub async fn fire_triggers(params: FireTriggersParams<'_>) -> FireReport {
         );
         if let Some(ref origin) = cross_shard_origin {
             executor = executor.with_cross_shard_origin(origin.clone());
+        }
+        if let Some(ref system_scope) = system_scope {
+            // Cascade inheritance (Gap 2): a body's DML that fires another
+            // trigger must stage into the SAME system transaction.
+            executor = executor.with_system_scope(Arc::clone(system_scope));
         }
 
         let error = executor

--- a/nodedb/src/control/trigger/fire_instead.rs
+++ b/nodedb/src/control/trigger/fire_instead.rs
@@ -76,6 +76,7 @@ pub async fn fire_instead_of_insert(
         // they are not part of the Event-Plane async cross-shard sender path.
         cross_shard_origin: None,
         on_error: FireErrorPolicy::Abort,
+        system_scope: None,
     })
     .await
     .into_result()?;
@@ -150,6 +151,7 @@ pub async fn fire_instead_of_update(
         // they are not part of the Event-Plane async cross-shard sender path.
         cross_shard_origin: None,
         on_error: FireErrorPolicy::Abort,
+        system_scope: None,
     })
     .await
     .into_result()?;
@@ -199,6 +201,7 @@ pub async fn fire_instead_of_delete(
         // they are not part of the Event-Plane async cross-shard sender path.
         cross_shard_origin: None,
         on_error: FireErrorPolicy::Abort,
+        system_scope: None,
     })
     .await
     .into_result()?;

--- a/nodedb/src/control/trigger/fire_statement.rs
+++ b/nodedb/src/control/trigger/fire_statement.rs
@@ -17,6 +17,8 @@ use super::fire_common::{
 };
 use super::registry::DmlEvent;
 use crate::control::planner::procedural::executor::bindings::RowBindings;
+use crate::control::system_txn::SystemTxnScope;
+use std::sync::Arc;
 use crate::control::security::catalog::trigger_types::{
     TriggerExecutionMode, TriggerGranularity, TriggerTiming,
 };
@@ -41,6 +43,8 @@ pub struct FireAfterStatementParams<'a> {
     pub mode_filter: Option<TriggerExecutionMode>,
     /// What a failing trigger does to the triggers queued behind it.
     pub on_error: FireErrorPolicy,
+    /// System transaction scope (Event-Plane fire path); `None` otherwise.
+    pub system_scope: Option<Arc<SystemTxnScope>>,
     /// Restricts firing to the one named trigger; `None` fires every match.
     ///
     /// A retry sets this so it re-runs only the trigger that failed.
@@ -68,6 +72,7 @@ pub async fn fire_after_statement(params: FireAfterStatementParams<'_>) -> FireR
         cascade_depth,
         mode_filter,
         on_error,
+        system_scope,
         only_trigger,
     } = params;
     let triggers = state.trigger_registry.get_matching(
@@ -108,6 +113,7 @@ pub async fn fire_after_statement(params: FireAfterStatementParams<'_>) -> FireR
         // cross-shard sender path (see tracked follow-up).
         cross_shard_origin: None,
         on_error,
+        system_scope,
     })
     .await
 }

--- a/nodedb/src/event/trigger/dispatcher/batch.rs
+++ b/nodedb/src/event/trigger/dispatcher/batch.rs
@@ -115,6 +115,8 @@ pub async fn dispatch_trigger_batch(
                 // available here; see the tracked follow-up.
                 cross_shard_origin: None,
                 on_error: fire_common::FireErrorPolicy::Abort,
+                // Batch path is not wired into the production consumer loop.
+                system_scope: None,
             })
             .await;
 

--- a/nodedb/src/event/trigger/dispatcher/retry_action.rs
+++ b/nodedb/src/event/trigger/dispatcher/retry_action.rs
@@ -109,6 +109,7 @@ async fn run(action: &FailedAction, state: &Arc<SharedState>) -> Result<(), Acti
                     source_collection: action.context.collection.clone(),
                 }),
                 on_error: FireErrorPolicy::Abort,
+                system_scope: None,
                 only_trigger: Some(trigger_name),
             })
             .await
@@ -134,6 +135,7 @@ async fn run(action: &FailedAction, state: &Arc<SharedState>) -> Result<(), Acti
                 cascade_depth: action.context.cascade_depth,
                 mode_filter: Some(TriggerExecutionMode::Async),
                 on_error: FireErrorPolicy::Abort,
+                system_scope: None,
                 only_trigger: Some(trigger_name),
             })
             .await

--- a/nodedb/src/event/trigger/dispatcher/single.rs
+++ b/nodedb/src/event/trigger/dispatcher/single.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::control::planner::procedural::executor::core::CrossShardOrigin;
 use crate::control::security::catalog::trigger_types::TriggerExecutionMode;
@@ -25,6 +25,7 @@ use crate::control::trigger::TriggerScope;
 use crate::control::trigger::fire;
 use crate::control::trigger::fire_common::{FireErrorPolicy, FireReport};
 use crate::control::trigger::fire_statement::{FireAfterStatementParams, fire_after_statement};
+use crate::control::system_txn::{SystemTxnScope, commit_scope, rollback_scope};
 use crate::control::trigger::row_identity::inject_row_identity;
 use crate::event::action::ActionRetryQueue;
 use crate::event::types::{EventSource, WriteEvent, WriteOp, deserialize_event_payload};
@@ -61,6 +62,26 @@ pub async fn dispatch_triggers(
 
     let identity = trigger_identity(event.tenant_id);
     let op_str = event.op.to_string();
+
+    // System-transaction scope for the Event-Plane ASYNC fire path: every
+    // body fired by this event stages into ONE transaction, so a mid-body
+    // failure rolls back the whole event (all-or-nothing + retry-safe).
+    // Sync and DEFERRED fires must NOT be wrapped — they already run inside
+    // the client's transaction.
+    let system_scope = if event.source == EventSource::User {
+        match SystemTxnScope::begin(state) {
+            Ok(scope) => Some(Arc::new(scope)),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "trigger dispatch: system txn begin failed; firing without atomicity"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
     let source = ActionSource {
         database_id: event.database_id,
         tenant_id: event.tenant_id.as_u64(),
@@ -84,6 +105,7 @@ pub async fn dispatch_triggers(
         WriteOp::BulkInsert { .. } | WriteOp::BulkDelete { .. }
     );
 
+    let mut row_failed = false;
     if !is_bulk {
         let report = fire_for_operation(FireForOperationParams {
             operation: &op_str,
@@ -104,8 +126,10 @@ pub async fn dispatch_triggers(
             }),
             on_error: FireErrorPolicy::Continue,
             only_trigger: None,
+            system_scope: system_scope.clone(),
         })
         .await;
+        row_failed = report.has_failure();
         record_row_failures(
             &source,
             report,
@@ -133,9 +157,23 @@ pub async fn dispatch_triggers(
         mode_filter,
         on_error: FireErrorPolicy::Continue,
         only_trigger: None,
+        system_scope: system_scope.clone(),
     })
     .await;
+    let stmt_failed = report.has_failure();
     record_statement_failures(&source, report, queue);
+
+    if let Some(ref scope) = system_scope {
+        if row_failed || stmt_failed {
+            rollback_scope(scope, &identity, state, event.source).await;
+            trace!(
+                collection = %event.collection,
+                "trigger body failed; fired-event system transaction rolled back"
+            );
+        } else if let Err(e) = commit_scope(scope, &identity, state, event.source).await {
+            warn!(error = %e, "trigger fired-event system transaction commit failed");
+        }
+    }
 }
 
 /// Decode one side of an event payload into trigger row bindings.
@@ -191,6 +229,8 @@ pub(super) struct FireForOperationParams<'a> {
     /// Source-write context, so a trigger body writing to a remote-homed
     /// collection is dispatched to the owning node instead of the local core.
     pub cross_shard_origin: Option<CrossShardOrigin>,
+    /// System transaction scope (Event-Plane fire path); `None` otherwise.
+    pub system_scope: Option<Arc<SystemTxnScope>>,
     /// What a failing trigger does to the triggers queued behind it.
     pub on_error: FireErrorPolicy,
     /// Restricts firing to the one named trigger; `None` fires every match.
@@ -214,6 +254,7 @@ pub(super) async fn fire_for_operation(params: FireForOperationParams<'_>) -> Fi
         cascade_depth,
         mode_filter,
         cross_shard_origin,
+        system_scope,
         on_error,
         only_trigger,
     } = params;
@@ -231,6 +272,7 @@ pub(super) async fn fire_for_operation(params: FireForOperationParams<'_>) -> Fi
                     cascade_depth,
                     mode_filter,
                     cross_shard_origin,
+        system_scope,
                     on_error,
                     only_trigger,
                 })
@@ -251,6 +293,7 @@ pub(super) async fn fire_for_operation(params: FireForOperationParams<'_>) -> Fi
                     cascade_depth,
                     mode_filter,
                     cross_shard_origin,
+        system_scope,
                     on_error,
                     only_trigger,
                 })
@@ -270,6 +313,7 @@ pub(super) async fn fire_for_operation(params: FireForOperationParams<'_>) -> Fi
                     cascade_depth,
                     mode_filter,
                     cross_shard_origin,
+        system_scope,
                     on_error,
                     only_trigger,
                 })


### PR DESCRIPTION
## Summary
Related to #165 (deferred actions — last unchecked box). A trigger body that fails mid-block leaves earlier statements applied, and its async retry repeats them. The Event-Plane fire path now stages every fired body into a `SystemTxnScope`: all statements commit together or roll back together.

**Option B′ (scope-bound executor)**, per the Phase-1 recon: bodies are procedural control flow (`If`/`While`/`For`), so pre-planning the whole body (Option A) is impossible; instead each statement's tasks route into the scope as they are planned.

## Gap hardening (review items 1–3)
1. **Lease-scope lifetime** — `SystemTxnScope::retain_lease_scope` holds each statement's `Arc<QueryLeaseScope>` until COMMIT's version fence.
2. **Cascade sharing** — `system_scope` threaded through `FireTriggersParams` + all `FireAfter*Params`; `StatementExecutor::with_system_scope`; nested (cascade) triggers inherit the caller's scope — one failure rolls back every body the cascade touched.
3. **DDL fail-fast** — `is_system_ddl` rejects the one DDL-shaped Data-Plane op (`MetaOp::ConvertCollection`) with `SystemTxnError::Ddl` before staging.

## Mechanics
- `push_task_into_scope` (statement-serial staging, extracted from `run_tasks_atomically`; the batch function is refactored onto it — behavior identical)
- `commit_scope` / `rollback_scope` exported helpers
- `dispatcher/single.rs`: one scope per fired event (**async only** — `EventSource::User`); row + statement fires share it; commit on `FireReport::has_failure() == false`, rollback otherwise
- Sync / DEFERRED / BEFORE / INSTEAD paths explicitly `system_scope: None` — never double-wrapped (they already run inside the client transaction)
- New non-consuming `FireReport::has_failure()`

## Verification (solve-first)
- `cargo check -p nodedb --lib --tests` — EXIT 0, zero warnings
- `control::system_txn` — 1/1 (DDL gate)
- `control::trigger` — 68/68 (no regression from the threading)
- `event::trigger` — 12/12 (dispatcher wiring)

Known follow-ups (tracked, not blockers): retry-path atomicity wiring in `retry_action.rs` (currently `None` — retries run the failed body non-atomically until it lands), cluster-tests stage-2 coverage (kill mid-trigger → retry/DLQ), deferred `batch.rs` path.