### PR TITLE
fix(control)

### DIFF
--- a/nodedb/src/control/catalog_entry/descriptor_validate.rs
+++ b/nodedb/src/control/catalog_entry/descriptor_validate.rs
@@ -30,6 +30,21 @@ pub fn validate(
                 .get_collection(stored.database_id, stored.tenant_id, &stored.name)
                 .ok()
                 .flatten();
+            // B10 (2026-08-26): a DROP (deactivate) retains the collection row
+            // and its descriptor_version (is_active=false), so a subsequent
+            // CREATE restarts the lifecycle with the SAME numeric version but
+            // a strictly newer HLC and a byte-different (active) payload.
+            // Comparing versions alone would flag this legit recreate as an
+            // anomaly and wedge the metadata applier permanently on replay.
+            // A newer HLC on a deactivated row is a new lifecycle — apply it.
+            if let Some(current) = &current {
+                if !current.is_active
+                    && stored.descriptor_version == current.descriptor_version
+                    && stored.modification_hlc > current.modification_hlc
+                {
+                    return Ok(ValidationOutcome::Apply);
+                }
+            }
             validate_one(
                 &stored.name,
                 stored.descriptor_version,
@@ -286,6 +301,60 @@ mod tests {
         assert!(matches!(
             validate(&collection_with_version("orders", 4), catalog),
             Ok(ValidationOutcome::Apply)
+        ));
+    }
+
+    #[test]
+    fn validate_allows_recreate_after_deactivate() {
+        // B10 (2026-08-26): DROP retains the row with is_active=false and the
+        // SAME descriptor_version; a later CREATE restarts the lifecycle with
+        // the same numeric version, a newer HLC and a byte-different (active)
+        // payload. Must Apply, not wedge as DescriptorVersionAnomaly.
+        let (store, _tmp) = make_catalog();
+        let catalog = store.catalog();
+        let mut deactivated = StoredCollection::new(1, "orders", "tester");
+        deactivated.descriptor_version = 1;
+        deactivated.is_active = false;
+        deactivated.modification_hlc = nodedb_types::Hlc::new(100, 0);
+        catalog
+            .put_collection(DatabaseId::DEFAULT, &deactivated)
+            .expect("seed deactivated prior");
+
+        let mut recreated = StoredCollection::new(1, "orders", "tester");
+        recreated.descriptor_version = 1;
+        recreated.is_active = true;
+        recreated.modification_hlc = nodedb_types::Hlc::new(200, 0);
+        let entry = CatalogEntry::PutCollection(Box::new(recreated));
+        assert!(
+            matches!(validate(&entry, catalog), Ok(ValidationOutcome::Apply)),
+            "recreate after deactivate must Apply (B10), got: {:?}",
+            validate(&entry, catalog)
+        );
+    }
+
+    #[test]
+    fn validate_treats_stale_recreate_as_already_applied() {
+        // Same version + deactivated row but OLDER HLC = stale replay — the
+        // existing incoming_hlc < current_hlc guard must treat it as applied
+        // (not a new lifecycle, not an anomaly).
+        let (store, _tmp) = make_catalog();
+        let catalog = store.catalog();
+        let mut deactivated = StoredCollection::new(1, "orders", "tester");
+        deactivated.descriptor_version = 1;
+        deactivated.is_active = false;
+        deactivated.modification_hlc = nodedb_types::Hlc::new(200, 0);
+        catalog
+            .put_collection(DatabaseId::DEFAULT, &deactivated)
+            .expect("seed deactivated prior");
+
+        let mut recreated = StoredCollection::new(1, "orders", "tester");
+        recreated.descriptor_version = 1;
+        recreated.is_active = true;
+        recreated.modification_hlc = nodedb_types::Hlc::new(100, 0);
+        let entry = CatalogEntry::PutCollection(Box::new(recreated));
+        assert!(matches!(
+            validate(&entry, catalog),
+            Ok(ValidationOutcome::AlreadyApplied)
         ));
     }
 

--- a/nodedb/src/control/catalog_entry/descriptor_validate.rs
+++ b/nodedb/src/control/catalog_entry/descriptor_validate.rs
@@ -37,10 +37,18 @@ pub fn validate(
             // Comparing versions alone would flag this legit recreate as an
             // anomaly and wedge the metadata applier permanently on replay.
             // A newer HLC on a deactivated row is a new lifecycle — apply it.
+            // `>=` (not `>`) because full-log replay re-delivers the exact
+            // same frozen entry: the stored HLC equals the persisted row's
+            // HLC (frozen at propose, applied once, row later deactivated).
+            // Strict `>` would treat that idempotent re-delivery as a
+            // divergence and wedge (observed: 26298 'bugtest', backup 17:20
+            // + restart replay). Equal-HLC + deactivated + same version is
+            // still a recreate, never a stale anomaly; older HLC stays
+            // AlreadyApplied via the existing guard below.
             if let Some(current) = &current {
                 if !current.is_active
                     && stored.descriptor_version == current.descriptor_version
-                    && stored.modification_hlc > current.modification_hlc
+                    && stored.modification_hlc >= current.modification_hlc
                 {
                     return Ok(ValidationOutcome::Apply);
                 }
@@ -333,10 +341,38 @@ mod tests {
     }
 
     #[test]
+    fn validate_allows_recreate_with_equal_hlc_on_full_log_replay() {
+        // B10 replay regression (2026-08-26, live wedge 26298 'bugtest'):
+        // full-log replay re-delivers the exact frozen entry. The persisted
+        // row (created earlier, then DROPPED) carries the SAME HLC as the
+        // stored entry — frozen at propose, applied once, deactivated later,
+        // then the same entry is replayed from the log after a restart.
+        // Equal HLC + deactivated row + same version is still a recreate,
+        // NOT a divergence: must Apply. Strict `>` previously wedged here.
+        let (store, _tmp) = make_catalog();
+        let catalog = store.catalog();
+        let mut deactivated = StoredCollection::new(1, "orders", "tester");
+        deactivated.descriptor_version = 1;
+        deactivated.is_active = false;
+        deactivated.modification_hlc = nodedb_types::Hlc::new(200, 0);
+        catalog
+            .put_collection(DatabaseId::DEFAULT, &deactivated)
+            .expect("seed deactivated prior");
+
+        let mut recreated = StoredCollection::new(1, "orders", "tester");
+        recreated.descriptor_version = 1;
+        recreated.is_active = true;
+        recreated.modification_hlc = nodedb_types::Hlc::new(200, 0);
+        let entry = CatalogEntry::PutCollection(Box::new(recreated));
+        assert!(
+            matches!(validate(&entry, catalog), Ok(ValidationOutcome::Apply)),
+            "equal-HLC recreate on replay must Apply (B10 replay), got: {:?}",
+            validate(&entry, catalog)
+        );
+    }
+
+    #[test]
     fn validate_treats_stale_recreate_as_already_applied() {
-        // Same version + deactivated row but OLDER HLC = stale replay — the
-        // existing incoming_hlc < current_hlc guard must treat it as applied
-        // (not a new lifecycle, not an anomaly).
         let (store, _tmp) = make_catalog();
         let catalog = store.catalog();
         let mut deactivated = StoredCollection::new(1, "orders", "tester");


### PR DESCRIPTION
## Summary

**Root cause: idempotent replay / redelivery.** The same Raft entry is replayed over a state that already contains its mutation (apply → cold backup → restart). On replay `stored.modification_hlc == current.modification_hlc`; the strict `>` condition misclassifies equal HLC as a version-payload conflict instead of a no-op / replay-safe redelivery, firing a false-positive `DescriptorVersionAnomaly`. Relaxed to `>=` (equal HLC on a deactivated row → Apply; older HLC → AlreadyApplied; newer → Apply). 15/15 tests pass.

---
## Bug Description

CREATE COLLECTION after DROP + restart → metadata applier wedges permanently (descriptor version anomaly)

## Steps to Reproduce

1. `CREATE COLLECTION t`; `DROP COLLECTION t`; `CREATE COLLECTION t` (recreate).
2. Restart the node (cold backup / crash).
3. Replay hits the recreate entry: `descriptor version anomaly for 't': replicated version 1 is inconsistent with local prior 1 (expected 1 or prior+1)`.
4. `classify()` marks it Permanent → watermark halts forever; `/healthz` → `{"reason":"metadata_apply_wedged","status":"failed"}`; operator intervention required.

## Root Cause

DROP (deactivate) retains the collection row with `is_active=false` and its `descriptor_version`. A later CREATE restarts the lifecycle with the SAME numeric version (1), a strictly newer HLC, and a byte-different (active) payload. `descriptor_validate::validate_one` compares versions alone (`carried==prior` + payload differs → anomaly), never consulting HLC or the deactivated flag.

## Observed

2026-08-26 live: verify scripts used a temp `bugtest` collection (CREATE → DROP → CREATE → DROP) before a cold-backup restart; replay wedged at raft_index 26298, watermark halted at 26297, node served /healthz failed. Crash test `crash_metadata_applier_wedge.rs` covers the drain-race variant (542e7473c) but NOT recreate-after-drop.

The live case is an **idempotent replay / redelivery**: the same Raft entry was replayed over a state that already contained its mutation (entry applied live → cold backup → restart). On replay, `stored.modification_hlc` (frozen in the raft log) **equals** `current.modification_hlc` (the same mutation already in state). The strict `>` condition misclassified equal HLC as a version-payload conflict instead of a no-op / replay-safe redelivery, firing a false-positive anomaly (`carried==prior` + payload differs because stored is active while current is deactivated after the final DROP).

## Proposed Fix

1. `descriptor_validate.rs` PutCollection: if current row is `!is_active` && same descriptor_version && strictly newer HLC → `Apply` (new lifecycle). Older HLC stays `AlreadyApplied` via existing guard.
2. Follow-up from live replay: relaxed to `>=` — exact-equal HLC on a deactivated row is idempotent re-delivery, not divergence; strictly older HLC still yields `AlreadyApplied`. Dedicated test `validate_allows_recreate_with_equal_hlc_on_full_log_replay`.

Unit tests: `validate_allows_recreate_after_deactivate`, `validate_treats_stale_recreate_as_already_applied`, `validate_allows_recreate_with_equal_hlc_on_full_log_replay`. 15/15 descriptor_validate tests pass.

Closes #257
