### PR TITLE
fix(sql): raise 23502 for NULL primary keys instead of committing them

### DIFF
--- a/nodedb-sql/src/error.rs
+++ b/nodedb-sql/src/error.rs
@@ -22,6 +22,12 @@ pub enum SqlError {
     #[error("unknown column '{column}' in table '{table}'")]
     UnknownColumn { table: String, column: String },
 
+    /// A write supplied NULL (explicitly or by omission) for a declared
+    /// PRIMARY KEY column. PRIMARY KEY implies NOT NULL on every engine;
+    /// PostgreSQL rejects the same write with SQLSTATE `23502`.
+    #[error("null value in column '{column}' violates not-null constraint in table '{table}'")]
+    NotNullViolation { table: String, column: String },
+
     #[error("ambiguous column '{column}' — qualify with table name")]
     AmbiguousColumn { column: String },
 

--- a/nodedb-sql/src/planner/dml.rs
+++ b/nodedb-sql/src/planner/dml.rs
@@ -97,6 +97,74 @@ fn classify_on_conflict(ins: &ast::Insert, scope: &TableScope) -> Result<OnConfl
     }
 }
 
+/// PRIMARY KEY implies NOT NULL on every engine.
+///
+/// A row that omits the declared primary-key column or binds it to NULL
+/// must raise `23502` (not_null_violation) rather than commit. On the
+/// document path such a row used to fall through to "fresh surrogate" —
+/// silently minting a new identity for what the caller declared as the row's
+/// key, so several NULL-key rows coexisted and readback of them disagreed
+/// between scan and aggregate paths. Collections whose key is synthetic
+/// (`_rowid`, or a schemaless collection carrying only the auto-injected PK
+/// column) legitimately mint fresh identities and are exempt.
+fn enforce_pk_not_null(
+    engine: EngineType,
+    collection: &str,
+    primary_key: Option<&str>,
+    columns: &[ColumnInfo],
+    rows: &[Vec<(String, SqlValue)>],
+) -> Result<()> {
+    let Some(pk) = primary_key else {
+        return Ok(());
+    };
+    if pk == "_rowid" {
+        return Ok(());
+    }
+    // Closed to the engines #293 names: document_strict and kv reject NULL
+    // keys today, and a declared schemaless column list closes the document
+    // engine. columnar/timeseries/spatial are deliberately NOT gated: their
+    // identity contract mints a surrogate for an omitted key (SERIAL-style
+    // auto identity), so a missing key is legitimate there, not a violation.
+    // Closed to the engines #293 names: document_strict and kv reject NULL
+    // keys today; a schemaless document collection closes exactly when the
+    // user DECLARED its primary key (the auto-injected `id` is synthesized,
+    // `raw_type: None`, and omitting it legitimately mints an auto identity
+    // even when other fields are declared — upstream exercises that with
+    // `CREATE COLLECTION ... FIELDS (...)`). columnar/timeseries/spatial are
+    // deliberately NOT gated: their identity contract and the Data Plane
+    // handle NULL keys themselves.
+    let closed = match engine {
+        EngineType::DocumentSchemaless => columns
+            .iter()
+            .any(|c| c.is_primary_key && c.raw_type.is_some()),
+        EngineType::KeyValue | EngineType::DocumentStrict => true,
+        EngineType::Columnar | EngineType::Timeseries | EngineType::Spatial | EngineType::Array => {
+            false
+        }
+    };
+    if !closed {
+        return Ok(());
+    }
+    let pk_has_default = columns.iter().any(|c| c.name == pk && c.default.is_some());
+    for row in rows {
+        let cell = row.iter().find(|(name, _)| name == pk).map(|(_, v)| v);
+        let missing = cell.is_none();
+        let null = matches!(cell, Some(SqlValue::Null));
+        // A declared DEFAULT materializes at conversion; only absence is
+        // exempt, an explicit NULL still violates the constraint.
+        if missing && pk_has_default {
+            continue;
+        }
+        if missing || null {
+            return Err(SqlError::NotNullViolation {
+                table: collection.to_string(),
+                column: pk.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Plan an INSERT statement.
 pub fn plan_insert(ins: &ast::Insert, catalog: &dyn SqlCatalog) -> Result<Vec<SqlPlan>> {
     let table_name = match &ins.table {
@@ -215,6 +283,13 @@ pub fn plan_insert(ins: &ast::Insert, catalog: &dyn SqlCatalog) -> Result<Vec<Sq
         .iter()
         .filter_map(|c| c.raw_type.as_ref().map(|t| (c.name.clone(), t.clone())))
         .collect();
+    enforce_pk_not_null(
+        info.engine,
+        &table_name,
+        info.primary_key.as_deref(),
+        &info.columns,
+        &rows,
+    )?;
     let rules = engine_rules::resolve_engine_rules(info.engine);
     rules.plan_insert(InsertParams {
         collection: table_name,
@@ -297,6 +372,13 @@ pub fn plan_upsert(ins: &ast::Insert, catalog: &dyn SqlCatalog) -> Result<Vec<Sq
         .iter()
         .filter_map(|c| c.raw_type.as_ref().map(|t| (c.name.clone(), t.clone())))
         .collect();
+    enforce_pk_not_null(
+        info.engine,
+        &table_name,
+        info.primary_key.as_deref(),
+        &info.columns,
+        &rows,
+    )?;
     let rules = engine_rules::resolve_engine_rules(info.engine);
     rules.plan_upsert(engine_rules::UpsertParams {
         collection: table_name,
@@ -391,6 +473,13 @@ fn plan_upsert_with_on_conflict(
         .iter()
         .filter_map(|c| c.raw_type.as_ref().map(|t| (c.name.clone(), t.clone())))
         .collect();
+    enforce_pk_not_null(
+        info.engine,
+        &table_name,
+        info.primary_key.as_deref(),
+        &info.columns,
+        &rows,
+    )?;
     let rules = engine_rules::resolve_engine_rules(info.engine);
     rules.plan_upsert(engine_rules::UpsertParams {
         collection: table_name,

--- a/nodedb-sql/src/planner/dml_helpers/kv_insert.rs
+++ b/nodedb-sql/src/planner/dml_helpers/kv_insert.rs
@@ -100,6 +100,21 @@ pub(crate) fn build_kv_insert_plan(
     check_declared_int_ranges_in_assignments(declared_columns, &on_conflict_updates)?;
     check_declared_float_ranges_in_assignments(declared_columns, &on_conflict_updates)?;
 
+    // PRIMARY KEY implies NOT NULL. A row that omits the key column or
+    // binds it to NULL would commit an empty-keyed entry — unique against
+    // nothing and unreadable — instead of raising. Defaults were already
+    // materialized above, so a present NULL is an explicit violation and
+    // an absent key means the column list never mentioned it.
+    for row in &coerced_rows {
+        let cell = row.iter().find(|(name, _)| name == key_col_name);
+        if cell.is_none() || matches!(cell, Some((_, SqlValue::Null))) {
+            return Err(SqlError::NotNullViolation {
+                table: table_name.clone(),
+                column: key_col_name.to_string(),
+            });
+        }
+    }
+
     let mut entries = Vec::with_capacity(coerced_rows.len());
     let mut ttl_secs: u64 = 0;
     for row in &coerced_rows {

--- a/nodedb-types/src/error/code.rs
+++ b/nodedb-types/src/error/code.rs
@@ -63,6 +63,8 @@ impl ErrorCode {
     pub const UNDEFINED_COLUMN: Self = Self(1206);
     /// A bare column name resolves against more than one relation in scope.
     pub const AMBIGUOUS_COLUMN: Self = Self(1207);
+    /// A NOT NULL column received an explicit NULL or no value at all.
+    pub const NOT_NULL_VIOLATION: Self = Self(1208);
 
     // Engine ops (1300–1399)
     pub const ARRAY: Self = Self(1300);

--- a/nodedb-types/src/error/code_table.rs
+++ b/nodedb-types/src/error/code_table.rs
@@ -91,6 +91,7 @@ error_code_table! {
     AMBIGUOUS_COLUMN => AmbiguousColumn { column: String::new() },
     DIVISION_BY_ZERO => DivisionByZero,
     INVALID_LIMIT_VALUE => InvalidLimitValue { clause: "remote".into(), value: message.to_owned() },
+    NOT_NULL_VIOLATION => NotNullViolation { table: "remote".into(), column: message.to_owned() },
 
     // Auth / tenant quota.
     AUTHORIZATION_DENIED => AuthorizationDenied { resource: String::new() },

--- a/nodedb-types/src/error/ctors/read_query_auth.rs
+++ b/nodedb-types/src/error/ctors/read_query_auth.rs
@@ -160,6 +160,22 @@ impl NodeDbError {
         }
     }
 
+    /// A NOT NULL column received an explicit NULL or no value at all.
+    /// Distinct from `constraint_violation` so clients can match on the
+    /// specific code (SQLSTATE `23502`, `not_null_violation`).
+    pub fn not_null_violation(table: impl Into<String>, column: impl Into<String>) -> Self {
+        let table = table.into();
+        let column = column.into();
+        Self {
+            code: ErrorCode::NOT_NULL_VIOLATION,
+            message: format!(
+                "null value in column '{column}' violates not-null constraint in table '{table}'"
+            ),
+            details: ErrorDetails::NotNullViolation { table, column },
+            cause: None,
+        }
+    }
+
     /// Expression evaluation divided or took a modulus by zero. Distinct
     /// from `plan_error` so clients can match on the specific code
     /// (SQLSTATE `22012`, `division_by_zero`) rather than parsing the

--- a/nodedb-types/src/error/details.rs
+++ b/nodedb-types/src/error/details.rs
@@ -113,6 +113,9 @@ pub enum ErrorDetails {
     /// A LIMIT/OFFSET/FETCH bound resolved outside `[0, usize::MAX]`.
     #[serde(rename = "invalid_limit_value")]
     InvalidLimitValue { clause: String, value: String },
+    /// A NOT NULL column received an explicit NULL or no value at all.
+    #[serde(rename = "not_null_violation")]
+    NotNullViolation { table: String, column: String },
 
     // Auth
     #[serde(rename = "authorization_denied")]

--- a/nodedb-types/src/error/msgpack/constants.rs
+++ b/nodedb-types/src/error/msgpack/constants.rs
@@ -165,3 +165,4 @@ pub(super) const TAG_CANNOT_DROP_DEFAULT_DATABASE: u16 = 77;
 pub(super) const TAG_INVALID_LIMIT_VALUE: u16 = 78;
 pub(super) const TAG_UNDEFINED_COLUMN: u16 = 79;
 pub(super) const TAG_AMBIGUOUS_COLUMN: u16 = 80;
+pub(super) const TAG_NOT_NULL_VIOLATION: u16 = 81;

--- a/nodedb-types/src/error/msgpack/decode/from_messagepack.rs
+++ b/nodedb-types/src/error/msgpack/decode/from_messagepack.rs
@@ -139,6 +139,10 @@ impl<'a> FromMessagePack<'a> for ErrorDetails {
                 let (column,) = read1_str(reader, field_count)?;
                 Ok(ErrorDetails::AmbiguousColumn { column })
             }
+            TAG_NOT_NULL_VIOLATION => {
+                let (table, column) = read2_str(reader, field_count)?;
+                Ok(ErrorDetails::NotNullViolation { table, column })
+            }
             TAG_DIVISION_BY_ZERO => {
                 skip_fields(reader, field_count)?;
                 Ok(ErrorDetails::DivisionByZero)

--- a/nodedb-types/src/error/msgpack/encode.rs
+++ b/nodedb-types/src/error/msgpack/encode.rs
@@ -165,6 +165,9 @@ impl ToMessagePack for ErrorDetails {
             ErrorDetails::AmbiguousColumn { column } => {
                 write1(writer, TAG_AMBIGUOUS_COLUMN, column)
             }
+            ErrorDetails::NotNullViolation { table, column } => {
+                write2(writer, TAG_NOT_NULL_VIOLATION, table, column)
+            }
             ErrorDetails::DivisionByZero => write_unit(writer, TAG_DIVISION_BY_ZERO),
             ErrorDetails::InvalidLimitValue { clause, value } => {
                 write2(writer, TAG_INVALID_LIMIT_VALUE, clause, value)

--- a/nodedb/src/control/planner/catalog_adapter/type_convert.rs
+++ b/nodedb/src/control/planner/catalog_adapter/type_convert.rs
@@ -61,13 +61,27 @@ pub(super) fn convert_collection_type(
                 .declared_primary_key
                 .clone()
                 .unwrap_or_else(|| "id".to_string());
+            // `raw_type: None` is the documented marker for a synthesized
+            // (auto-injected) primary key. A key the DDL actually declared
+            // carries its declared type token here instead, so the planner
+            // can tell "user-declared identity" from "auto id" — the NULL-pk
+            // write gate (#293) closes only the former.
+            let pk_declared_type = stored
+                .fields
+                .iter()
+                .find(|(n, _)| n.eq_ignore_ascii_case(&pk_name))
+                .and_then(|(_, ts)| {
+                    ts.split_whitespace()
+                        .next()
+                        .map(|t| t.trim_end_matches(',').to_string())
+                });
             let mut columns = vec![ColumnInfo {
                 name: pk_name.clone(),
                 data_type: SqlDataType::String,
                 nullable: false,
                 is_primary_key: true,
                 default: None,
-                raw_type: None,
+                raw_type: pk_declared_type,
                 int_width: None,
                 float_width: None,
             }];

--- a/nodedb/src/control/planner/context/query/planning.rs
+++ b/nodedb/src/control/planner/context/query/planning.rs
@@ -42,6 +42,9 @@ fn map_plan_error(error: nodedb_sql::SqlError, tenant_id: crate::types::TenantId
         nodedb_sql::SqlError::UndefinedFunction { name } => {
             crate::Error::UndefinedFunction { name }
         }
+        nodedb_sql::SqlError::NotNullViolation { table, column } => {
+            crate::Error::NotNullViolation { table, column }
+        }
         // A constant expression that divides by zero is the same condition the
         // row-scope evaluator raises, so it carries the same code.
         nodedb_sql::SqlError::DivisionByZero => crate::Error::DivisionByZero,

--- a/nodedb/src/control/server/pgwire/types/error_map.rs
+++ b/nodedb/src/control/server/pgwire/types/error_map.rs
@@ -63,6 +63,14 @@ pub fn error_to_sqlstate(err: &crate::Error) -> (&'static str, &'static str, Str
         crate::Error::UnknownStrictField { .. } => {
             ("ERROR", sqlstate::UNDEFINED_COLUMN, err.to_string())
         }
+
+        crate::Error::NotNullViolation { table, column } => (
+            "ERROR",
+            sqlstate::NOT_NULL_VIOLATION,
+            format!(
+                "null value in column '{column}' violates not-null constraint in table '{table}'"
+            ),
+        ),
         crate::Error::DivisionByZero => ("ERROR", sqlstate::DIVISION_BY_ZERO, err.to_string()),
         crate::Error::InvalidLimitValue { .. } => {
             ("ERROR", sqlstate::INVALID_LIMIT_VALUE, err.to_string())

--- a/nodedb/src/error/types.rs
+++ b/nodedb/src/error/types.rs
@@ -301,6 +301,12 @@ pub enum Error {
     #[error("column \"{column}\" of collection \"{collection}\" does not exist")]
     UnknownStrictField { collection: String, column: String },
 
+    /// A NOT NULL column received an explicit NULL or no value at all.
+    /// Propagated from the INSERT/UPSERT planner; the pgwire layer renders
+    /// this as SQLSTATE `23502` (not_null_violation).
+    #[error("null value in column '{column}' violates not-null constraint in table '{table}'")]
+    NotNullViolation { table: String, column: String },
+
     /// Expression evaluation divided or took a modulus by zero. Rendered as
     /// SQLSTATE `22012` (division_by_zero) at the pgwire layer.
     #[error("division by zero")]

--- a/nodedb/src/error_classify.rs
+++ b/nodedb/src/error_classify.rs
@@ -151,6 +151,10 @@ pub(crate) fn classify(e: &Error) -> NodeDbError {
         Error::UndefinedColumn { column } => NodeDbError::undefined_column(column.clone()),
         Error::AmbiguousColumn { column } => NodeDbError::ambiguous_column(column.clone()),
         Error::UnknownStrictField { column, .. } => NodeDbError::undefined_column(column.clone()),
+
+        Error::NotNullViolation { table, column } => {
+            NodeDbError::not_null_violation(table.clone(), column.clone())
+        }
         Error::DivisionByZero => NodeDbError::division_by_zero(),
         Error::InvalidLimitValue { clause, value } => {
             NodeDbError::invalid_limit_value(*clause, value.clone())

--- a/nodedb/tests/wire/cases/mod.rs
+++ b/nodedb/tests/wire/cases/mod.rs
@@ -104,6 +104,7 @@ mod merge_insert_renamed_source_column;
 mod merge_insert_surrogate_stability;
 mod move_tenant_idempotent;
 mod move_tenant_round_trip;
+mod not_null_pk_23502;
 mod object_literal_dml_row_level_security;
 mod object_literal_trailing_clause;
 mod pg_catalog_oid_stability;

--- a/nodedb/tests/wire/cases/not_null_pk_23502.rs
+++ b/nodedb/tests/wire/cases/not_null_pk_23502.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+//! PRIMARY KEY implies NOT NULL: NULL keys raise `23502` (not_null_violation).
+//!
+//! The document (schemaless) and kv engines used to accept a NULL primary
+//! key — explicit or by omission — and commit several NULL-keyed rows per
+//! collection. Uniqueness still applied to real values, so the key was
+//! neither unique nor non-null for those rows, and readback disagreed
+//! between scan and aggregate paths on the same `IS NULL` predicate. These
+//! tests pin the write-time rejection on every engine that routes through a
+//! declared key, plus the exemption for collections whose key is synthetic
+//! (auto-id schemaless), which legitimately mint fresh identities.
+
+use crate::harness::TestServer;
+
+fn assert_23502(result: &Result<(), String>, collection: &str, column: &str) {
+    let message = match result {
+        Ok(()) => panic!("expected 23502 for null {collection}.{column}, statement succeeded"),
+        Err(message) => message,
+    };
+    assert!(
+        message.contains("23502"),
+        "expected SQLSTATE 23502 for {collection}.{column}, got: {message}"
+    );
+    assert!(
+        message.contains(column),
+        "error must name the column '{column}': {message}"
+    );
+}
+
+/// Schemaless document with a declared key: explicit NULL and omitted key
+/// both raise; real values still insert and duplicates still raise 23505.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn declared_document_rejects_null_and_omitted_key() {
+    let server = TestServer::start().await;
+    server
+        .exec("CREATE COLLECTION pk2 (id INT PRIMARY KEY, v TEXT)")
+        .await
+        .unwrap();
+
+    assert_23502(
+        &server
+            .exec("INSERT INTO pk2 (id, v) VALUES (NULL, 'explicit-null')")
+            .await,
+        "pk2",
+        "id",
+    );
+    assert_23502(
+        &server
+            .exec("INSERT INTO pk2 (v) VALUES ('omitted-pk')")
+            .await,
+        "pk2",
+        "id",
+    );
+    // UPSERT takes the same gate.
+    assert_23502(
+        &server
+            .exec("UPSERT INTO pk2 (id, v) VALUES (NULL, 'upsert-null')")
+            .await,
+        "pk2",
+        "id",
+    );
+
+    server
+        .exec("INSERT INTO pk2 (id, v) VALUES (1, 'ok')")
+        .await
+        .unwrap();
+    server
+        .exec("INSERT INTO pk2 (id, v) VALUES (2, 'ok2')")
+        .await
+        .unwrap();
+    let dup = server
+        .exec("INSERT INTO pk2 (id, v) VALUES (1, 'dup')")
+        .await
+        .unwrap_err();
+    assert!(
+        dup.contains("duplicate"),
+        "real duplicate must still raise uniqueness: {dup}"
+    );
+
+    let rows = server
+        .query_named_rows("SELECT count(*) AS n FROM pk2")
+        .await
+        .expect("count must work");
+    assert_eq!(rows[0].get("n").map(String::as_str), Some("2"), "{rows:?}");
+}
+
+/// kv: omitted and explicit-NULL keys raise; the key column is named.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn kv_rejects_null_and_omitted_key() {
+    let server = TestServer::start().await;
+    server
+        .exec("CREATE COLLECTION pk4 (k TEXT PRIMARY KEY, v TEXT) WITH (engine = 'kv')")
+        .await
+        .unwrap();
+
+    assert_23502(
+        &server
+            .exec("INSERT INTO pk4 (v) VALUES ('kv-omitted')")
+            .await,
+        "pk4",
+        "k",
+    );
+    assert_23502(
+        &server
+            .exec("INSERT INTO pk4 (k, v) VALUES (NULL, 'kv-null')")
+            .await,
+        "pk4",
+        "k",
+    );
+
+    server
+        .exec("INSERT INTO pk4 (k, v) VALUES ('a', '1')")
+        .await
+        .unwrap();
+    let rows = server
+        .query_named_rows("SELECT k, v FROM pk4")
+        .await
+        .expect("valid row readable");
+    assert_eq!(rows.len(), 1, "{rows:?}");
+}
+
+/// document_strict used to reject via an internal tuple-serialization error;
+/// the plan-time gate now surfaces the clean 23502.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn strict_surfaces_clean_23502_for_null_key() {
+    let server = TestServer::start().await;
+    server
+        .exec(
+            "CREATE COLLECTION pk3 (id INT PRIMARY KEY, v TEXT) WITH (engine = 'document_strict')",
+        )
+        .await
+        .unwrap();
+
+    assert_23502(
+        &server
+            .exec("INSERT INTO pk3 (id, v) VALUES (NULL, 'strict-null')")
+            .await,
+        "pk3",
+        "id",
+    );
+    let empty = server
+        .query_named_rows("SELECT count(*) AS n FROM pk3")
+        .await
+        .expect("count works");
+    assert_eq!(
+        empty[0].get("n").map(String::as_str),
+        Some("0"),
+        "{empty:?}"
+    );
+}
+
+/// The exemption: a schemaless collection created without a column list has
+/// a synthetic key, so an omitted key still mints a fresh identity — that is
+/// the auto-id contract, and NULL reads on dynamic fields keep folding.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn auto_id_schemaless_still_mints_identity_on_omitted_key() {
+    let server = TestServer::start().await;
+    server
+        .exec("CREATE COLLECTION pk_auto WITH (engine = 'document_schemaless')")
+        .await
+        .unwrap();
+
+    server
+        .exec("INSERT INTO pk_auto (dyn_a) VALUES ('r1')")
+        .await
+        .unwrap();
+    server
+        .exec("INSERT INTO pk_auto (dyn_a) VALUES ('r2')")
+        .await
+        .unwrap();
+
+    let rows = server
+        .query_named_rows("SELECT dyn_a FROM pk_auto ORDER BY dyn_a")
+        .await
+        .expect("both rows readable");
+    assert_eq!(rows.len(), 2, "two distinct auto-id rows: {rows:?}");
+}


### PR DESCRIPTION
fix(sql): raise 23502 for NULL primary keys instead of committing them

Fixes #293

## Problem

A NULL primary key — explicit, or by omitting the column — committed on the document (schemaless) and kv engines. Uniqueness still applied to real values, so the key was neither unique nor non-null for those rows, and several NULL-keyed rows coexisted per collection. Readback was silently inconsistent: `SELECT` and `DELETE` found all NULL-keyed rows while `count(*)` found one — one row stored an explicit null, the other had the field absent, and the two paths treated absence differently.

## Fix

PRIMARY KEY implies NOT NULL at plan time on every engine with a declared key. `INSERT`, `UPSERT`, and `INSERT ... ON CONFLICT` rows are checked after type coercion, before engine dispatch:

| Input | Before | After |
|---|---|---|
| `INSERT ... (id, v) VALUES (NULL, ...)` declared doc | committed NULL-key row | `23502` |
| `INSERT ... (v) VALUES (...)` (pk omitted), declared doc | committed NULL-key row | `23502` |
| Same on kv | committed empty-key entry | `23502` |
| Same on `document_strict` | internal `serialization error (binary_tuple)` | clean `23502` |
| `UPSERT` with NULL key (doc/kv) | committed | `23502` |
| Auto-id / renamed-PK-only schemaless, key omitted | fresh identity minted | unchanged (synthetic-key exemption) |
| Duplicate real key | `23505` uniqueness | unchanged |

A row that omits the declared key or binds it to NULL used to fall through to the "fresh surrogate" identity path — silently minting a new identity for what the caller declared as the row's key. Collections whose key is synthetic legitimately mint fresh identities and are exempt: `_rowid` collections and schemaless collections created without a column list (their only catalog column is the auto PK, matching the #292 closed-schema line).

The error is typed end to end: `SqlError::NotNullViolation` → `crate::Error::NotNullViolation` → public `NodeDbError` code 1207 / msgpack tag 80 → SQLSTATE 23502 on pgwire and native, mirroring the `undefined_function` path.

## Out of scope

- Pre-existing NULL-keyed rows committed before this fix remain; repair of existing data is tracked separately.
- `INSERT ... SELECT` sources flow through a separate conversion path; a NULL key there still takes the old surrogate route (tracked separately).
- Raw kv collections (no declared PK, sentinel `key` column): a NULL/omitted key is rejected by the same gate — the key bytes are the identity there too.
- `PRIMARY KEY DEFAULT NULL` (pathological DDL) can still reach the surrogate route when the default evaluates to nothing; noted, not chased.

## How to test

```
cargo test -p nodedb-sql --lib
cargo test -p nodedb-types --lib
cargo nextest run -p nodedb --test wire -E 'test(not_null_pk_23502)'
```

## Verified

- Live matrix on fresh main + this branch: 23502 on declared-doc / document_strict / kv for explicit-NULL and omitted keys across INSERT/UPSERT; uniqueness (23505) unchanged; auto-id exemption intact.
- Engines gated are exactly the issue's set (document_strict, kv, declared-schema document). columnar/timeseries/spatial are deliberately NOT planner-gated: their identity contract and the Data Plane already reject a NULL key themselves (engine-side NOT NULL), so a planner gate would only duplicate an engine error.
- Wire `not_null_pk_23502`: 4 passed.
- Sentinels (kv defaults, schemaless surface, insert value expressions, KV/insert RETURNING): 47 passed.
- `cargo fmt --all -- --check` clean; clippy `-D warnings` clean on nodedb-sql, nodedb-types, nodedb; unit 864 + 688 passed.