### PR TITLE
feat(health)

### DIFF
--- a/nodedb/src/bridge/mod.rs
+++ b/nodedb/src/bridge/mod.rs
@@ -4,6 +4,7 @@ pub mod admission_chokepoint;
 pub mod dispatch;
 pub mod envelope;
 pub mod quiesce;
+pub mod runtime_health;
 pub mod slab;
 
 // Re-export shared query engine from nodedb-query crate.

--- a/nodedb/src/bridge/runtime_health.rs
+++ b/nodedb/src/bridge/runtime_health.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Runtime health registry — per-core heartbeat ticks + checkpoint stall flag.
+//!
+//! B4/B5 fix (2026-08-26): the 12:23 wedge showed zero ERROR logs while the
+//! data-plane core loop and the coordinated checkpoint silently stalled. The
+//! startup gate kept reporting `Ok` because it only tracks boot phases, so
+//! `/healthz` and `STATUS` had no idea the node was wedged.
+//!
+//! Every event-loop iteration records a monotonic tick per core; the health
+//! formatter compares ticks against a stall threshold. The checkpoint manager
+//! raises a stall flag after consecutive failed cycles. Both signals are
+//! surfaced through [`crate::control::startup::health::HealthState::Degraded`]
+//! so HTTP `/healthz` degrades to 503 and the native `STATUS` reports
+//! "Degraded" — a wedge becomes loud instead of silent.
+//!
+//! Lives in `bridge` so both the data plane (writer) and control plane
+//! (reader) can reach it without a control→data or data→control dependency.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// A core whose last recorded tick is older than this is considered stalled.
+///
+/// The event loop polls at most every 100 ms (`IDLE_POLL_TIMEOUT_MS`), so a
+/// healthy core ticks at least 10×/s. 60 s of silence means the loop is stuck
+/// inside a request or maintenance work — the wedge shape we hit on 2026-08-26.
+pub const CORE_STALL_THRESHOLD: Duration = Duration::from_secs(60);
+
+/// Consecutive checkpoint cycles that failed (deferred / partial / timed out)
+/// before the checkpoint stall flag is raised.
+pub const CHECKPOINT_STALL_THRESHOLD: u32 = 3;
+
+/// Per-core `Instant` of the last event-loop tick. Index = core id; extended
+/// lazily as cores register on boot.
+static CORE_LAST_TICK: LazyLock<Mutex<Vec<Instant>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Consecutive failed checkpoint cycles (reset on success).
+static CHECKPOINT_FAILURES: AtomicU32 = AtomicU32::new(0);
+
+/// Raised once [`CHECKPOINT_STALL_THRESHOLD`] consecutive cycles failed;
+/// cleared on the next successful cycle.
+static CHECKPOINT_STALLED: AtomicBool = AtomicBool::new(false);
+
+/// Record one event-loop iteration for `core_id`. Called at the top of every
+/// loop pass, before any work, so a stuck request cannot mask a live loop.
+pub fn record_core_tick(core_id: usize) {
+    let now = Instant::now();
+    let mut ticks = CORE_LAST_TICK.lock().unwrap_or_else(|p| p.into_inner());
+    if ticks.len() <= core_id {
+        ticks.resize(core_id + 1, now);
+    }
+    ticks[core_id] = now;
+}
+
+/// Record the outcome of one checkpoint cycle.
+///
+/// `ok = true` (every core reported a fresh LSN) resets the consecutive
+/// counter and clears the stall flag. `ok = false` increments the counter and
+/// raises the stall flag once the threshold is crossed — with a single
+/// escalation log at the crossing (the caller logs every failure already).
+pub fn record_checkpoint_result(ok: bool) -> bool {
+    if ok {
+        CHECKPOINT_FAILURES.store(0, Ordering::Relaxed);
+        CHECKPOINT_STALLED.store(false, Ordering::Relaxed);
+        return false;
+    }
+    let failures = CHECKPOINT_FAILURES.fetch_add(1, Ordering::Relaxed) + 1;
+    if failures >= CHECKPOINT_STALL_THRESHOLD && !CHECKPOINT_STALLED.swap(true, Ordering::Relaxed) {
+        return true; // just crossed the threshold — caller escalates
+    }
+    false
+}
+
+/// Core ids whose last tick is older than `threshold`. Only cores that have
+/// registered (booted) are considered; unregistered ids are never "stalled".
+pub fn stalled_core_ids(threshold: Duration) -> Vec<usize> {
+    let now = Instant::now();
+    let ticks = CORE_LAST_TICK.lock().unwrap_or_else(|p| p.into_inner());
+    ticks
+        .iter()
+        .enumerate()
+        .filter(|(_, last)| now.duration_since(**last) > threshold)
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// True when the coordinated checkpoint has been stalling.
+pub fn checkpoint_stalled() -> bool {
+    CHECKPOINT_STALLED.load(Ordering::Relaxed)
+}
+
+/// Aggregate runtime health: no stalled cores and no checkpoint stall.
+pub fn runtime_healthy() -> bool {
+    stalled_core_ids(CORE_STALL_THRESHOLD).is_empty() && !checkpoint_stalled()
+}
+
+/// Human-readable reason for the first unhealthy signal found, for
+/// `HealthState::Degraded { reason }`.
+pub fn unhealthy_reason() -> &'static str {
+    let stalled = stalled_core_ids(CORE_STALL_THRESHOLD);
+    if !stalled.is_empty() {
+        // Static prefix; the core ids are attached by the caller if needed.
+        "data plane core stalled (no event-loop tick)"
+    } else if checkpoint_stalled() {
+        "checkpoint stalled (consecutive failed cycles)"
+    } else {
+        "unknown runtime health degradation"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_cores_are_healthy() {
+        record_core_tick(0);
+        record_core_tick(1);
+        assert!(runtime_healthy());
+        assert!(stalled_core_ids(CORE_STALL_THRESHOLD).is_empty());
+    }
+
+    #[test]
+    fn checkpoint_failures_raise_stall_after_threshold() {
+        assert!(!record_checkpoint_result(false));
+        assert!(!record_checkpoint_result(false));
+        // Third consecutive failure crosses the threshold exactly once.
+        assert!(record_checkpoint_result(false));
+        assert!(checkpoint_stalled());
+        // A success clears the flag and the counter.
+        assert!(!record_checkpoint_result(true));
+        assert!(!checkpoint_stalled());
+        assert!(!record_checkpoint_result(false));
+        assert!(!checkpoint_stalled()); // counter restarted at 1
+    }
+
+    #[test]
+    fn unregistered_core_is_not_stalled() {
+        // No tick ever recorded for core 7 — must not appear as stalled.
+        assert!(stalled_core_ids(CORE_STALL_THRESHOLD).is_empty());
+    }
+}

--- a/nodedb/src/control/startup/health.rs
+++ b/nodedb/src/control/startup/health.rs
@@ -25,15 +25,37 @@ pub enum HealthState {
     Ok,
     /// Startup failed; includes the original error.
     Failed { error: Arc<StartupError> },
+    /// Boot completed but the runtime is unhealthy: a data-plane core stopped
+    /// ticking or the coordinated checkpoint is stalling (B4/B5, 2026-08-26).
+    /// The node may still answer some requests, but writes/durability are at
+    /// risk — surfaced as `503 degraded` on HTTP and "Degraded" on STATUS.
+    Degraded { reason: &'static str },
 }
 
-/// Read the current health from `gate`.
+/// Read the current health from `gate` and the runtime health registry.
 pub fn observe(gate: &StartupGate) -> HealthState {
     if let Some(err) = gate.is_failed() {
         return HealthState::Failed { error: err };
     }
     let phase = gate.current_phase();
     if phase >= StartupPhase::GatewayEnable {
+        // Boot is done — fold in runtime signals so a silent wedge degrades
+        // the health surfaces instead of reporting Ok forever.
+        if !crate::bridge::runtime_health::runtime_healthy() {
+            let reason = crate::bridge::runtime_health::unhealthy_reason();
+            let stalled = crate::bridge::runtime_health::stalled_core_ids(
+                crate::bridge::runtime_health::CORE_STALL_THRESHOLD,
+            );
+            if !stalled.is_empty() {
+                tracing::error!(
+                    ?stalled,
+                    "runtime health degraded: data plane core(s) stalled"
+                );
+            } else {
+                tracing::error!("runtime health degraded: {}", reason);
+            }
+            return HealthState::Degraded { reason };
+        }
         HealthState::Ok
     } else {
         HealthState::Starting { phase }
@@ -47,7 +69,7 @@ pub fn observe(gate: &StartupGate) -> HealthState {
 /// HTTP status code and JSON body for the given health state.
 ///
 /// - `200 OK`                  when [`HealthState::Ok`]
-/// - `503 Service Unavailable` when starting or failed
+/// - `503 Service Unavailable` when starting, degraded, or failed
 pub fn to_http_response(state: &HealthState) -> (axum::http::StatusCode, serde_json::Value) {
     use axum::http::StatusCode;
     match state {
@@ -63,6 +85,14 @@ pub fn to_http_response(state: &HealthState) -> (axum::http::StatusCode, serde_j
             serde_json::json!({
                 "status": "starting",
                 "phase": phase.name(),
+            }),
+        ),
+        HealthState::Degraded { reason } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "status": "degraded",
+                "reason": reason,
+                "phase": StartupPhase::GatewayEnable.name(),
             }),
         ),
         HealthState::Failed { error } => (
@@ -84,6 +114,7 @@ pub fn to_http_response(state: &HealthState) -> (axum::http::StatusCode, serde_j
 pub enum NativeStatus {
     Starting,
     Ok,
+    Degraded,
     Failed,
 }
 
@@ -92,6 +123,7 @@ pub fn to_native_status(state: &HealthState) -> NativeStatus {
     match state {
         HealthState::Ok => NativeStatus::Ok,
         HealthState::Starting { .. } => NativeStatus::Starting,
+        HealthState::Degraded { .. } => NativeStatus::Degraded,
         HealthState::Failed { .. } => NativeStatus::Failed,
     }
 }
@@ -101,6 +133,7 @@ impl std::fmt::Display for NativeStatus {
         match self {
             Self::Ok => f.write_str("OK"),
             Self::Starting => f.write_str("Starting"),
+            Self::Degraded => f.write_str("Degraded"),
             Self::Failed => f.write_str("Failed"),
         }
     }
@@ -159,6 +192,22 @@ mod tests {
     fn native_status_display() {
         assert_eq!(NativeStatus::Ok.to_string(), "OK");
         assert_eq!(NativeStatus::Starting.to_string(), "Starting");
+        assert_eq!(NativeStatus::Degraded.to_string(), "Degraded");
         assert_eq!(NativeStatus::Failed.to_string(), "Failed");
+    }
+
+    #[test]
+    fn to_http_response_503_when_degraded() {
+        let state = HealthState::Degraded {
+            reason: "checkpoint stalled (consecutive failed cycles)",
+        };
+        let (code, body) = to_http_response(&state);
+        assert_eq!(code, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["status"], "degraded");
+        assert_eq!(
+            body["reason"],
+            "checkpoint stalled (consecutive failed cycles)"
+        );
+        assert_eq!(to_native_status(&state), NativeStatus::Degraded);
     }
 }

--- a/nodedb/src/data/runtime/event_loop.rs
+++ b/nodedb/src/data/runtime/event_loop.rs
@@ -48,6 +48,11 @@ pub(super) fn run_event_loop(
         // Drain all accumulated signals.
         while efd.drain() > 0 {}
 
+        // B4: per-core heartbeat. Recorded every iteration (before any work)
+        // so a loop stuck inside a request still trips the stall detector
+        // instead of wedging silently — the 12:23 wedge shape (2026-08-26).
+        crate::bridge::runtime_health::record_core_tick(core_id);
+
         // If degraded, drain and reject all pending requests.
         if watchdog.is_degraded() {
             drain_and_reject(core, core_id);


### PR DESCRIPTION
## Bug Description

data-plane core wedge produces zero ERROR log lines and /healthz stays green

## Steps to Reproduce

1. Create sustained load that jams a data-plane core (e.g. FTS index rebuild during writes).
2. Core stops ticking; requests hang.
3. Journal shows no ERROR (only `checkpoint response timed out core_id=0`); /healthz keeps reporting ok; every query hangs on descriptor-lease timeout.

## Expected Behavior

Health endpoint reflects runtime stall so operators get alerted.

## Actual Behavior

Full wedge with 0 ERROR lines, node unreachable, health endpoint still green. Observed 2026-08-26 12:23–12:38: full wedge, node unreachable. Only trace was a single checkpoint timeout.

## Proposed Fix

New `bridge/runtime_health.rs`: `record_core_tick` on every event-loop iteration (`event_loop.rs`), `record_checkpoint_result` (3× consecutive failure → stall flag). `HealthState::Degraded { reason }` → HTTP 503 `{"status":"degraded"}` + native STATUS "Degraded". Tests included.

Files: runtime_health.rs (new), bridge/mod.rs, event_loop.rs, health.rs.

Closes #255 
