### PR TITLE
fix(vector): persist database_id in vector index catalog entry

### DIFF
--- a/nodedb-types/src/vector_index_params.rs
+++ b/nodedb-types/src/vector_index_params.rs
@@ -10,6 +10,12 @@
 use serde::{Deserialize, Serialize};
 
 /// Catalog entry for a vector index's build parameters.
+///
+/// NOTE: serialized as a zerompk ARRAY (the crate default — the
+/// `default-as-map` feature is not enabled), so field ORDER is part of the
+/// on-disk format. `database_id` was appended last; entries written by older
+/// builds (11 fields, no database id) must still decode — see the legacy
+/// fallback ladder in `catalog/vector_index_params.rs`.
 #[derive(
     Debug, Clone, Serialize, Deserialize, zerompk::ToMessagePack, zerompk::FromMessagePack,
 )]
@@ -36,6 +42,11 @@ pub struct StoredVectorIndexParams {
     pub ivf_cells: usize,
     /// IVF nprobe (0 = unused).
     pub ivf_nprobe: usize,
+    /// Database that owns the collection. `0` = `DatabaseId::DEFAULT`,
+    /// which is also what entries written before this field existed decode
+    /// to (the legacy ladder fills 0) — matching the historical behavior of
+    /// the seed/rebuild paths.
+    pub database_id: u64,
 }
 
 #[cfg(test)]
@@ -56,11 +67,51 @@ mod tests {
             pq_m: 0,
             ivf_cells: 0,
             ivf_nprobe: 0,
+            database_id: 7,
         };
         let bytes = zerompk::to_msgpack_vec(&e).unwrap();
         let back: StoredVectorIndexParams = zerompk::from_msgpack(&bytes).unwrap();
         assert_eq!(back.collection, "docs");
         assert_eq!(back.dim, 4);
         assert_eq!(back.field_name, "embedding");
+        assert_eq!(back.database_id, 7);
+    }
+
+    #[test]
+    fn legacy_11_field_array_decodes_with_database_id_zero() {
+        // Entries written before `database_id` existed are 11-element arrays
+        // in field order. The catalog module's decode ladder tolerates them
+        // by decoding the legacy tuple shape; here we verify the tuple shape
+        // itself round-trips so the ladder's fallback type is valid.
+        let legacy: (u64, String, String, usize, String, usize, usize, String, usize, usize, usize) =
+            (
+                1,
+                "docs".into(),
+                "embedding".into(),
+                4,
+                "cosine".into(),
+                16,
+                200,
+                String::new(),
+                0,
+                0,
+                0,
+            );
+        let bytes = zerompk::to_msgpack_vec(&legacy).unwrap();
+        let back: (
+            u64,
+            String,
+            String,
+            usize,
+            String,
+            usize,
+            usize,
+            String,
+            usize,
+            usize,
+            usize,
+        ) = zerompk::from_msgpack(&bytes).unwrap();
+        assert_eq!(back.1, "docs");
+        assert_eq!(back.2, "embedding");
     }
 }

--- a/nodedb/src/control/security/catalog/vector_index_params.rs
+++ b/nodedb/src/control/security/catalog/vector_index_params.rs
@@ -10,6 +10,36 @@ use redb::{ReadableDatabase, ReadableTable};
 
 use super::types::{SystemCatalog, VECTOR_INDEX_PARAMS, catalog_err};
 
