### PR TITLE
fix(router): TOPK recognized as call, not substring

### DIFF
--- a/nodedb/src/control/server/shared/ddl/neutral/router/dispatch.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/router/dispatch.rs
@@ -40,7 +40,9 @@ pub async fn try_dispatch(
     database_id: DatabaseId,
     txn_ctx: &DmlTxnCtx<'_>,
 ) -> Option<Result<Vec<DdlResult>, DdlError>> {
-    let upper = sql.to_uppercase();
+    // Trim so prefix-anchored arms (SELECT TOPK(, SELECT RANK(, …) still
+    // match a statement that arrives with leading whitespace or a newline.
+    let upper = sql.trim().to_uppercase();
 
     if let Some(r) = string_admin::try_string(state, identity, sql, &upper, database_id).await {
         return Some(r);

--- a/nodedb/src/control/server/shared/ddl/neutral/router/string_engine_ops.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/router/string_engine_ops.rs
@@ -57,8 +57,11 @@ pub(super) async fn try_string(
     // on the pgwire path too), so the timeseries `show_partitions` handler stays
     // shadowed exactly as it was.
 
-    // Weighted random selection.
-    if upper.contains("WEIGHTED_PICK(") || upper.contains("WEIGHTED_PICK (") {
+    // Weighted random selection — anchored to the statement prefix so a
+    // doc-object UPSERT body carrying the token never reaches this arm.
+    if upper.starts_with("SELECT * FROM WEIGHTED_PICK(")
+        || upper.starts_with("SELECT * FROM WEIGHTED_PICK (")
+    {
         return Some(weighted_pick::weighted_pick(state, identity, sql).await);
     }
 
@@ -89,16 +92,17 @@ pub(super) async fn try_string(
         return Some(kv_sorted_index::drop_sorted_index(state, identity, database_id, sql).await);
     }
 
-    // Sorted index query functions.
+    // Sorted index query functions, anchored to the statement prefix: a
+    // doc-object UPSERT body, string literal, or comment carrying the token
+    // can never reach these arms.
     if upper.starts_with("SELECT RANK(") || upper.starts_with("SELECT RANK (") {
         return Some(kv_sorted_index::select_rank(state, identity, database_id, sql).await);
     }
-    // TOPK is recognized as a *call*, not by substring: `contains("TOPK(")`
-    // also matched string literals and identifiers in doc-object UPSERTs
-    // (e.g. name: 'merge_from_topk()') and misrouted them into select_topk,
-    // which then failed with "TOPK requires 2 arguments". Require a real
-    // identifier boundary and skip quoted literals.
-    if has_topk_call(upper) {
+    if upper.starts_with("SELECT TOPK(")
+        || upper.starts_with("SELECT TOPK (")
+        || upper.starts_with("SELECT * FROM TOPK(")
+        || upper.starts_with("SELECT * FROM TOPK (")
+    {
         return Some(kv_sorted_index::select_topk(state, identity, database_id, sql).await);
     }
     if upper.starts_with("SELECT SORTED_COUNT(") || upper.starts_with("SELECT SORTED_COUNT (") {
@@ -296,14 +300,13 @@ pub(super) async fn try_string(
 
     // `NDB_CHUNK_TEXT(...)` table-valued function, `SHOW CHANGES FOR …`
     // change-stream query, and `SELECT ESTIMATE_COUNT(…)` — string-recognized
-    // (none parse into a typed DDL variant). The pgwire dsl string router
-    // recognized all three by prefix from the raw SQL; replicate that exactly
-    // here, before the parse gate, so the prefix recognition and syntax messages
-    // stay byte-identical. The `NDB_CHUNK_TEXT(` and `ESTIMATE_COUNT(`
-    // function-name checks are specific enough not to collide with the other
-    // migrated `SELECT …` arms above.
-    if (upper.starts_with("SELECT ") && upper.contains("NDB_CHUNK_TEXT("))
+    // (none parse into a typed DDL variant). Anchored to the statement prefix
+    // so a string literal or doc-object UPSERT body carrying the token never
+    // reaches this arm.
+    if upper.starts_with("SELECT * FROM NDB_CHUNK_TEXT(")
+        || upper.starts_with("SELECT * FROM NDB_CHUNK_TEXT (")
         || upper.starts_with("SELECT NDB_CHUNK_TEXT(")
+        || upper.starts_with("SELECT NDB_CHUNK_TEXT (")
     {
         return Some(chunk_text::execute_chunk_text(sql));
     }
@@ -357,63 +360,10 @@ fn crdt_transaction_error() -> DdlError {
     )
 }
 
-/// True when `sql_upper` contains a real `TOPK(...)` call: the token must sit
-/// at an identifier boundary (not `x_topk(`) and outside single-quoted
-/// string literals (so a doc-object value like `name: 'merge_from_topk()'`
-/// in an UPSERT is not misrouted to the sorted-index TOPK handler).
-fn has_topk_call(sql_upper: &str) -> bool {
-    let bytes = sql_upper.as_bytes();
-    let mut in_literal = false;
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'\'' => {
-                in_literal = !in_literal;
-                i += 1;
-            }
-            b'T' if !in_literal && bytes[i..].starts_with(b"TOPK") => {
-                let after = &bytes[i + 4..];
-                let call = after.starts_with(b"(") || after.starts_with(b" (");
-                let boundary = i == 0
-                    || !(bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
-                if call && boundary {
-                    return true;
-                }
-                i += 1;
-            }
-            _ => i += 1,
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::control::server::shared::session::{SessionId, SessionStore};
-
-    #[test]
-    fn topk_call_detection_respects_identifier_boundary_and_literals() {
-        // Real TOPK calls — with and without the SELECT * FROM prefix.
-        assert!(has_topk_call("SELECT * FROM TOPK(sidx, 5)"));
-        assert!(has_topk_call("SELECT TOPK(sidx, 5)"));
-        assert!(has_topk_call("SELECT * FROM TOPK (sidx, 5)"));
-        // Identifier suffix is not a call: `x_topk(` must not route.
-        assert!(!has_topk_call("SELECT x_topk(1)"));
-        assert!(!has_topk_call("SELECT merge_from_topk()"));
-        // Doc-object string literal values must not be treated as calls.
-        assert!(!has_topk_call(
-            "UPSERT INTO code2g_nodes { id: 'x', name: 'merge_from_topk()' }"
-        ));
-        assert!(!has_topk_call("UPSERT INTO c { name: 'TOPK(a, b)' }"));
-        // A genuine call after a quoted literal still routes.
-        assert!(has_topk_call("SELECT 'lit', TOPK(sidx, 3)"));
-        // Router passes the uppercase mirror; lowercase input is not a match.
-        assert!(has_topk_call("SELECT * FROM TOPK(sidx, 5)"));
-        assert!(!has_topk_call("select * from topk(sidx, 5)"));
-        // No call at all.
-        assert!(!has_topk_call("SELECT * FROM code2g_nodes"));
-    }
 
     #[test]
     fn crdt_apply_and_merge_are_forbidden_in_active_or_failed_transactions() {

--- a/nodedb/src/control/server/shared/ddl/neutral/router/string_engine_ops.rs
+++ b/nodedb/src/control/server/shared/ddl/neutral/router/string_engine_ops.rs
@@ -93,7 +93,12 @@ pub(super) async fn try_string(
     if upper.starts_with("SELECT RANK(") || upper.starts_with("SELECT RANK (") {
         return Some(kv_sorted_index::select_rank(state, identity, database_id, sql).await);
     }
-    if upper.contains("TOPK(") || upper.contains("TOPK (") {
+    // TOPK is recognized as a *call*, not by substring: `contains("TOPK(")`
+    // also matched string literals and identifiers in doc-object UPSERTs
+    // (e.g. name: 'merge_from_topk()') and misrouted them into select_topk,
+    // which then failed with "TOPK requires 2 arguments". Require a real
+    // identifier boundary and skip quoted literals.
+    if has_topk_call(upper) {
         return Some(kv_sorted_index::select_topk(state, identity, database_id, sql).await);
     }
     if upper.starts_with("SELECT SORTED_COUNT(") || upper.starts_with("SELECT SORTED_COUNT (") {
@@ -352,10 +357,63 @@ fn crdt_transaction_error() -> DdlError {
     )
 }
 
+/// True when `sql_upper` contains a real `TOPK(...)` call: the token must sit
+/// at an identifier boundary (not `x_topk(`) and outside single-quoted
+/// string literals (so a doc-object value like `name: 'merge_from_topk()'`
+/// in an UPSERT is not misrouted to the sorted-index TOPK handler).
+fn has_topk_call(sql_upper: &str) -> bool {
+    let bytes = sql_upper.as_bytes();
+    let mut in_literal = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                in_literal = !in_literal;
+                i += 1;
+            }
+            b'T' if !in_literal && bytes[i..].starts_with(b"TOPK") => {
+                let after = &bytes[i + 4..];
+                let call = after.starts_with(b"(") || after.starts_with(b" (");
+                let boundary = i == 0
+                    || !(bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
+                if call && boundary {
+                    return true;
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::control::server::shared::session::{SessionId, SessionStore};
+
+    #[test]
+    fn topk_call_detection_respects_identifier_boundary_and_literals() {
+        // Real TOPK calls — with and without the SELECT * FROM prefix.
+        assert!(has_topk_call("SELECT * FROM TOPK(sidx, 5)"));
+        assert!(has_topk_call("SELECT TOPK(sidx, 5)"));
+        assert!(has_topk_call("SELECT * FROM TOPK (sidx, 5)"));
+        // Identifier suffix is not a call: `x_topk(` must not route.
+        assert!(!has_topk_call("SELECT x_topk(1)"));
+        assert!(!has_topk_call("SELECT merge_from_topk()"));
+        // Doc-object string literal values must not be treated as calls.
+        assert!(!has_topk_call(
+            "UPSERT INTO code2g_nodes { id: 'x', name: 'merge_from_topk()' }"
+        ));
+        assert!(!has_topk_call("UPSERT INTO c { name: 'TOPK(a, b)' }"));
+        // A genuine call after a quoted literal still routes.
+        assert!(has_topk_call("SELECT 'lit', TOPK(sidx, 3)"));
+        // Router passes the uppercase mirror; lowercase input is not a match.
+        assert!(has_topk_call("SELECT * FROM TOPK(sidx, 5)"));
+        assert!(!has_topk_call("select * from topk(sidx, 5)"));
+        // No call at all.
+        assert!(!has_topk_call("SELECT * FROM code2g_nodes"));
+    }
 
     #[test]
     fn crdt_apply_and_merge_are_forbidden_in_active_or_failed_transactions() {

--- a/nodedb/tests/wire/cases/mod.rs
+++ b/nodedb/tests/wire/cases/mod.rs
@@ -130,6 +130,7 @@ mod redaction_policy_database_scope;
 mod reindex_concurrent;
 mod restart_refused_write_not_resurrected;
 mod rls_policy_database_scope;
+mod router_misroute_literals;
 mod scalar_aggregate_empty_input;
 mod scalar_aggregate_multicore_merge;
 mod schema_visibility_barrier;

--- a/nodedb/tests/wire/cases/router_misroute_literals.rs
+++ b/nodedb/tests/wire/cases/router_misroute_literals.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Prefix anchoring for the router's function arms.
+//!
+//! `TOPK`, `WEIGHTED_PICK` and `NDB_CHUNK_TEXT` are recognized only at the
+//! statement prefix. A statement carrying one of those tokens anywhere else —
+//! a doc-object UPSERT value, a string literal, a comment — belongs to its own
+//! handler and must never reach the function arm. These tests hold both
+//! directions: the literal stores verbatim, the anchored form still routes.
+
+use crate::harness::TestServer;
+
+/// A doc-object value carrying `merge_from_topk()` must store verbatim, and
+/// `SELECT * FROM TOPK(...)` must still route.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn upsert_literal_does_not_misroute_topk() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION lit_c (id STRING PRIMARY KEY, name STRING, score INT) \
+             WITH (engine='kv')",
+        )
+        .await
+        .expect("create collection");
+    server
+        .exec("INSERT INTO lit_c { id: 'a', name: 'plain', score: 10 }")
+        .await
+        .expect("seed a");
+    server
+        .exec("CREATE SORTED INDEX lit_idx ON lit_c (score DESC) KEY id")
+        .await
+        .expect("create sorted index");
+
+    // The value carries the token, the statement is an UPSERT: it must store
+    // the value verbatim rather than reach the sorted-index handler.
+    server
+        .exec("UPSERT INTO lit_c { id: 'b', name: 'merge_from_topk()', score: 20 }")
+        .await
+        .expect("UPSERT with TOPK-shaped literal must store verbatim, not misroute");
+
+    let rows = server
+        .query_text("SELECT name FROM lit_c WHERE id = 'b'")
+        .await
+        .expect("read back the upserted row");
+    assert_eq!(
+        rows,
+        vec!["merge_from_topk()".to_string()],
+        "the literal must be stored verbatim"
+    );
+
+    // The anchored form still routes and returns rows.
+    let top = server
+        .query_text("SELECT * FROM TOPK(lit_idx, 3)")
+        .await
+        .expect("anchored TOPK must still route");
+    assert_eq!(top.len(), 2, "both seeded rows must be returned: {top:?}");
+}
+
+/// A doc-object value carrying `weighted_pick()` must store verbatim — the
+/// token in call order, so a `contains("WEIGHTED_PICK(")` predicate would
+/// match it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn insert_literal_weighted_pick_stores_verbatim() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION lit_c2 (id STRING PRIMARY KEY, name STRING, weight INT) \
+             WITH (engine='kv')",
+        )
+        .await
+        .expect("create collection");
+    server
+        .exec("INSERT INTO lit_c2 { id: 'a', name: 'plain', weight: 1 }")
+        .await
+        .expect("seed a");
+
+    // The token in call order inside an INSERT doc-object value.
+    server
+        .exec("INSERT INTO lit_c2 { id: 'b', name: 'weighted_pick()', weight: 2 }")
+        .await
+        .expect("INSERT with WEIGHTED_PICK-shaped literal must store verbatim");
+
+    let rows = server
+        .query_text("SELECT name FROM lit_c2 WHERE id = 'b'")
+        .await
+        .expect("read back");
+    assert_eq!(
+        rows,
+        vec!["weighted_pick()".to_string()],
+        "the literal must be stored verbatim"
+    );
+}
+
+/// A SELECT whose WHERE literal carries `ndb_chunk_text(x)` must return the
+/// matching row, not route into the chunk-text handler.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn select_literal_does_not_misroute_ndb_chunk_text() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION lit_c3 (id STRING PRIMARY KEY, name STRING) \
+             WITH (engine='kv')",
+        )
+        .await
+        .expect("create collection");
+    server
+        .exec("INSERT INTO lit_c3 { id: 'a', name: 'plain' }")
+        .await
+        .expect("seed a");
+    server
+        .exec("INSERT INTO lit_c3 { id: 'b', name: 'ndb_chunk_text(x)' }")
+        .await
+        .expect("seed b");
+
+    // The token in a WHERE literal must return the matching row, not route into
+    // the chunk-text handler.
+    let rows = server
+        .query_text("SELECT name FROM lit_c3 WHERE name = 'ndb_chunk_text(x)'")
+        .await
+        .expect("SELECT with a chunk-text-shaped literal must not misroute");
+    assert_eq!(
+        rows,
+        vec!["ndb_chunk_text(x)".to_string()],
+        "the matching row must be returned, not chunk-text output"
+    );
+}
+
+/// Leading whitespace must not break the prefix anchors — the router trims
+/// before uppercasing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn leading_whitespace_still_routes_anchored_arms() {
+    let server = TestServer::start().await;
+
+    server
+        .exec(
+            "CREATE COLLECTION ws_c (id STRING PRIMARY KEY, score INT) \
+             WITH (engine='kv')",
+        )
+        .await
+        .expect("create collection");
+    server
+        .exec("INSERT INTO ws_c { id: 'a', score: 10 }")
+        .await
+        .expect("seed a");
+    server
+        .exec("CREATE SORTED INDEX ws_idx ON ws_c (score DESC) KEY id")
+        .await
+        .expect("create sorted index");
+
+    let top = server
+        .query_text("\n  SELECT * FROM TOPK(ws_idx, 3)")
+        .await
+        .expect("leading whitespace must not break the TOPK anchor");
+    assert_eq!(
+        top.len(),
+        1,
+        "row must be returned despite leading whitespace"
+    );
+}


### PR DESCRIPTION
## Summary

The SQL router misroutes statements that carry `TOPK(` anywhere in the body — including inside doc-object UPSERT values, string literals, and comments — into `select_topk`, which then fails with `TOPK requires 2 arguments` (or a nonsense k argument error when the first `(` belongs to a different function). `TOPK` must route only when the statement actually calls it.

## Root cause

`upper.contains("TOPK(")` matched the token anywhere, not just in call position. `UPSERT INTO c { id: 'x', name: 'merge_from_topk()' }` reached the sorted-index handler the same way a real `SELECT * FROM TOPK(...)` did. The same unanchored class existed two arms above: `contains("WEIGHTED_PICK(")` (now fixed) and a `SELECT … contains("NDB_CHUNK_TEXT(")` predicate on the chunk-text arm (now fixed).

## Fix — anchor all three arms to the statement prefix

Every neighbour in this dispatch list is already anchored (`SELECT RANK(`, `SELECT SORTED_COUNT(`, `SELECT * FROM RANGE(`, …). TOPK was the only unanchored arm — precisely why an UPSERT body could reach it. A doc-object UPSERT cannot start with `SELECT TOPK(`.

- **TOPK**: `SELECT TOPK(`, `SELECT TOPK (`, `SELECT * FROM TOPK(`, `SELECT * FROM TOPK (` — replaces the lexer-scan helper entirely (deleted, ~70 lines incl. its tests).
- **WEIGHTED_PICK**: `SELECT * FROM WEIGHTED_PICK(`, `SELECT * FROM WEIGHTED_PICK (` — was `contains(...)`.
- **NDB_CHUNK_TEXT**: `SELECT * FROM NDB_CHUNK_TEXT(`, `SELECT * FROM NDB_CHUNK_TEXT (`, `SELECT NDB_CHUNK_TEXT(`, `SELECT NDB_CHUNK_TEXT (` — was `SELECT … && contains(...)`.

Anchoring also rejects `SELECT MAX(x), TOPK(sidx, 3)`, which the scan-based version still misrouted (the handler spans first `(` to last `)` and produced garbage args).

## Tests

- Router module: 2/2.
- Wire `sorted_index` (TOPK/RANK/RANGE end-to-end): 13/13.
- Wire `query_function_authorization` + chunk-text (WEIGHTED_PICK, NDB_CHUNK_TEXT): 16/16.

## Validation

- `cargo check -p nodedb --all-targets` — clean
- `cargo fmt --all --check` — clean
- clippy: single failure is the pre-existing `nodedb-vector/src/quantize/pq.rs:334` `nonminimal_bool` (documented in #240)
