### PR TITLE
fix(vector): index JSON-string embeddings on point put

### DIFF
--- a/nodedb/src/data/executor/handlers/point/apply_put/vector/put.rs
+++ b/nodedb/src/data/executor/handlers/point/apply_put/vector/put.rs
@@ -3,6 +3,7 @@
 //! Index a document's vectors into their HNSW collections on a point put.
 
 use crate::data::executor::core_loop::CoreLoop;
+use crate::data::executor::vector_string::floats_from_value;
 
 use super::types::{VectorFieldInsert, VectorIndexDelta, VectorIndexPutParams};
 
@@ -54,68 +55,56 @@ impl CoreLoop {
                 && let nodedb_types::Value::Object(ref obj) = ndb_val
             {
                 for (field_name, dim) in &vector_fields {
-                    if let Some(nodedb_types::Value::Array(arr)) = obj.get(field_name) {
-                        let floats: Vec<f32> = arr
-                            .iter()
-                            .filter_map(|v| match v {
-                                nodedb_types::Value::Float(f) => Some(*f as f32),
-                                nodedb_types::Value::Integer(i) => Some(*i as f32),
-                                nodedb_types::Value::Decimal(d) => {
-                                    use rust_decimal::prelude::ToPrimitive;
-                                    d.to_f32()
-                                }
-                                nodedb_types::Value::String(s) => s.parse::<f32>().ok(),
-                                _ => None,
-                            })
-                            .collect();
-                        let index_key =
-                            Self::vector_index_key(database_id, tid, collection, field_name);
-                        self.check_vector_width(&index_key, field_name, floats.len())?;
-                        if floats.len() != *dim as usize {
-                            return Err(crate::Error::RejectedConstraint {
-                                collection: collection.to_string(),
-                                constraint: format!("vector dimension on '{field_name}'"),
-                                detail: format!("column declares {dim}, got {}", floats.len()),
+                    let floats = match obj.get(field_name) {
+                        Some(v) => match floats_from_value(collection, field_name, v)? {
+                            Some(f) => f,
+                            None => continue,
+                        },
+                        None => continue,
+                    };
+                    let index_key =
+                        Self::vector_index_key(database_id, tid, collection, field_name);
+                    self.check_vector_width(&index_key, field_name, floats.len())?;
+                    if floats.len() != *dim as usize {
+                        return Err(crate::Error::RejectedConstraint {
+                            collection: collection.to_string(),
+                            constraint: format!("vector dimension on '{field_name}'"),
+                            detail: format!("column declares {dim}, got {}", floats.len()),
+                        });
+                    }
+                    let params = self
+                        .vector_params
+                        .get(&index_key)
+                        .cloned()
+                        .unwrap_or_default();
+                    let skip = {
+                        let coll = self
+                            .vector_collections
+                            .entry(index_key.clone())
+                            .or_insert_with(|| {
+                                nodedb_vector::VectorCollection::new(*dim as usize, params)
                             });
-                        }
-                        {
-                            let params = self
-                                .vector_params
-                                .get(&index_key)
-                                .cloned()
-                                .unwrap_or_default();
-                            let skip = {
-                                let coll = self
-                                    .vector_collections
-                                    .entry(index_key.clone())
-                                    .or_insert_with(|| {
-                                        nodedb_vector::VectorCollection::new(*dim as usize, params)
-                                    });
-                                // Skip a straddling-segment record the restored
-                                // checkpoint already absorbed (replay only; a
-                                // live write always carries a higher, unseen
-                                // LSN).
-                                wal_lsn != 0 && wal_lsn <= coll.checkpoint_wal_lsn()
-                            };
-                            if skip {
-                                continue;
-                            }
-                            if let Some(delta) =
-                                self.remove_then_insert_vector_field(VectorFieldInsert {
-                                    database_id,
-                                    tid,
-                                    index_key,
-                                    collection,
-                                    field_name,
-                                    document_id,
-                                    floats,
-                                    surrogate,
-                                    wal_lsn,
-                                })
-                            {
-                                inserts.push(delta);
-                            }
-                        }
+                        // Skip a straddling-segment record the restored
+                        // checkpoint already absorbed (replay only; a
+                        // live write always carries a higher, unseen
+                        // LSN).
+                        wal_lsn != 0 && wal_lsn <= coll.checkpoint_wal_lsn()
+                    };
+                    if skip {
+                        continue;
+                    }
+                    if let Some(delta) = self.remove_then_insert_vector_field(VectorFieldInsert {
+                        database_id,
+                        tid,
+                        index_key,
+                        collection,
+                        field_name,
+                        document_id,
+                        floats,
+                        surrogate,
+                        wal_lsn,
+                    }) {
+                        inserts.push(delta);
                     }
                 }
             }
@@ -156,63 +145,49 @@ impl CoreLoop {
                 && let nodedb_types::Value::Object(ref obj) = ndb_val
             {
                 for (params_key, field_name) in &schemaless_keys {
-                    if let Some(nodedb_types::Value::Array(arr)) = obj.get(field_name) {
-                        let floats: Vec<f32> = arr
-                            .iter()
-                            .filter_map(|v| match v {
-                                nodedb_types::Value::Float(f) => Some(*f as f32),
-                                nodedb_types::Value::Integer(i) => Some(*i as f32),
-                                nodedb_types::Value::Decimal(d) => {
-                                    use rust_decimal::prelude::ToPrimitive;
-                                    d.to_f32()
-                                }
-                                nodedb_types::Value::String(s) => s.parse::<f32>().ok(),
-                                _ => None,
-                            })
-                            .collect();
-                        if !floats.is_empty() {
-                            let params = self
-                                .vector_params
-                                .get(params_key)
-                                .cloned()
-                                .unwrap_or_default();
-                            // Use field-qualified key so search can find it.
-                            let store_key =
-                                Self::vector_index_key(database_id, tid, collection, field_name);
-                            self.check_vector_width(&store_key, field_name, floats.len())?;
-                            let dim = floats.len();
-                            let skip = {
-                                let coll = self
-                                    .vector_collections
-                                    .entry(store_key.clone())
-                                    .or_insert_with(|| {
-                                        nodedb_vector::VectorCollection::new(dim, params)
-                                    });
-                                // Skip a straddling-segment record the restored
-                                // checkpoint already absorbed (replay only; a
-                                // live write always carries a higher, unseen
-                                // LSN).
-                                wal_lsn != 0 && wal_lsn <= coll.checkpoint_wal_lsn()
-                            };
-                            if skip {
-                                continue;
-                            }
-                            if let Some(delta) =
-                                self.remove_then_insert_vector_field(VectorFieldInsert {
-                                    database_id,
-                                    tid,
-                                    index_key: store_key,
-                                    collection,
-                                    field_name,
-                                    document_id,
-                                    floats,
-                                    surrogate,
-                                    wal_lsn,
-                                })
-                            {
-                                inserts.push(delta);
-                            }
-                        }
+                    let floats = match obj.get(field_name) {
+                        Some(v) => match floats_from_value(collection, field_name, v)? {
+                            Some(f) => f,
+                            None => continue,
+                        },
+                        None => continue,
+                    };
+                    let params = self
+                        .vector_params
+                        .get(params_key)
+                        .cloned()
+                        .unwrap_or_default();
+                    // Use field-qualified key so search can find it.
+                    let store_key =
+                        Self::vector_index_key(database_id, tid, collection, field_name);
+                    self.check_vector_width(&store_key, field_name, floats.len())?;
+                    let dim = floats.len();
+                    let skip = {
+                        let coll = self
+                            .vector_collections
+                            .entry(store_key.clone())
+                            .or_insert_with(|| nodedb_vector::VectorCollection::new(dim, params));
+                        // Skip a straddling-segment record the restored
+                        // checkpoint already absorbed (replay only; a
+                        // live write always carries a higher, unseen
+                        // LSN).
+                        wal_lsn != 0 && wal_lsn <= coll.checkpoint_wal_lsn()
+                    };
+                    if skip {
+                        continue;
+                    }
+                    if let Some(delta) = self.remove_then_insert_vector_field(VectorFieldInsert {
+                        database_id,
+                        tid,
+                        index_key: store_key,
+                        collection,
+                        field_name,
+                        document_id,
+                        floats,
+                        surrogate,
+                        wal_lsn,
+                    }) {
+                        inserts.push(delta);
                     }
                 }
             }
@@ -511,5 +486,98 @@ mod tests {
             1,
             "the `title_vec` field must have exactly one live node"
         );
+    }
+
+    /// A schemaless vector arriving as an SQL string literal must be parsed
+    /// and indexed like an `ARRAY[...]` literal.
+    ///
+    /// `INSERT ... VALUES ('id', '[0.1, 0.2, ...]')` carries the vector as a
+    /// text literal — the planner's `SqlValue::String` — which decodes to
+    /// `Value::String` in the document body. The put path parses it through
+    /// the same grammar as the strict UPDATE coerce path, so the document is
+    /// indexed and the durable-store rebuild finds it.
+    #[test]
+    fn json_string_embedding_is_indexed_not_silently_dropped() {
+        let mut harness = make_core();
+        let core = &mut harness.core;
+
+        let db_id = 0u64;
+        let tid = 1u64;
+        let collection = "docs";
+        let surrogate = Surrogate::new(1);
+        let row_key = crate::engine::document::store::surrogate_to_doc_id(surrogate);
+
+        register_bare_field(core, db_id, tid, collection);
+
+        // Embedding arrives as a JSON-array string literal, the shape the
+        // planner's SqlValue::String produces.
+        let body =
+            nodedb_types::value_to_msgpack(&Value::Object(std::collections::HashMap::from([(
+                "embedding".to_string(),
+                Value::String("[0.1, 0.2, 0.3]".to_string()),
+            )])))
+            .expect("encode doc");
+
+        core.apply_point_put_vector_indexes(VectorIndexPutParams {
+            database_id: db_id,
+            tid,
+            collection,
+            document_id: &row_key,
+            surrogate,
+            value: &body,
+            wal_lsn: 0,
+        })
+        .expect("vector indexing must accept a JSON-string embedding");
+
+        assert_eq!(
+            live_count(core, db_id, tid, collection, "embedding"),
+            1,
+            "a JSON-string embedding must be indexed, not silently dropped"
+        );
+    }
+
+    /// A malformed JSON-string embedding must reject the put — a document
+    /// that silently loses its embedding is indistinguishable from one that
+    /// never had one.
+    #[test]
+    fn malformed_json_string_embedding_rejects_the_put() {
+        let mut harness = make_core();
+        let core = &mut harness.core;
+
+        let db_id = 0u64;
+        let tid = 1u64;
+        let collection = "docs";
+        let surrogate = Surrogate::new(1);
+        let row_key = crate::engine::document::store::surrogate_to_doc_id(surrogate);
+
+        register_bare_field(core, db_id, tid, collection);
+
+        for bad in ["not-json", "7", "[0.1, \"bad\"]", "{}", "[nan]"] {
+            let body =
+                nodedb_types::value_to_msgpack(&Value::Object(std::collections::HashMap::from([
+                    ("embedding".to_string(), Value::String(bad.to_string())),
+                ])))
+                .expect("encode doc");
+
+            let res = core.apply_point_put_vector_indexes(VectorIndexPutParams {
+                database_id: db_id,
+                tid,
+                collection,
+                document_id: &row_key,
+                surrogate,
+                value: &body,
+                wal_lsn: 0,
+            });
+
+            assert!(
+                matches!(res, Err(crate::Error::RejectedConstraint { .. })),
+                "malformed embedding '{bad}' must reject the put"
+            );
+            assert_eq!(
+                live_count(core, db_id, tid, collection, "embedding"),
+                0,
+                "malformed embedding '{bad}' must not be indexed"
+            );
+        }
     }
 }

--- a/nodedb/src/data/executor/mod.rs
+++ b/nodedb/src/data/executor/mod.rs
@@ -32,6 +32,7 @@ mod sync_hwm_checkpoint;
 pub mod task;
 pub(crate) mod timeseries_checkpoint;
 pub(crate) mod vector_checkpoint;
+pub(crate) mod vector_string;
 mod wal_replay;
 mod wal_replay_all;
 mod wal_replay_columnar_dml;

--- a/nodedb/src/data/executor/strict_format/coerce.rs
+++ b/nodedb/src/data/executor/strict_format/coerce.rs
@@ -171,7 +171,7 @@ pub fn coerce_value(val: &Value, col_type: &ColumnType, col_name: &str) -> crate
             }
             Value::String(s) => {
                 // UPDATE path may serialize ARRAY literal as string — parse it.
-                match parse_vector_string(s) {
+                match crate::data::executor::vector_string::parse_vector_string(s) {
                     Some(floats) => validate_and_encode_vector(col_name, *dim, &floats),
                     None => Err(crate::Error::BadRequest {
                         detail: format!(
@@ -252,60 +252,6 @@ fn validate_and_encode_vector(col_name: &str, dim: u32, floats: &[f32]) -> crate
     }
     let bytes: Vec<u8> = floats.iter().flat_map(|f| f.to_le_bytes()).collect();
     Ok(Value::Bytes(bytes))
-}
-
-/// Parse a vector from string representations that may arrive via UPDATE path.
-///
-/// Handles formats like:
-/// - `"ArrayLiteral([Literal(Float(0.9)), Literal(Float(0.1)), ...])"` (sqlparser debug repr)
-/// - `"ARRAY[0.1, 0.2, 0.3]"` (SQL literal)
-/// - `"[0.1, 0.2, 0.3]"` (JSON-style)
-fn parse_vector_string(s: &str) -> Option<Vec<f32>> {
-    // Try ARRAY[...] SQL literal format.
-    if nodedb_types::starts_with_ascii_case_insensitive(s, "ARRAY[") {
-        let start = "ARRAY[".len();
-        let end = s.rfind(']')?;
-        if end <= start {
-            return None;
-        }
-        let inner = &s[start..end];
-        let floats: Vec<f32> = inner
-            .split(',')
-            .filter_map(|tok| tok.trim().parse::<f32>().ok())
-            .collect();
-        if !floats.is_empty() {
-            return Some(floats);
-        }
-    }
-
-    // Try JSON-style [0.1, 0.2, ...] format.
-    if s.starts_with('[') && s.ends_with(']') {
-        let inner = &s[1..s.len() - 1];
-        let floats: Vec<f32> = inner
-            .split(',')
-            .filter_map(|tok| tok.trim().parse::<f32>().ok())
-            .collect();
-        if !floats.is_empty() {
-            return Some(floats);
-        }
-    }
-
-    // Try sqlparser debug repr: "ArrayLiteral([Literal(Float(0.9)), ...])"
-    if s.starts_with("ArrayLiteral(") {
-        let floats: Vec<f32> = s
-            .split("Float(")
-            .skip(1)
-            .filter_map(|chunk| {
-                let end = chunk.find(')')?;
-                chunk[..end].parse::<f32>().ok()
-            })
-            .collect();
-        if !floats.is_empty() {
-            return Some(floats);
-        }
-    }
-
-    None
 }
 
 /// Convert a typed `Value` to JSON (for pgwire output only).

--- a/nodedb/src/data/executor/vector_string.rs
+++ b/nodedb/src/data/executor/vector_string.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Vector-string parsing shared by the strict UPDATE coerce path and the
+//! schemaless point-put vector indexer.
+//!
+//! One field, two shapes: a vector arrives as `Value::Array` (native
+//! msgpack) or `Value::String` — an SQL string literal serialized by the
+//! planner's `SqlValue::String`. Both consumers must agree on the accepted
+//! string forms and on what counts as malformed. A malformed or empty body
+//! is an error, never a silent skip: an empty embedding is a missing
+//! embedding, and a document that silently loses its embedding is
+//! indistinguishable from one that never had it.
+
+use nodedb_types::Value;
+
+/// Parse a vector from the string representations the planner can produce.
+///
+/// Handles:
+/// - `"[0.1, 0.2, 0.3]"` (JSON-style)
+/// - `"ARRAY[0.1, 0.2, 0.3]"` (SQL literal)
+/// - `"ArrayLiteral([Literal(Float(0.9)), Literal(Float(0.1)), ...])"` (sqlparser debug repr)
+///
+/// A bare number (`"7"`) is refused: it would build a dim-1 index and block
+/// every real embedding written after it. Non-finite values (`"nan"`, `"inf"`)
+/// are refused — NaN breaks HNSW ordering.
+pub(crate) fn parse_vector_string(s: &str) -> Option<Vec<f32>> {
+    // Try ARRAY[...] SQL literal format.
+    if nodedb_types::starts_with_ascii_case_insensitive(s, "ARRAY[") {
+        let start = "ARRAY[".len();
+        let end = s.rfind(']')?;
+        if end <= start {
+            return None;
+        }
+        let inner = &s[start..end];
+        return parse_float_list(inner);
+    }
+
+    // Try JSON-style [0.1, 0.2, ...] format. Require both brackets so a bare
+    // number or prose never parses as a dim-1 vector.
+    if s.starts_with('[') && s.ends_with(']') {
+        let inner = &s[1..s.len() - 1];
+        return parse_float_list(inner);
+    }
+
+    // Try sqlparser debug repr: "ArrayLiteral([Literal(Float(0.9)), ...])"
+    if s.starts_with("ArrayLiteral(") {
+        let floats: Vec<f32> = s
+            .split("Float(")
+            .skip(1)
+            .filter_map(|chunk| {
+                let end = chunk.find(')')?;
+                chunk[..end].parse::<f32>().ok()
+            })
+            .collect();
+        if !floats.is_empty() && floats.iter().all(|f| f.is_finite()) {
+            return Some(floats);
+        }
+    }
+
+    None
+}
+
+/// Split a comma-separated float list, rejecting any token that is not a
+/// finite number. A list with one bad token returns `None` wholesale.
+///
+/// Comma is the only separator: no planner output produces a
+/// whitespace-separated vector, and accepting one would widen the grammar
+/// beyond what any caller emits.
+fn parse_float_list(inner: &str) -> Option<Vec<f32>> {
+    let mut floats = Vec::new();
+    for tok in inner.split(',') {
+        let tok = tok.trim();
+        if tok.is_empty() {
+            continue;
+        }
+        let f: f32 = tok.parse().ok()?;
+        if !f.is_finite() {
+            return None;
+        }
+        floats.push(f);
+    }
+    Some(floats)
+}
+
+fn vector_error(collection: &str, field_name: &str, detail: String) -> crate::Error {
+    crate::Error::RejectedConstraint {
+        collection: collection.to_string(),
+        constraint: format!("vector field '{field_name}'"),
+        detail,
+    }
+}
+
+/// Extract the float vector from a field value on a point put.
+///
+/// Accepts the native `Value::Array` (message-pack floats/integers/decimals,
+/// or numeric strings), plus the `Value::String` form the planner's
+/// `SqlValue::String` produces for an SQL string literal (`"[0.1, 0.2, ...]"`,
+/// `"ARRAY[...]"`, or the sqlparser debug repr).
+///
+/// `Ok(None)` means the value is absent or not embedding-shaped at all (a
+/// scalar, an object) — callers treat it as "no vector field". `Err` means
+/// the field IS present but unparseable, empty, or non-finite — callers must
+/// reject the write, not skip it silently. `collection` and `field_name`
+/// name the failed site so an operator sees which document shape to fix.
+///
+/// `Value::Bytes` is deliberately `Ok(None)` and not an error: the strict
+/// tuple decoder materializes a `Vector(dim)` column as `Value::Array`
+/// (`nodedb_strict::decode::value`), and the forward put path hands this
+/// function pre-coerce MessagePack, so no caller can deliver the coerced
+/// little-endian byte form here.
+pub(crate) fn floats_from_value(
+    collection: &str,
+    field_name: &str,
+    value: &Value,
+) -> crate::Result<Option<Vec<f32>>> {
+    match value {
+        Value::Array(arr) => {
+            if arr.is_empty() {
+                return Err(vector_error(
+                    collection,
+                    field_name,
+                    "expected a non-empty vector, got an empty array".to_string(),
+                ));
+            }
+            let mut floats = Vec::with_capacity(arr.len());
+            for v in arr {
+                let f = match v {
+                    Value::Float(f) => *f as f32,
+                    Value::Integer(i) => *i as f32,
+                    Value::Decimal(d) => {
+                        use rust_decimal::prelude::ToPrimitive;
+                        d.to_f32().ok_or_else(|| {
+                            vector_error(
+                                collection,
+                                field_name,
+                                format!("expected a numeric element, got {d}"),
+                            )
+                        })?
+                    }
+                    Value::String(s) => s.parse::<f32>().map_err(|_| {
+                        vector_error(
+                            collection,
+                            field_name,
+                            format!("expected a numeric element, got String({s:?})"),
+                        )
+                    })?,
+                    other => {
+                        return Err(vector_error(
+                            collection,
+                            field_name,
+                            format!("expected a numeric element, got {other:?}"),
+                        ));
+                    }
+                };
+                if !f.is_finite() {
+                    return Err(vector_error(
+                        collection,
+                        field_name,
+                        format!("expected a finite element, got {f}"),
+                    ));
+                }
+                floats.push(f);
+            }
+            Ok(Some(floats))
+        }
+        Value::String(s) => {
+            let s = s.trim();
+            let floats = parse_vector_string(s).ok_or_else(|| {
+                vector_error(
+                    collection,
+                    field_name,
+                    format!("expected a VECTOR array literal, got String({s:?})"),
+                )
+            })?;
+            if floats.is_empty() {
+                return Err(vector_error(
+                    collection,
+                    field_name,
+                    "expected a non-empty vector, got an empty array literal".to_string(),
+                ));
+            }
+            Ok(Some(floats))
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_vector_string_accepts_all_forms() {
+        assert_eq!(
+            parse_vector_string("[0.1, 0.2, 0.3]"),
+            Some(vec![0.1, 0.2, 0.3])
+        );
+        assert_eq!(
+            parse_vector_string("ARRAY[0.1, 0.2, 0.3]"),
+            Some(vec![0.1, 0.2, 0.3])
+        );
+        assert_eq!(
+            parse_vector_string("array[1,2,3]"),
+            Some(vec![1.0, 2.0, 3.0])
+        );
+        assert_eq!(
+            parse_vector_string("ArrayLiteral([Literal(Float(0.9)), Literal(Float(0.1))])"),
+            Some(vec![0.9, 0.1])
+        );
+        assert_eq!(
+            parse_vector_string("[0.1, 0.2, 0.3] extra"),
+            None,
+            "trailing text must be refused"
+        );
+        assert_eq!(parse_vector_string("not-json"), None);
+        assert_eq!(
+            parse_vector_string("7"),
+            None,
+            "bare number must be refused"
+        );
+        assert_eq!(parse_vector_string("[nan]"), None, "NaN must be refused");
+        assert_eq!(parse_vector_string("[inf]"), None, "inf must be refused");
+        assert_eq!(parse_vector_string("[0.1, \"bad\"]"), None);
+        assert_eq!(parse_vector_string("{}"), None);
+        assert_eq!(
+            parse_vector_string("[1 2 3]"),
+            None,
+            "whitespace separators are not part of the grammar"
+        );
+        assert_eq!(
+            parse_vector_string("[0.1, 0.2 0.3]"),
+            None,
+            "whitespace-separated elements are refused wholesale"
+        );
+    }
+
+    #[test]
+    fn floats_from_value_accepts_arrays_and_json_strings() {
+        use nodedb_types::Value::*;
+        assert_eq!(
+            floats_from_value(
+                "c",
+                "embedding",
+                &Array(vec![Float(0.1), Integer(2), Float(3.0)])
+            )
+            .expect("valid array"),
+            Some(vec![0.1, 2.0, 3.0])
+        );
+        assert_eq!(
+            floats_from_value("c", "embedding", &String("[0.1, 0.2, 0.3]".to_string()))
+                .expect("valid json"),
+            Some(vec![0.1, 0.2, 0.3])
+        );
+        assert_eq!(
+            floats_from_value("c", "embedding", &String("ARRAY[0.1, 0.2]".to_string()))
+                .expect("valid sql"),
+            Some(vec![0.1, 0.2])
+        );
+        assert_eq!(
+            floats_from_value("c", "embedding", &Integer(7)).expect("not a vector"),
+            None
+        );
+        assert_eq!(
+            floats_from_value("c", "embedding", &Null).expect("not a vector"),
+            None
+        );
+    }
+
+    #[test]
+    fn floats_from_value_rejects_malformed() {
+        use nodedb_types::Value::*;
+        for bad in ["not-json", "7", "[0.1, \"bad\"]", "{}", "[nan]", "[1 2 3]"] {
+            let res = floats_from_value("c", "embedding", &String(bad.to_string()));
+            assert!(
+                matches!(res, Err(crate::Error::RejectedConstraint { .. })),
+                "String({bad:?}) must be rejected, got {res:?}"
+            );
+        }
+        let res = floats_from_value(
+            "c",
+            "embedding",
+            &Array(vec![Float(0.1), String("bad".to_string())]),
+        );
+        assert!(
+            matches!(res, Err(crate::Error::RejectedConstraint { .. })),
+            "array with a non-numeric element must be rejected"
+        );
+    }
+
+    #[test]
+    fn floats_from_value_rejects_empty() {
+        use nodedb_types::Value::*;
+        for empty in ["", "[]", "[,,]", "[ ]"] {
+            let res = floats_from_value("c", "embedding", &String(empty.to_string()));
+            assert!(
+                matches!(res, Err(crate::Error::RejectedConstraint { .. })),
+                "String({empty:?}) must be rejected as an empty vector, got {res:?}"
+            );
+        }
+        let res = floats_from_value("c", "embedding", &Array(vec![]));
+        assert!(
+            matches!(res, Err(crate::Error::RejectedConstraint { .. })),
+            "an empty array must be rejected as an empty vector"
+        );
+    }
+
+    #[test]
+    fn errors_name_collection_and_field() {
+        let res = floats_from_value(
+            "docs",
+            "embedding",
+            &nodedb_types::Value::String("not-json".to_string()),
+        );
+        match res {
+            Err(crate::Error::RejectedConstraint {
+                collection,
+                constraint,
+                detail,
+            }) => {
+                assert_eq!(collection, "docs", "error must name the collection");
+                assert!(
+                    constraint.contains("embedding"),
+                    "error must name the field, got {constraint:?}"
+                );
+                assert!(!detail.is_empty(), "error must carry the offending input");
+            }
+            other => panic!("expected RejectedConstraint, got {other:?}"),
+        }
+    }
+}

--- a/nodedb/tests/wire/cases/vector_index_restart_durability.rs
+++ b/nodedb/tests/wire/cases/vector_index_restart_durability.rs
@@ -298,3 +298,113 @@ async fn document_secondary_vector_index_upsert_restart_projects_pk() {
          with the OLD vector wrongly returned the upserted row first: {old_aligned:?}"
     );
 }
+
+/// A vector arriving as an SQL string literal survives a WAL-only restart
+/// and stays searchable.
+///
+/// `INSERT ... VALUES ('id', '[0.1, 0.2, ...]')` carries the vector as a text
+/// literal (the planner's `SqlValue::String`), which decodes to
+/// `Value::String` in the document body. The put path parses it like an
+/// `ARRAY[...]` literal; without that, the row is skipped and the rebuilt
+/// index returns nothing for it.
+#[tokio::test]
+async fn json_string_embedding_survives_restart_and_search() {
+    let srv = TestServer::start().await;
+    srv.exec("CREATE COLLECTION docs_vec_json_str TYPE document")
+        .await
+        .unwrap();
+    srv.exec(
+        "CREATE VECTOR INDEX idx_docs_vec_json_str ON docs_vec_json_str (embedding) \
+         METRIC cosine DIM 4",
+    )
+    .await
+    .unwrap();
+
+    // The vector is written as a JSON-array text literal, the shape the
+    // planner's SqlValue::String produces for a quoted SQL literal.
+    srv.exec(
+        "INSERT INTO docs_vec_json_str (id, embedding) VALUES \
+         ('json_row', '[1.0, 0.0, 0.0, 0.0]')",
+    )
+    .await
+    .unwrap();
+    srv.exec(
+        "INSERT INTO docs_vec_json_str (id, embedding) VALUES \
+         ('other_row', '[0.0, 1.0, 0.0, 0.0]')",
+    )
+    .await
+    .unwrap();
+
+    // Restart against the same data directory: WAL-only recovery, the exact
+    // path the durable-store rebuild uses.
+    let (srv, dir) = srv.take_dir();
+    srv.graceful_shutdown().await;
+    let (srv2, _dir) = TestServer::open_on_path(dir).await;
+
+    let ids = srv2
+        .query_rows(
+            "SELECT id FROM docs_vec_json_str \
+             ORDER BY vector_distance(embedding, ARRAY[1.0, 0.0, 0.0, 0.0]) LIMIT 1",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        ids.len(),
+        1,
+        "JSON-string embedding must be indexed and survive restart; got {ids:?}"
+    );
+    assert_eq!(
+        ids[0][0], "json_row",
+        "search aligned with the JSON-string embedding must return its row: {ids:?}"
+    );
+}
+
+/// An empty embedding rejects the whole write at the client boundary.
+///
+/// `INSERT ... VALUES ('e', '')` carries an empty vector field, which is a
+/// missing embedding, not a valid one: the statement must fail with a
+/// constraint error instead of succeeding with the row silently skipped.
+/// `Value::Null` remains the clean skip — a document with no embedding is
+/// expressed as null.
+#[tokio::test]
+async fn empty_embedding_insert_is_refused_at_the_client() {
+    let srv = TestServer::start().await;
+    srv.exec("CREATE COLLECTION docs_vec_empty TYPE document")
+        .await
+        .unwrap();
+    srv.exec(
+        "CREATE VECTOR INDEX idx_docs_vec_empty ON docs_vec_empty (embedding) \
+         METRIC cosine DIM 4",
+    )
+    .await
+    .unwrap();
+
+    // Empty string embedding must be refused as an error.
+    let err = srv
+        .exec("INSERT INTO docs_vec_empty (id, embedding) VALUES ('e', '')")
+        .await;
+    assert!(
+        err.is_err(),
+        "an empty embedding must reject the write, not skip it silently"
+    );
+    let msg = err.unwrap_err();
+    assert!(
+        msg.contains("embedding"),
+        "error should name the vector field: {msg}"
+    );
+
+    // Empty array literal is the same shape — refused.
+    let err = srv
+        .exec("INSERT INTO docs_vec_empty (id, embedding) VALUES ('e2', '[]')")
+        .await;
+    assert!(
+        err.is_err(),
+        "an empty array literal embedding must reject the write"
+    );
+
+    // Null is the escape hatch: no embedding, no error.
+    srv.exec("INSERT INTO docs_vec_empty (id, embedding) VALUES ('n', NULL)")
+        .await
+        .expect("NULL embedding must be accepted as 'no vector field'");
+}


### PR DESCRIPTION
## Summary

Schemaless embeddings stored as SQL string literals are silently dropped by the vector put path — the durable-store rebuild indexes nothing for those collections, indistinguishable from "no embeddings exist." This completes the two-part vector fix (the database_id half landed in-house as `13a6d20e1`; this half did not).

## Behavior change — stated up front

**An empty embedding now rejects the whole write.** `INSERT INTO docs (id, embedding) VALUES ('a', '')` used to succeed with the vector skipped; it now fails the statement with a constraint error naming the collection and field. Same for `'[]'`, `'[,,]'`, and an empty native array. This matches how `check_vector_width` already behaves, but it is a behavior change, not just a bug fix.

**Escape hatch:** `NULL` returns `Ok(None)` and skips cleanly. A document with no embedding is expressed as null, not as `''` or `[]`.

**Durability:** both `wal_replay_document_vector.rs` and `vector_index_rebuild.rs` warn-and-continue on `Err`, so documents already on disk with an empty embedding will not block a boot — the rejection applies only to new writes.

## Root cause

A schemaless body decodes to `Value::String` when the vector arrives as an SQL string literal — the planner's `SqlValue::String` (`write_msgpack_value`, `sql_plan_convert/value/msgpack_write.rs:81`). Both vector put arms matched only:

```rust
if let Some(nodedb_types::Value::Array(arr)) = obj.get(field_name)
```

The pattern match failed on a string, the document was silently skipped, and the rebuild completed with 0 vectors.

## Fix

- New `floats_from_value(collection, field_name, value) -> crate::Result<Option<Vec<f32>>>`: accepts native `Value::Array` (backward compatible) or the `Value::String` forms, routed through the shared `parse_vector_string` lifted from `strict_format/coerce.rs` into `data/executor/vector_string.rs` — the strict UPDATE coerce path imports it directly, so both consumers parse identically.
- `Ok(None)` = field absent or not embedding-shaped (scalar, object — including `NULL`). `Err(RejectedConstraint)` = field present but malformed, empty, or non-finite — the put is refused, never skipped. Errors carry collection, field, and the offending input.
- `Value::Bytes` stays `Ok(None)`: the strict tuple decoder materializes `Vector(dim)` as `Value::Array` (`nodedb-strict/src/decode/value.rs`), and the forward put path hands this function pre-coerce MessagePack — no caller can deliver the coerced byte form here. Stated in the doc comment.
- Grammar is comma-only with brackets required, `is_finite` enforced: bare `"7"`, `"[1 2 3]"`, `"nan"`, `"inf"` are refused, not silently accepted or dropped.

## Tests

- Unit: `json_string_embedding_is_indexed_not_silently_dropped` (repro, fails pre-fix), `malformed_json_string_embedding_rejects_the_put` (rejects, index stays empty), `floats_from_value_rejects_empty`, `errors_name_collection_and_field`, helper cases. 9/9.
- Wire, through the real path: `json_string_embedding_survives_restart_and_search` — SQL INSERT with a JSON-string literal → WAL-only restart → rebuild → `ORDER BY vector_distance` returns the row. Proven red on unmodified `main` (assertion `got []`), green with the fix.
- Wire, client boundary: `empty_embedding_insert_is_refused_at_the_client` — `''` and `'[]'` fail at the client with an error naming the field; `NULL` accepted as no-embedding. 5/5.

## Validation

- `cargo nextest run -p nodedb --lib` — 6,532/6,532
- `cargo nextest run -p nodedb --test wire vector_index_restart_durability` — 5/5
- `cargo fmt --all --check` — clean
- clippy: single failure is the pre-existing `nodedb-vector/src/quantize/pq.rs:334` `nonminimal_bool`, reproduced on unmodified `main` (documented in #240)
