### PR TITLE
fix(bootstrap): raise tokio worker stack to 16 MiB

### DIFF
--- a/nodedb/src/main.rs
+++ b/nodedb/src/main.rs
@@ -31,7 +31,14 @@ fn main() -> anyhow::Result<()> {
     // worker threads while building its runtime, and the default panic hook
     // renders arbitrary panic payloads.
     nodedb::bootstrap::panic_hook::install();
+    // Worker threads carry the whole planning -> dispatch -> execution
+    // pipeline synchronously; the DDL/index path in particular nests deep
+    // enough to exhaust tokio's 2 MiB default and die with a silent SIGSEGV.
+    // 16 MiB gives the same headroom the rest of the process
+    // already relies on for main-thread work; tokio reserves it virtually
+    // and commits pages on demand, so idle workers cost nothing.
     let runtime = tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(16 * 1024 * 1024)
         .enable_all()
         .build()?;
     if let Err(error) = runtime.block_on(server_main()) {


### PR DESCRIPTION
## Problem

Tokio worker threads use a 2 MiB default stack. The DDL → index planning path nests deep enough to overflow it, causing a silent SIGSEGV with no error message. Affected operations:

- \`CREATE VECTOR INDEX\`
- \`CREATE SORTED INDEX\`

The process dies mid-planning with \`tokio-rt-worker has overflowed its stack\` (or silently on the server wire path).

## Reproduction

```bash
git clone https://github.com/NodeDB-Lab/nodedb.git
cd nodedb
RUST_MIN_STACK=\"\" cargo test -p nodedb --test inproc sorted_index_rows -- --test-threads 1
# → thread 'tokio-rt-worker' has overflowed its stack
# → SIGABRT, EXIT:101
```

Tested on x86_64 (Intel Core i5-8400, 32 GiB RAM, Debian 13 trixie / Proxmox VE). aarch64 CI runners reproduce with less nesting depth.

## Fix

Raise the tokio worker stack from 2 MiB to 16 MiB in \`nodedb/src/main.rs\`. This matches the main-thread stack the rest of the process already relies on. Tokio reserves the space virtually and commits pages on demand, so idle workers cost nothing.

```rust
let runtime = tokio::runtime::Builder::new_multi_thread()
    .thread_stack_size(16 * 1024 * 1024)  // 16 MiB — fixes #312
    .enable_all()
    .build()?;
```

## Verification

| Config | Result |
|---|---|
| Pre-fix + no \`RUST_MIN_STACK\` | **CRASH** — stack overflow |
| Post-fix + no \`RUST_MIN_STACK\` | **PASS** (server binary) |
| Post-fix + \`RUST_MIN_STACK=32MiB\` | **PASS** (16/16 inproc tests) |

Note: \`#[tokio::test]\` creates an independent runtime per test, so the test suite still requires \`RUST_MIN_STACK=33554432\` (already set in CI). The fix covers the **server binary**, which is what runs in production.

## Files changed

- \`nodedb/src/main.rs\` — add \`thread_stack_size(16 MiB)\` to the tokio runtime builder
