### PR TITLE
fix(core): hold SPSC throttled depth under sustained Critical (#274)

### DIFF
--- a/nodedb/src/data/executor/core_loop/pressure.rs
+++ b/nodedb/src/data/executor/core_loop/pressure.rs
@@ -120,13 +120,18 @@ impl CoreLoop {
                         "pressure Critical — lifting SPSC suspension"
                     );
                 }
-                let new_depth = (self.spsc_read_depth / 2).max(1);
-                if new_depth != self.spsc_read_depth {
-                    self.spsc_read_depth = new_depth;
+                // Throttle is ONE step from normal (64 -> 32), held while
+                // Critical persists. The old per-tick halving compounded
+                // (depth/2).max(1) every tick, collapsing 64 -> 1 after six
+                // Critical ticks — indistinguishable from an Emergency stall.
+                // Only the Emergency branch sets depth to 1.
+                let desired = SPSC_READ_DEPTH_NORMAL / 2;
+                if self.spsc_read_depth != desired {
+                    self.spsc_read_depth = desired;
                     warn!(
                         core = self.core_id,
-                        read_depth = new_depth,
-                        "Critical memory pressure — reduced SPSC read depth"
+                        read_depth = desired,
+                        "Critical memory pressure — throttled SPSC read depth"
                     );
                 }
             }
@@ -352,6 +357,23 @@ mod tests {
              cascade that turns transient or accounting-drift memory pressure \
              into permanent schema-register barrier timeouts and a server that \
              answers /healthz but fails every DDL"
+        );
+    }
+
+    #[test]
+    fn spsc_critical_ticks_do_not_collapse_to_one() {
+        // CLAIM D1: sustained Critical applies (depth/2).max(1) per tick,
+        // compounding 64 -> 1 instead of settling at NORMAL/2.
+        let (mut core, _tx, _rx, _dir) = make_core();
+        core.spsc_read_depth = SPSC_READ_DEPTH_NORMAL;
+        core.set_governor(make_governor_at(EngineId::Vector, 88));
+        for _ in 0..6 {
+            core.apply_spsc_pressure();
+        }
+        assert_eq!(
+            core.spsc_read_depth,
+            SPSC_READ_DEPTH_NORMAL / 2,
+            "D1: sustained Critical must settle at NORMAL/2, not compound to 1"
         );
     }
 


### PR DESCRIPTION
## Summary

Under sustained Critical memory pressure the SPSC read depth was halved **every tick**: `(depth / 2).max(1)`. Six consecutive Critical ticks compound 64 → 32 → 16 → 8 → 4 → 2 → 1 — a full read stall that only the Emergency branch is meant to cause (issue #274).

## Fix

The Critical branch now sets the throttled depth (`SPSC_READ_DEPTH_NORMAL / 2`) once and holds it while Critical persists. Emergency remains the only path to depth 1; leaving Emergency lifts back to the throttled level (existing behavior, unchanged).

## How to test

```bash
cargo test -p nodedb --lib spsc_critical_ticks_do_not_collapse_to_one
```

Regression test was red against `origin/main` (depth 1 after 6 Critical ticks); green here (depth stays 32). Controls unchanged: `spsc_critical_halves_depth`, `spsc_hysteresis_restores_depth_after_n_normal_ticks`.

Fixes #274.
