### PR TITLE
fix(pgwire)

### DIFF
--- a/nodedb/src/control/server/pgwire/handler/sql_exec.rs
+++ b/nodedb/src/control/server/pgwire/handler/sql_exec.rs
@@ -43,10 +43,30 @@ impl NodeDbPgHandler {
                     .await
             }
             _ => {
+                let total = statements.len();
                 let mut all = Vec::new();
                 for stmt in statements {
                     let mut resp = self.execute_single_sql(identity, session_id, &stmt).await?;
                     all.append(&mut resp);
+                }
+                // B1 ack reconciliation (2026-08-26): every statement must
+                // produce at least one response. A short count means the
+                // executor silently dropped work (observed: batch 64 → 32
+                // landed, batch 128 → ~25%, no error). Surface it as a hard
+                // error instead of letting the client believe the batch
+                // committed. Defense-in-depth until the propose-path drop
+                // site is traced and fixed.
+                if all.len() < total {
+                    return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+                        "ERROR".to_owned(),
+                        "XX000".to_owned(),
+                        format!(
+                            "incomplete batch: {}/{} statements produced responses — \
+                             some work may have been dropped; retry with a smaller batch",
+                            all.len(),
+                            total,
+                        ),
+                    ))));
                 }
                 Ok(all)
             }


### PR DESCRIPTION
## Bug Description

multi-statement SQL batches silently drop statements beyond 32 (no error)

## Steps to Reproduce

1. Send 64 UPSERT statements in one multi-statement query via pgwire.
2. `SELECT count(*)` → 32 (half landed). 128 statements → ~25% landed.
3. No error returned — client believes the batch committed.

## Expected Behavior

All statements commit, or the client receives a hard error on partial commit.

## Actual Behavior

Silent divergence between what the client thinks committed and what is durable. Measured on 2026-08-26 during code-graph import: 64→50% land, 128→25%, 32→100%.

## Proposed Fix

`sql_exec.rs` multi-statement branch: after executing all statements, if `all.len() < total` → `XX000 "incomplete batch: N/M statements produced responses — some work may have been dropped; retry with a smaller batch"`. Defense-in-depth until the propose-path drop site (vshard channel full backpressure) is traced and fixed.

Files: sql_exec.rs.

Closes #254 