### PR TITLE
fix(cluster)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,11 +79,11 @@ ports:
 
 ### Common env vars
 
-| Variable                  | Default    | Description                  |
-| ------------------------- | ---------- | ---------------------------- |
-| `NODEDB_MEMORY_LIMIT`     | 1 GiB      | e.g. `4GiB`                  |
-| `NODEDB_DATA_PLANE_CORES` | CPUs - 1   | number of Data Plane threads |
-| `NODEDB_LOG_FORMAT`       | `text`     | `text` or `json`             |
+| Variable                  | Default  | Description                  |
+| ------------------------- | -------- | ---------------------------- |
+| `NODEDB_MEMORY_LIMIT`     | 1 GiB    | e.g. `4GiB`                  |
+| `NODEDB_DATA_PLANE_CORES` | CPUs - 1 | number of Data Plane threads |
+| `NODEDB_LOG_FORMAT`       | `text`   | `text` or `json`             |
 
 Set them under `environment:` in `docker-compose.yml` or pass with `-e` to `docker run`.
 
@@ -220,6 +220,9 @@ memory_limit = "4GiB"
 data_plane_cores = 4
 max_connections = 1024
 log_format = "text"               # "text" or "json"
+raft_ready_timeout_ms = 30000     # Max wait for raft metadata group readiness at boot
+                                  # (default 30s; raise for large WAL replays / big
+                                  # migrations, e.g. 300000)
 
 [server.ports]
 native = 6433                     # Always-on protocols have defaults
@@ -272,18 +275,18 @@ port named — the server never comes up missing a protocol.
 
 **Checkpoint & WAL settings:**
 
-| Config field                    | Environment variable              | Default |
-| -------------------------------- | ---------------------------------- | ------- |
-| `checkpoint.interval_secs`       | `NODEDB_CHECKPOINT_INTERVAL_SECS`  | `300`   |
-| `checkpoint.wal_segment_target_mb` | `NODEDB_WAL_SEGMENT_TARGET_MB`   | `64`    |
+| Config field                       | Environment variable              | Default |
+| ---------------------------------- | --------------------------------- | ------- |
+| `checkpoint.interval_secs`         | `NODEDB_CHECKPOINT_INTERVAL_SECS` | `300`   |
+| `checkpoint.wal_segment_target_mb` | `NODEDB_WAL_SEGMENT_TARGET_MB`    | `64`    |
 
 **Timeseries memtable settings:**
 
-| Config field                              | Environment variable                   | Default |
-| ----------------------------------------- | -------------------------------------- | ------- |
-| `tuning.timeseries.memtable_budget_bytes` | `NODEDB_TS_MEMTABLE_BUDGET_BYTES`      | `67108864` (64 MiB) |
+| Config field                                  | Environment variable                  | Default             |
+| --------------------------------------------- | ------------------------------------- | ------------------- |
+| `tuning.timeseries.memtable_budget_bytes`     | `NODEDB_TS_MEMTABLE_BUDGET_BYTES`     | `67108864` (64 MiB) |
 | `tuning.timeseries.memtable_hard_limit_bytes` | `NODEDB_TS_MEMTABLE_HARD_LIMIT_BYTES` | `83886080` (80 MiB) |
-| `tuning.timeseries.max_tag_cardinality`   | `NODEDB_TS_MAX_TAG_CARDINALITY`        | `100000` |
+| `tuning.timeseries.max_tag_cardinality`       | `NODEDB_TS_MAX_TAG_CARDINALITY`       | `100000`            |
 
 `memtable_budget_bytes` is the soft budget that schedules a flush;
 `memtable_hard_limit_bytes` is the ceiling that forces one before the next