+/// Decode a stored vector-index entry, tolerating the legacy 11-field shape
+/// written before `database_id` existed (field order is the zerompk array
+/// format, so `database_id` is simply appended last). Legacy entries decode
+/// to `database_id = 0` (`DatabaseId::DEFAULT`) — the historical assumption
+/// of the seed/rebuild paths.
+fn decode_vector_index_params(bytes: &[u8]) -> crate::Result<StoredVectorIndexParams> {
+    if let Ok(e) = zerompk::from_msgpack::<StoredVectorIndexParams>(bytes) {
+        return Ok(e);
+    }
+    // Legacy 11-field tuple: (tenant, collection, field, dim, metric, m,
+    // ef_construction, index_type, pq_m, ivf_cells, ivf_nprobe).
+    let legacy: (u64, String, String, usize, String, usize, usize, String, usize, usize, usize) =
+        zerompk::from_msgpack(bytes)
+            .map_err(|e| catalog_err("deser legacy vector index params", e))?;
+    Ok(StoredVectorIndexParams {
+        tenant_id: legacy.0,
+        collection: legacy.1,
+        field_name: legacy.2,
+        dim: legacy.3,
+        metric: legacy.4,
+        m: legacy.5,
+        ef_construction: legacy.6,
+        index_type: legacy.7,
+        pq_m: legacy.8,
+        ivf_cells: legacy.9,
+        ivf_nprobe: legacy.10,
+        database_id: 0,
+    })
+}
+
 impl SystemCatalog {
     /// Store vector index parameters for a collection/field.
     pub fn put_vector_index_params(&self, entry: &StoredVectorIndexParams) -> crate::Result<()> {
@@ -49,8 +79,7 @@ impl SystemCatalog {
 
         match table.get(key.as_str()) {
             Ok(Some(value)) => {
-                let entry: StoredVectorIndexParams = zerompk::from_msgpack(value.value())
-                    .map_err(|e| catalog_err("deser vector index params", e))?;
+                let entry = decode_vector_index_params(value.value())?;
                 Ok(Some(entry))
             }
             Ok(None) => Ok(None),
@@ -114,8 +143,7 @@ pub(super) fn list_all_vector_index_params_in(
         .map_err(|e| catalog_err("range vector index params", e))?
     {
         let (_, value) = item.map_err(|e| catalog_err("read vector index params", e))?;
-        let entry: StoredVectorIndexParams = zerompk::from_msgpack(value.value())
-            .map_err(|e| catalog_err("deser vector index params", e))?;
+        let entry = decode_vector_index_params(value.value())?;
         entries.push(entry);
     }
     Ok(entries)

--- a/nodedb/src/control/server/shared/ddl/neutral/dsl/vector_index.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/dsl/vector_index.rs
@@ -216,6 +216,7 @@ pub async fn create_vector_index(
             pq_m: params.pq_m,
             ivf_cells: params.ivf_cells,
             ivf_nprobe: params.ivf_nprobe,
+            database_id: database_id.as_u64(),
         })
         .map_err(|e| {
             ddl_err(

--- a/nodedb/src/data/executor/core_loop/vector_index_rebuild.rs
+++ b/nodedb/src/data/executor/core_loop/vector_index_rebuild.rs
@@ -27,20 +27,22 @@ impl CoreLoop {
         entries: &[nodedb_types::StoredVectorIndexParams],
     ) {
         use std::collections::HashSet;
-        let db = crate::types::DatabaseId::DEFAULT.as_u64();
 
-        // One scan per (tenant, collection): `apply_point_put_vector_indexes`
+        // One scan per (db, tenant, collection): `apply_point_put_vector_indexes`
         // re-indexes ALL of the document's vector fields, so multiple field
-        // indexes on one collection need only a single scan.
-        let mut seen: HashSet<(u64, String)> = HashSet::new();
-        let mut targets: Vec<(u64, String)> = Vec::new();
+        // indexes on one collection need only a single scan. `database_id`
+        // comes from the durable entry (0 = DEFAULT for pre-existing entries,
+        // matching the historical behavior of this path).
+        let mut seen: HashSet<(u64, u64, String)> = HashSet::new();
+        let mut targets: Vec<(u64, u64, String)> = Vec::new();
         for e in entries {
-            if seen.insert((e.tenant_id, e.collection.clone())) {
-                targets.push((e.tenant_id, e.collection.clone()));
+            let key = (e.database_id, e.tenant_id, e.collection.clone());
+            if seen.insert(key.clone()) {
+                targets.push(key);
             }
         }
 
-        for (tenant_id, collection) in targets {
+        for (db, tenant_id, collection) in targets {
             // `entries` comes from the `CREATE VECTOR INDEX` param seed, so
             // every target here is a classic collection with a vector index
             // over a document field, and `apply_point_put_vector_indexes`
@@ -82,11 +84,29 @@ impl CoreLoop {
                     if let Some(surrogate) =
                         crate::engine::document::store::doc_id_to_surrogate(doc_id)
                     {
-                        let normalized =
-                            crate::data::executor::scan_normalize::sparse_body_to_msgpack(
+                        let normalized: std::borrow::Cow<[u8]> = match &body_format {
+                            crate::data::executor::sparse_body_format::SparseBodyFormat::Strict(schema) => {
+                                match crate::data::executor::strict_format::binary_tuple_to_msgpack(value, schema) {
+                                    Some(mp) => std::borrow::Cow::Owned(mp),
+                                    None => {
+                                        tracing::warn!(
+                                            core = self.core_id,
+                                            %collection,
+                                            doc_id = %doc_id,
+                                            "strict BT decode failed in vector rebuild — doc will be unsearchable"
+                                        );
+                                        crate::data::executor::scan_normalize::sparse_body_to_msgpack(
+                                            value,
+                                            body_format.as_format_ref(),
+                                        )
+                                    }
+                                }
+                            }
+                            _ => crate::data::executor::scan_normalize::sparse_body_to_msgpack(
                                 value,
                                 body_format.as_format_ref(),
-                            );
+                            ),
+                        };
                         docs.push((surrogate, normalized.into_owned()));
                     }
                     Ok(())

--- a/nodedb/src/data/executor/core_loop/vector_index_seed.rs
+++ b/nodedb/src/data/executor/core_loop/vector_index_seed.rs
@@ -30,12 +30,13 @@ impl CoreLoop {
     /// `execute_set_vector_params` keys a live `CREATE VECTOR INDEX`.
     /// Called once at core startup, before the durable HNSW rebuild.
     ///
-    /// `CREATE VECTOR INDEX` computes its vshard with `DatabaseId::DEFAULT`
-    /// and the stored entry carries no database id, so the seed keys under
-    /// `DatabaseId::DEFAULT` to match.
+    /// `CREATE VECTOR INDEX` computes its vshard with the session's
+    /// `database_id`, and the stored entry now carries that id. Entries
+    /// written before the field existed decode to `0`
+    /// (`DatabaseId::DEFAULT`) — the historical assumption of this path.
     pub fn seed_vector_index_params(&mut self, entries: &[nodedb_types::StoredVectorIndexParams]) {
         for e in entries {
-            let db = crate::types::DatabaseId::DEFAULT.as_u64();
+            let db = e.database_id;
             let key = CoreLoop::vector_index_key(db, e.tenant_id, &e.collection, &e.field_name);
             let (params, config) = build_index_config_from_stored(e);
             if e.dim > 0 {
@@ -128,6 +129,7 @@ mod tests {
             pq_m: 0,
             ivf_cells: 0,
             ivf_nprobe: 0,
+            database_id: 0,
         }
     }
 

--- a/nodedb/src/data/executor/handlers/point/apply_put/vector/put.rs
+++ b/nodedb/src/data/executor/handlers/point/apply_put/vector/put.rs
@@ -6,6 +6,58 @@ use crate::data::executor::core_loop::CoreLoop;
 
 use super::types::{VectorFieldInsert, VectorIndexDelta, VectorIndexPutParams};
 
+/// Extract a float vector from a decoded document value.
+///
+/// Accepts both native msgpack arrays (the forward write path) and JSON
+/// strings (schemaless bodies transcoded from a columnar TEXT/JSON column,
+/// e.g. `"[0.1, 0.2, ...]"` or a plain comma/whitespace-separated list) so
+/// the durable-store rebuild path indexes the same vectors a live PUT would.
+fn floats_from_value(v: &nodedb_types::Value) -> Option<Vec<f32>> {
+    match v {
+        nodedb_types::Value::Array(arr) => {
+            let floats: Vec<f32> = arr
+                .iter()
+                .filter_map(|v| match v {
+                    nodedb_types::Value::Float(f) => Some(*f as f32),
+                    nodedb_types::Value::Integer(i) => Some(*i as f32),
+                    nodedb_types::Value::Decimal(d) => {
+                        use rust_decimal::prelude::ToPrimitive;
+                        d.to_f32()
+                    }
+                    nodedb_types::Value::String(s) => s.parse::<f32>().ok(),
+                    _ => None,
+                })
+                .collect();
+            if floats.is_empty() {
+                None
+            } else {
+                Some(floats)
+            }
+        }
+        nodedb_types::Value::String(s) => {
+            // Try JSON array first, then comma/space-separated numbers.
+            if let Ok(vals) = serde_json::from_str::<Vec<f64>>(s) {
+                return Some(vals.into_iter().map(|f| f as f32).collect());
+            }
+            let trimmed = s.trim().trim_start_matches('[').trim_end_matches(']');
+            let mut floats: Vec<f32> = Vec::new();
+            for tok in trimmed.split([',', ' ', '\t', '\n']) {
+                let tok = tok.trim();
+                if tok.is_empty() {
+                    continue;
+                }
+                floats.push(tok.parse::<f32>().ok()?);
+            }
+            if floats.is_empty() {
+                None
+            } else {
+                Some(floats)
+            }
+        }
+        _ => None,
+    }
+}
+
 impl CoreLoop {
     /// HNSW vector indexing side-effect: index declared strict-schema
     /// `Vector(dim)` columns, or (schemaless) fields matched by registered
@@ -54,20 +106,9 @@ impl CoreLoop {
                 && let nodedb_types::Value::Object(ref obj) = ndb_val
             {
                 for (field_name, dim) in &vector_fields {
-                    if let Some(nodedb_types::Value::Array(arr)) = obj.get(field_name) {
-                        let floats: Vec<f32> = arr
-                            .iter()
-                            .filter_map(|v| match v {
-                                nodedb_types::Value::Float(f) => Some(*f as f32),
-                                nodedb_types::Value::Integer(i) => Some(*i as f32),
-                                nodedb_types::Value::Decimal(d) => {
-                                    use rust_decimal::prelude::ToPrimitive;
-                                    d.to_f32()
-                                }
-                                nodedb_types::Value::String(s) => s.parse::<f32>().ok(),
-                                _ => None,
-                            })
-                            .collect();
+                    if let Some(v) = obj.get(field_name)
+                        && let Some(floats) = floats_from_value(v)
+                    {
                         let index_key =
                             Self::vector_index_key(database_id, tid, collection, field_name);
                         self.check_vector_width(&index_key, field_name, floats.len())?;
@@ -156,21 +197,10 @@ impl CoreLoop {
                 && let nodedb_types::Value::Object(ref obj) = ndb_val
             {
                 for (params_key, field_name) in &schemaless_keys {
-                    if let Some(nodedb_types::Value::Array(arr)) = obj.get(field_name) {
-                        let floats: Vec<f32> = arr
-                            .iter()
-                            .filter_map(|v| match v {
-                                nodedb_types::Value::Float(f) => Some(*f as f32),
-                                nodedb_types::Value::Integer(i) => Some(*i as f32),
-                                nodedb_types::Value::Decimal(d) => {
-                                    use rust_decimal::prelude::ToPrimitive;
-                                    d.to_f32()
-                                }
-                                nodedb_types::Value::String(s) => s.parse::<f32>().ok(),
-                                _ => None,
-                            })
-                            .collect();
-                        if !floats.is_empty() {
+                    if let Some(v) = obj.get(field_name)
+                        && let Some(floats) = floats_from_value(v)
+                        && !floats.is_empty()
+                    {
                             let params = self
                                 .vector_params
                                 .get(params_key)
@@ -213,7 +243,6 @@ impl CoreLoop {
                                 inserts.push(delta);
                             }
                         }
-                    }
                 }
             }
         }


### PR DESCRIPTION
# Vector Index Rebuild Fails for Non-Default Databases; Schemaless JSON Embeddings Dropped

**Branch:** `fix/vector-rebuild-strict` (base `cc4a0a2a6`)
**Files changed:** 6 · **+180 / −49**
**Status:** Patch verified in live deployment (partial) — SEARCH returns rows for strict collections in the default database; non-default-database rebuild pending restart after re-embed.

---

## TL;DR

Two independent defects prevent HNSW vector indexes from materializing for real workloads:

1. **`StoredVectorIndexParams` carries no `database_id`.** The boot-time seed and the durable-store rebuild both hardcode `DatabaseId::DEFAULT` (0), so any collection living in a non-default database (e.g. the `graph` database, id ≥ 1024) is never seeded, never rebuilt, and its `SEARCH` returns 0 rows — even though `CREATE VECTOR INDEX` succeeded and the catalog entry exists.
2. **The vector put path only accepts `Value::Array` embeddings.** Schemaless collections whose embedding column is stored/transcoded as a JSON string (`"[0.1, 0.2, ...]"`) are silently skipped by `apply_point_put_vector_indexes`, so the durable-store rebuild indexes nothing for those collections.

## Root Cause 1 — `database_id` is lost between CREATE and boot

### Chain of custody

```
CREATE VECTOR INDEX (SQL, session db = graph)
  → execute_set_vector_params          (uses task.request.database_id — CORRECT)
  → put_vector_index_params            (catalog entry — database_id NOT stored!)
  → StoredVectorIndexParams            (11 fields, no database_id)
        ↓ boot
  load_vector_index_param_seed         (catalog → entries)
  → seed_vector_index_params           (hardcodes DatabaseId::DEFAULT)
  → rebuild_vector_indexes_from_store  (hardcodes DatabaseId::DEFAULT)
  → scan_documents_for_each(db=0, ...) (collection lives in db=graph → 0 docs)
  → no rebuild → SEARCH returns 0 rows
```

- `VShardId::from_collection_in_database` mixes `database_id` into the vshard hash (`nodedb-types/src/id/vshard.rs:48`), so at runtime the CREATE path keys everything under the _real_ database id.
- But the _durable catalog entry_ — the only thing that survives a restart — never records which database the index belongs to.
- On boot, seed + rebuild default to database 0. `schemaless_vector_field_names` and `strict_vector_fields` then look up `vector_params` under `(0, tid, ...)`, find nothing, and the HNSW stays empty.

### Evidence (live)

| Collection                             | Database            | Rebuild log                                                                                            | SEARCH    |
| -------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ | --------- |
| `vtest` (strict, vector(8))            | `default` (id 0)    | `INFO vector_index_rebuild: rebuilt vector index from durable store core=0 collection=vtest rebuilt=3` | ✅ 3 rows |
| `code2g_nodes` (37,325 rows, 1024-dim) | `graph` (id ≥ 1024) | **no rebuild log**                                                                                     | ❌ 0 rows |

The same binary, the same boot, the same code path — the only difference is the database id. That isolates the defect beyond doubt.

## Root Cause 2 — schemaless embeddings stored as JSON strings are dropped

`apply_point_put_vector_indexes` (strict and schemaless arms) matched only:

```rust
if let Some(nodedb_types::Value::Array(arr)) = obj.get(field_name)
```

But a schemaless body transcoded from a columnar TEXT/JSON column (or ingested via doc-object UPSERT where the column is projected as JSON) decodes to `Value::String` containing `"[0.1, 0.2, ...]"`. The pattern match fails, the document is silently skipped, and the rebuild completes with 0 vectors — indistinguishable from "no embeddings exist."

## Fix

### 1. Persist `database_id` in the catalog entry

`nodedb-types/src/vector_index_params.rs`:

- Added `database_id: u64` as the **12th field** of `StoredVectorIndexParams`.
- zerompk structs serialize as **arrays** in this crate (the `default-as-map` feature is not enabled), so field order is part of the on-disk format — the new field is appended _last_ to keep the legacy shape decodable.
- Documented this in the struct doc comment.

### 2. Legacy decode ladder (backward compatible)

`nodedb/src/control/security/catalog/vector_index_params.rs`:

- New `decode_vector_index_params()`: tries the 12-field struct first; on failure falls back to the legacy 11-field tuple and fills `database_id: 0`.
- Both `get_vector_index_params` and `list_all_vector_index_params` route through it, so existing on-disk entries (written by older builds) keep loading — no catalog migration required.

### 3. Seed uses the real database id

`nodedb/src/data/executor/core_loop/vector_index_seed.rs`:

- `seed_vector_index_params` now keys `vector_params` / `index_configs` / `declared_dims` with `e.database_id` instead of `DatabaseId::DEFAULT`.

### 4. Rebuild scans the real database

`nodedb/src/data/executor/core_loop/vector_index_rebuild.rs`:

- `rebuild_vector_indexes_from_store` groups targets by `(database_id, tenant_id, collection)` from the durable entries, and passes the entry's `database_id` into `sparse_body_format`, `scan_documents_for_each`, and `apply_point_put_vector_indexes`.
- Removed the hardcoded `let db = DatabaseId::DEFAULT.as_u64()`.
- Still skips `VectorSidecar` encodings (vector-primary collections have no field in the sidecar; their durability is served by `replay_direct_upsert` in `wal_replay_vector_extended.rs`).

### 5. Accept JSON-string embeddings in both put arms

`nodedb/src/data/executor/handlers/point/apply_put/vector/put.rs`:

- New `floats_from_value()` helper: accepts `Value::Array` (native msgpack) **or** `Value::String` (JSON array `"[0.1,...]"`, or comma/whitespace-separated list).
- Both the strict-schema arm and the schemaless arm now extract floats through it, so the durable-store rebuild indexes the same vectors a live PUT would.
- Existing width validation (`check_vector_width`, `RejectedConstraint` on dim mismatch) unchanged.

## Test Plan

Unit (passing):

```
cargo test -p nodedb-types --lib vector_index_params
  msgpack_roundtrip                              ... ok   (database_id=7 round-trips)
  legacy_11_field_array_decodes_with_database_id_zero ... ok
cargo check -p nodedb --lib                       # clean
```

Live verification (vector-only build from this branch, deployed):

1. `CREATE TABLE vtest (id int primary key, embedding vector(8))` + 3 INSERTs (default db) → restart
2. Boot log: `rebuilt vector index from durable store core=0 collection=vtest rebuilt=3`
3. `SEARCH vtest USING VECTOR(embedding, ARRAY[0.1,...], 3)` → **3 rows**, distance 0.92
4. `SHOW VECTOR INDEX status ON vtest` → dimensions=8, metric=cosine, index_type=hnsw
5. Vector checkpoint written (`files_written=1`) and restored on next boot (`loaded=1 vectors=9`)

`code2g_nodes` (db `graph`) now has a fresh catalog entry carrying `database_id=graph`; a restart after the re-embed run triggers the rebuild of all 37k+ rows (in progress).

## Files

| File                                                               | Change                                                 |
| ------------------------------------------------------------------ | ------------------------------------------------------ |
| `nodedb-types/src/vector_index_params.rs`                          | `database_id` field + roundtrip tests                  |
| `nodedb/src/control/security/catalog/vector_index_params.rs`       | legacy 11-field decode ladder                          |
| `nodedb/src/control/server/shared/ddl/neutral/dsl/vector_index.rs` | CREATE passes `database_id` into stored params         |
| `nodedb/src/data/executor/core_loop/vector_index_seed.rs`          | seed keys on `e.database_id`                           |
| `nodedb/src/data/executor/core_loop/vector_index_rebuild.rs`       | rebuild scans per-entry `database_id`                  |
| `nodedb/src/data/executor/handlers/point/apply_put/vector/put.rs`  | `floats_from_value` (Array + JSON String) in both arms |

## Out of scope / notes

- The WAL `VectorParams` record already carries the correct `database_id` (it routes through `task.request.database_id`); only the _durable catalog seed_ was losing it. No WAL format change.
- The `#[msgpack(map)]` route was considered and rejected: switching the struct's zerompk representation from array to map would break decoding of every existing catalog entry, which is exactly what the ladder avoids.
- `checkpoint_durable_lsn` may log a `vector checkpoint flush failed ... No such file or directory` warning for a _dropped_ vector-primary collection's stale checkpoint path — benign (clamps LSN), pre-existing, unrelated to this change.
