### PR TITLE
fix(build): repair fuzz target and wasm decoder after upstream refactors

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1149,9 +1149,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h3o"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f033ee4f3b98f6842df9ce5111ff2dd36fd9be9804b9c0afd43e69e3891a6fbf"
+checksum = "9fb2db7abbf5a95268cfb53ee6c2d4c02894323e1d3e1d7b300595eee61c482c"
 dependencies = [
  "ahash 0.8.12",
  "either",
@@ -2101,6 +2101,7 @@ dependencies = [
  "libfuzzer-sys",
  "nodedb-codec",
  "nodedb-columnar",
+ "nodedb-mem",
  "nodedb-sql",
  "nodedb-strict",
  "nodedb-types",
@@ -2992,9 +2993,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruzstd"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]
@@ -3237,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -3275,12 +3276,6 @@ dependencies = [
  "psm",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -3642,13 +3637,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "typenum"
@@ -4195,16 +4186,18 @@ dependencies = [
 
 [[package]]
 name = "zerompk"
-version = "0.7.1"
-source = "git+https://github.com/farhan-syah/zerompk?rev=bb3156cf17b399b0dc2dd90895133a169a29cac0#bb3156cf17b399b0dc2dd90895133a169a29cac0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c3e632951a5d373caf7c818d92f0157f5a69d94d9decdb155ce80d26f20e9a"
 dependencies = [
  "zerompk_derive",
 ]
 
 [[package]]
 name = "zerompk_derive"
-version = "0.7.1"
-source = "git+https://github.com/farhan-syah/zerompk?rev=bb3156cf17b399b0dc2dd90895133a169a29cac0#bb3156cf17b399b0dc2dd90895133a169a29cac0"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45d40506e32ba80b9a861df3a0f30aa910cf1e6465ebc14ab2b8fdb2b40eec7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ libfuzzer-sys = { version = "0.4", optional = true }
 tempfile = "3"
 nodedb-codec = { path = "../nodedb-codec" }
 nodedb-columnar = { path = "../nodedb-columnar" }
+nodedb-mem = { path = "../nodedb-mem" }
 nodedb-strict = { path = "../nodedb-strict" }
 nodedb-types = { path = "../nodedb-types" }
 nodedb-wal = { path = "../nodedb-wal" }

--- a/fuzz/src/targets/columnar_segment.rs
+++ b/fuzz/src/targets/columnar_segment.rs
@@ -1,8 +1,13 @@
+use std::sync::Arc;
+
 use nodedb_columnar::memtable::ColumnData;
+use nodedb_columnar::writer::PROFILE_PLAIN;
 use nodedb_columnar::{
     DeleteBitmap, OwnedSegmentReader, ScanPredicate, SegmentReader, SegmentWriter,
 };
+use nodedb_mem::{EngineId, EngineLimits, GovernorConfig, MemoryGovernor, ScopedMemory};
 use nodedb_types::columnar::{ColumnDef, ColumnType, ColumnarSchema};
+use nodedb_types::{DatabaseId, TenantId};
 use nodedb_wal::crypto::WalEncryptionKey;
 
 const INPUT_PREFIX_BYTES: usize = 64;
@@ -16,6 +21,26 @@ const MAX_BINARY_VALUE_BYTES: usize = 16;
 const COLUMN_COUNT: usize = 5;
 const FUZZ_KEK_BYTES: [u8; 32] = [0x5a; 32];
 const FUZZ_KEK_EPOCH: [u8; 4] = [0; 4];
+
+/// A memory scope whose governor ceiling covers every engine's limit — the
+/// same shape the integration tests use. Segment writes now take mandatory
+/// ScopedMemory (refactor(mem): make ScopedMemory budgeting mandatory).
+fn fuzz_memory() -> ScopedMemory {
+    let per_engine = usize::MAX / EngineId::ALL.len();
+    let governor = Arc::new(
+        MemoryGovernor::new(GovernorConfig {
+            global_ceiling: per_engine * EngineId::ALL.len(),
+            engine_limits: EngineLimits::uniform(per_engine),
+        })
+        .expect("fuzz governor"),
+    );
+    ScopedMemory::new(
+        governor,
+        DatabaseId::DEFAULT,
+        TenantId::new(0),
+        EngineId::Columnar,
+    )
+}
 
 fn exercise_reader(reader: &SegmentReader<'_>) {
     let count = reader.column_count().min(COLUMN_COUNT);
@@ -169,7 +194,7 @@ fn generated_segment(seed: &[u8], kek: Option<&WalEncryptionKey>) -> Option<Vec<
         },
     ];
 
-    SegmentWriter::plain()
+    SegmentWriter::new(PROFILE_PLAIN, fuzz_memory())
         .write_segment(&schema, &columns, ROW_COUNT, kek)
         .ok()
 }

--- a/nodedb-codec/src/zstd_codec.rs
+++ b/nodedb-codec/src/zstd_codec.rs
@@ -321,7 +321,7 @@ fn compress_native(_data: &[u8], _level: i32) -> Result<Vec<u8>, CodecError> {
 
 #[cfg(target_arch = "wasm32")]
 fn decompress_native(frame: &[u8], expected_size: usize) -> Result<Vec<u8>, CodecError> {
-    use ruzstd::StreamingDecoder;
+    use ruzstd::decoding::StreamingDecoder;
 
     let mut decoder = StreamingDecoder::new(std::io::Cursor::new(frame)).map_err(|e| {
         CodecError::DecompressFailed {


### PR DESCRIPTION
## Problem

Two build breaks landed on main today (`637feea41` mem refactor + the workspace `ruzstd` 0.7 -> 0.9 bump) and redden the ASan-fuzz matrix and the 32-bit build check for every PR touching the path-filtered crates:

- `fuzz/src/targets/columnar_segment.rs` still calls `SegmentWriter::plain()`, which `637feea41` replaced with `SegmentWriter::new(profile_tag, ScopedMemory)` — mandatory memory budgeting. `nodedb-fuzz` does not compile.
- `nodedb-codec/src/zstd_codec.rs` (WASM decompression path) imports `ruzstd::StreamingDecoder` from the crate root; ruzstd 0.9 moved it to `ruzstd::decoding`. The 32-bit build check fails on the unresolved import.

## Fix

- Fuzz target: adapt to `SegmentWriter::new(PROFILE_PLAIN, fuzz_memory())` with a governor-backed `ScopedMemory` (the shape the columnar integration tests use), matching the production call sites in `columnar_checkpoint/load.rs`. Adds the `nodedb-mem` dependency to the fuzz crate.
- Codec: import `ruzstd::decoding::StreamingDecoder` (verified present in vendored ruzstd 0.9.0).

## Verified

- `cargo build --manifest-path fuzz/Cargo.toml` (nightly) compiles clean.
- `cargo clippy -p nodedb-codec --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.

- The 32-bit build check (wasm32) runs in CI.
- Local ASan smoke on the fix branch, all six targets with the CI flags
  (\`--sanitizer address\`, \`-max_total_time=60 -runs=0 -max_len=1048576
  -timeout=10 -rss_limit_mb=2048\` + dict): exit 0, no crash artifacts.
## How to test

```
cargo build --manifest-path fuzz/Cargo.toml   # nightly
cargo check --target wasm32-unknown-unknown -p nodedb-codec -p nodedb-columnar -p nodedb-strict
```