--- a/nodedb/src/bootstrap/cluster_ready.rs
+++ b/nodedb/src/bootstrap/cluster_ready.rs
@@ -33,6 +33,7 @@ pub async fn await_cluster_ready(
     raft_ready_rx: Option<tokio::sync::watch::Receiver<bool>>,
     data_plane_replay_done: Vec<tokio::sync::oneshot::Receiver<()>>,
     gates: ClusterReadyGates,
+    raft_ready_timeout: std::time::Duration,
 ) -> anyhow::Result<()> {
     let ClusterReadyGates {
         raft_gate,
@@ -51,8 +52,7 @@ pub async fn await_cluster_ready(
     // `metadata propose: not leader` because election had not yet
     // completed.
     if let Some(mut ready_rx) = raft_ready_rx {
-        const RAFT_READY_TIMEOUT: Duration = Duration::from_secs(30);
-        match tokio::time::timeout(RAFT_READY_TIMEOUT, ready_rx.wait_for(|v| *v)).await {
+        match tokio::time::timeout(raft_ready_timeout, ready_rx.wait_for(|v| *v)).await {
             Ok(Ok(_)) => {
                 info!("metadata raft group ready — opening client listeners");
             }
@@ -64,10 +64,10 @@ pub async fn await_cluster_ready(
             }
             Err(_) => {
                 raft_gate.fail(format!(
-                    "raft readiness timeout after {RAFT_READY_TIMEOUT:?}"
+                    "raft readiness timeout after {raft_ready_timeout:?}"
                 ));
                 return Err(anyhow::anyhow!(
-                    "raft readiness timeout after {RAFT_READY_TIMEOUT:?} — \
+                    "raft readiness timeout after {raft_ready_timeout:?} — \
                      metadata group failed to apply first entry"
                 ));
             }

--- a/nodedb/src/config/server/section.rs
+++ b/nodedb/src/config/server/section.rs
@@ -71,6 +71,13 @@ pub struct ServerSection {
     #[serde(default)]
     pub log_format: LogFormat,
 
+    /// Boot-time raft metadata group readiness timeout in milliseconds.
+    /// Default 30_000 (30s). Replay of a large raft log (long write bursts,
+    /// big migrations) can exceed 30s — raise this via `raft_ready_timeout_ms`.
+    /// Script/config set: `[server] raft_ready_timeout_ms = 300000`.
+    #[serde(default)]
+    pub raft_ready_timeout_ms: Option<u64>,
+
     /// Per-listener TLS configuration. Lives under `[server.tls]` because
     /// it directly modifies the listeners declared in `[server.ports]`
     /// (per-protocol toggles + cert paths). When absent, every listener
@@ -126,6 +133,7 @@ impl Default for ServerSection {
             memory_limit: default_memory_limit(),
             max_connections: default_max_connections(),
             log_format: LogFormat::Text,
+            raft_ready_timeout_ms: None,
             tls: None,
             single_node_calvin: default_single_node_calvin(),
             native_crash_dumps: false,

--- a/nodedb/src/main.rs
+++ b/nodedb/src/main.rs
@@ -243,6 +243,9 @@ async fn server_main() -> anyhow::Result<()> {
             health_loop_gate,
             gateway_enable_gate,
         },
+        std::time::Duration::from_millis(
+            config.server.raft_ready_timeout_ms.unwrap_or(30_000),
+        ),
     )
     .await?;
 


### PR DESCRIPTION
## Bug Description

raft readiness timeout is hardcoded to 30s — large replay wedges the node

## Steps to Reproduce

1. Build up a raft log >150k entries (long write bursts / big migration).
2. Restart node.
3. `await_cluster_ready` uses `RAFT_READY_TIMEOUT = Duration::from_secs(30)` (nodedb/src/bootstrap/cluster_ready.rs:54) while the replay path allows 300s.
4. Replay >30s → `raft_gate.fail("raft readiness timeout after 30s")` → ReadyGate Failed → process alive, all ports dead (deadlock).

## Expected Behavior

Node finishes replay and becomes ready regardless of replay duration; operator can raise the timeout for large logs.

## Actual Behavior

Boot fails after 30s with no way to override; node deadlocks (process alive, ports dead) until force-stop + wipe.

## Environment

- 2026-08-26: rebuild with 446k-entry replay → 2 boots failed exactly this way. Node unreachable until force-stop + wipe.
- OS: Debian (LXC), nodedb 0.5.0

## Proposed Fix

New `[server] raft_ready_timeout_ms` config key (Option<u64>, default 30_000 = unchanged behaviour). Passed through `main.rs` → `await_cluster_ready`. Config: `raft_ready_timeout_ms = 300000`.

Files: section.rs, cluster_ready.rs, main.rs. cargo check clean.

Closes #253
