### PR TITLE
fix(config): auto-initialize [cluster] from env vars when section absent (#276)

### DIFF
--- a/nodedb/src/config/server/env/cluster.rs
+++ b/nodedb/src/config/server/env/cluster.rs
@@ -5,9 +5,44 @@
 
 use std::net::SocketAddr;
 
-use crate::config::server::ServerConfig;
+use crate::config::server::{ClusterSettings, ServerConfig};
 
 pub(super) fn apply_cluster_overrides(config: &mut ServerConfig) {
+    // Auto-initialize [cluster] when a cluster-scoped env var is present and
+    // the operator's TOML has no [cluster] table (issue #276): containers that
+    // pass NODEDB_NODE_ID / NODEDB_SEED_NODES expect cluster mode; silently
+    // dropping the setting boots a standalone node with zero replication.
+    if config.cluster.is_none() {
+        let node_id_env = std::env::var("NODEDB_NODE_ID").ok();
+        let seed_nodes_env = std::env::var("NODEDB_SEED_NODES").ok();
+        if node_id_env.is_some() || seed_nodes_env.is_some() {
+            config.cluster = Some(ClusterSettings {
+                node_id: node_id_env
+                    .as_deref()
+                    .and_then(|v| v.trim().parse().ok())
+                    .unwrap_or(0),
+                listen: "0.0.0.0:9400".parse().expect("static addr"),
+                seed_nodes: Vec::new(),
+                num_groups: 1,
+                replication_factor: 1,
+                force_bootstrap: false,
+                tls: None,
+                max_active_sessions: 0,
+                login_attempts_per_ip_per_min: 30,
+                login_attempts_per_user_per_min: 10,
+                insecure_transport: false,
+                log_compaction_threshold: None,
+            });
+            tracing::info!(
+                node_id = node_id_env
+                    .as_deref()
+                    .and_then(|v| v.trim().parse::<u64>().ok())
+                    .unwrap_or(0),
+                "cluster env vars present without [cluster] section; auto-initialized cluster mode"
+            );
+        }
+    }
+
     if let Ok(val) = std::env::var("NODEDB_NODE_ID") {
         match val.trim().parse::<u64>() {
             Ok(node_id) => {
@@ -139,14 +174,17 @@ mod tests {
         );
         unsafe { std::env::remove_var("NODEDB_NODE_ID") };
 
-        // ── NODEDB_NODE_ID: cluster absent → config.cluster stays None ──
+        // ── NODEDB_NODE_ID: [cluster] absent → auto-initialized (issue #276) ──
 
         unsafe { std::env::set_var("NODEDB_NODE_ID", "99") };
         let mut cfg = ServerConfig::default();
         apply_env_overrides(&mut cfg);
-        assert!(
-            cfg.cluster.is_none(),
-            "NODEDB_NODE_ID with no [cluster] section must not create cluster"
+        let cluster = cfg.cluster.as_ref().expect(
+            "NODEDB_NODE_ID with no [cluster] section must auto-initialize cluster mode",
+        );
+        assert_eq!(
+            cluster.node_id, 99,
+            "auto-initialized cluster must adopt the env node id"
         );
         unsafe { std::env::remove_var("NODEDB_NODE_ID") };
 
@@ -199,5 +237,22 @@ mod tests {
         );
         assert_eq!(seeds[0], existing_seed);
         unsafe { std::env::remove_var("NODEDB_SEED_NODES") };
+    }
+
+    #[test]
+    fn c2_env_cluster_auto_initializes_section() {
+        // CLAIM C2: NODEDB_NODE_ID without any [cluster] section is silently
+        // dropped (if let Some(cluster) = cluster.as_mut()); must auto-init.
+        unsafe {
+            std::env::remove_var("NODEDB_NODE_ID");
+            std::env::remove_var("NODEDB_SEED_NODES");
+            std::env::set_var("NODEDB_NODE_ID", "7");
+        }
+        let mut cfg: ServerConfig = ServerConfig::default();
+        apply_env_overrides(&mut cfg);
+        assert!(
+            cfg.cluster.is_some(),
+            "C2: NODEDB_NODE_ID must auto-initialize [cluster] config"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`NODEDB_NODE_ID` / `NODEDB_SEED_NODES` set in the environment with a config that has **no** `[cluster]` table were silently dropped (warn + ignore) and the node booted standalone — issue #276. A container that passes cluster variables expects cluster mode; the setting disappeared instead.

## Fix

Presence of either variable now auto-initializes a default `[cluster]` section (`node_id` adopted from the env var, `listen 0.0.0.0:9400`, `replication_factor 1`, no seeds) before the normal override pass applies the environment values. Existing configs with a `[cluster]` table behave exactly as before.

## How to test

```bash
cargo test -p nodedb --lib c2_env_cluster_auto_initializes_section
cargo test -p nodedb --lib env_cluster_overrides
```

The `cluster-absent` case of the control test was flipped: it now asserts auto-init + adopted node_id (was: cluster stays None — that was the defect). Env suite: 16 passed.

Fixes #276.
