### PR TITLE
fix(mem): resolve unknown engine before increments in try_reserve (#271)

### DIFF
--- a/nodedb-mem/src/governor.rs
+++ b/nodedb-mem/src/governor.rs
@@ -224,6 +224,15 @@ impl MemoryGovernor {
         engine: EngineId,
         size: usize,
     ) -> Result<ReservationToken> {
+        // ── Layer 0: fail fast on unknown engine (D2 / #271) ──────────────────
+        // Must resolve BEFORE any increment: with a bad engine name every
+        // other path rolls back, this one used to return from the lookup
+        // after global/db/tenant counters were already bumped.
+        let engine_budget = self
+            .budgets
+            .get(&engine)
+            .ok_or(MemError::UnknownEngine(engine))?;
+
         // ── Layer 1: global ceiling ───────────────────────────────────────────
         let global_arc = Arc::clone(&self.global_counter);
         if size > 0 {
@@ -306,11 +315,7 @@ impl MemoryGovernor {
             }
         };
 
-        // ── Layer 4: per-engine budget ────────────────────────────────────────
-        let engine_budget = self
-            .budgets
-            .get(&engine)
-            .ok_or(MemError::UnknownEngine(engine))?;
+        // ── Layer 4: per-engine budget (resolved above, fail-fast) ────────────
 
         let engine_counter = if let Some(arc) = engine_budget.try_reserve_arc(size) {
             Some(arc)
@@ -491,6 +496,25 @@ mod tests {
     }
 
     // ── Basic 4-arity reservation ────────────────────────────────────────────
+
+    #[test]
+    fn try_reserve_unknown_engine_rolls_back_global() {
+        // CLAIM D2: engine lookup (`ok_or(UnknownEngine)?`) happens AFTER
+        // global/db/tenant increments; error path must roll back or leak.
+        let gov = MemoryGovernor::new(test_config()).unwrap();
+        let err = gov
+            .try_reserve(db(), tenant(), EngineId::Array, 1000)
+            .unwrap_err();
+        assert!(
+            matches!(err, MemError::UnknownEngine(_)),
+            "Array is not in test_config engine limits"
+        );
+        assert_eq!(
+            gov.global_counter.allocated.load(Ordering::Relaxed),
+            0,
+            "D2: UnknownEngine must not leak the global counter"
+        );
+    }
 
     #[test]
     fn reserve_within_budget() {

--- a/nodedb-mem/src/governor.rs
+++ b/nodedb-mem/src/governor.rs
@@ -228,6 +228,9 @@ impl MemoryGovernor {
         // Must resolve BEFORE any increment: with a bad engine name every
         // other path rolls back, this one used to return from the lookup
         // after global/db/tenant counters were already bumped.
+        // Intent: an unknown engine is rejected for ANY size, including 0 —
+        // a zero-size reservation still names an engine, and silently
+        // succeeding under an unknown name would hide configuration drift.
         let engine_budget = self
             .budgets
             .get(&engine)
@@ -513,6 +516,23 @@ mod tests {
             gov.global_counter.allocated.load(Ordering::Relaxed),
             0,
             "D2: UnknownEngine must not leak the global counter"
+        );
+    }
+
+    #[test]
+    fn unknown_engine_rejected_even_for_zero_size() {
+        let gov = MemoryGovernor::new(test_config()).unwrap();
+        let err = gov
+            .try_reserve(db(), tenant(), EngineId::Array, 0)
+            .unwrap_err();
+        assert!(
+            matches!(err, MemError::UnknownEngine(_)),
+            "zero-size reservation must still validate the engine name"
+        );
+        assert_eq!(
+            gov.global_counter.allocated.load(Ordering::Relaxed),
+            0,
+            "no counter may move for a rejected reservation"
         );
     }
 


### PR DESCRIPTION
## Summary

`MemoryGovernor::try_reserve` detected an unknown engine at the per-engine layer — **after** incrementing the global ceiling, database ceiling, and tenant ceiling. The failure at the lookup returned `MemError::UnknownEngine` without rolling back, permanently inflating all three counters (issue #271). Every other error path in this function rolls back; this was the single exception.

## Fix

Resolve the per-engine budget **before** any atomic increment. An unknown engine now aborts the call with zero counters touched; Layer 4 reuses the pre-resolved budget.

## How to test

```bash
cargo test -p nodedb-mem --lib try_reserve_unknown_engine_rolls_back_global
```

The regression test was red against `origin/main` (global counter leaked 1000 bytes after the error); it is green here (counter stays 0).

## Regression

- `cargo test -p nodedb-mem --lib`: 66 passed, 0 failed
- Existing rollback paths (`reserve_exceeds_engine_budget`, `reserve_exceeds_global_ceiling`) unchanged and green

Fixes #271.
